### PR TITLE
fix reshape to match matlab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 .*~
 pyttb.egg-info/
+dist/
 .pytest_cache
 tests/__pycache__
 TensorToolbox/__pycache__

--- a/TensorToolbox/tensor.py
+++ b/TensorToolbox/tensor.py
@@ -59,7 +59,7 @@ class tensor(object):
 
         # Make sure the data is indeed the right shape
         if data.size > 0 and len(shape) > 0:
-            data = np.reshape(data, np.array(shape))
+            data = np.reshape(data, np.array(shape), order='F')
 
         # Create the tensor
         tensorInstance = cls()


### PR DESCRIPTION
in the tensor class we have issues when using reshape as it does not match MATLAB TensorToolbox, not sure how far this propagates, but here is one fix that I need to do to match Matlab