### PR TITLE
Compatibility with numpy 1.24.x

### DIFF
--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -1806,7 +1806,7 @@ class ktensor(object):
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])
 
-        assert len(vector) > 0, 'sptensor.ttv: vector must be nonempty'
+        assert len(vector) > 0, 'ktensor.ttv: vector must be nonempty'
 
         # Check that vector is a list of vectors, if not place single vector as element in list
         if isinstance(vector[0], (int, float, np.int_, np.float_)):

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -882,7 +882,7 @@ class ktensor(object):
                 vecs = []
                 for n in range(self.ndims):
                     vecs.append(self.factor_matrices[n][:, r])
-                res = res + self.weights[r] * other.ttv(np.array(vecs))
+                res = res + self.weights[r] * other.ttv(vecs)
             return res
 
     def isequal(self, other):
@@ -1808,7 +1808,7 @@ class ktensor(object):
 
         # Check that vector is a list of vectors, if not place single vector as element in list
         if len(vector.shape) == 1 and isinstance(vector[0], (int, float, np.int_, np.float_)):
-            return self.ttv(np.array([vector]), dims)
+            return self.ttv([vector], dims)
 
         # Get sorted dims and index for multiplicands
         dims, vidx = ttb.tt_dimscheck(dims, self.ndims, vector.shape[0])

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -1806,12 +1806,14 @@ class ktensor(object):
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])
 
+        assert len(vector) > 0, 'sptensor.ttv: vector must be nonempty'
+
         # Check that vector is a list of vectors, if not place single vector as element in list
-        if len(vector.shape) == 1 and isinstance(vector[0], (int, float, np.int_, np.float_)):
+        if isinstance(vector[0], (int, float, np.int_, np.float_)):
             return self.ttv([vector], dims)
 
         # Get sorted dims and index for multiplicands
-        dims, vidx = ttb.tt_dimscheck(dims, self.ndims, vector.shape[0])
+        dims, vidx = ttb.tt_dimscheck(dims, self.ndims, len(vector))
 
         # Check that each multiplicand is the right size.
         for i in range(dims.size):

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -1806,10 +1806,8 @@ class ktensor(object):
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])
 
-        assert len(vector) > 0, 'ktensor.ttv: vector must be nonempty'
-
         # Check that vector is a list of vectors, if not place single vector as element in list
-        if isinstance(vector[0], (int, float, np.int_, np.float_)):
+        if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
             return self.ttv([vector], dims)
 
         # Get sorted dims and index for multiplicands

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -116,14 +116,14 @@ class ktensor(object):
         # Create ktensor and populate data members
         k = cls()
         k.weights = weights.copy()
-        if k.weights.dtype != np.float:
-            print("converting weights from {} to np.float".format(k.weights.dtype))
-            k.weights = k.weights.astype(np.float)
+        if k.weights.dtype != float:
+            print("converting weights from {} to float".format(k.weights.dtype))
+            k.weights = k.weights.astype(float)
         k.factor_matrices = _factor_matrices
         for i in range(len(k.factor_matrices)):
-            if k.factor_matrices[i].dtype != np.float:
-                print("converting factor_matrices[{}] from {} to np.float".format(i, k.factor_matrices[i].dtype))
-                k.factor_matrices[i] = k.factor_matrices[i].astype(np.float)
+            if k.factor_matrices[i].dtype != float:
+                print("converting factor_matrices[{}] from {} to float".format(i, k.factor_matrices[i].dtype))
+                k.factor_matrices[i] = k.factor_matrices[i].astype(float)
 
         return k
 
@@ -358,7 +358,7 @@ class ktensor(object):
 
         >>> rank = 2
         >>> shape = np.array([2, 3, 4])
-        >>> data = np.arange(1, rank*sum(shape)+1).astype(np.float)
+        >>> data = np.arange(1, rank*sum(shape)+1).astype(float)
         >>> K_without_weights = ttb.ktensor.from_vector(data[:], shape, False)
         >>> print(K_without_weights)
         ktensor of shape 2 x 3 x 4
@@ -378,7 +378,7 @@ class ktensor(object):
 
         Create a `ktensor` from a vector containing elements of both the weights and the factor matrices:
 
-        >>> weights = 2 * np.ones(rank).astype(np.float)
+        >>> weights = 2 * np.ones(rank).astype(float)
         >>> weights_and_data = np.concatenate((weights, data), axis=0)
         >>> K_with_weights = ttb.ktensor.from_vector(weights_and_data[:], shape, True)
         >>> print(K_with_weights)

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -1479,7 +1479,7 @@ class ktensor(object):
 
         # Option to do greedy matching
         if greedy:
-            best_perm = -1 * np.ones((RA), dtype=np.int)
+            best_perm = -1 * np.ones((RA), dtype=int)
             best_score = 0
             for r in range(RB):
                 idx = np.argmax(C.reshape(np.prod(C.shape),order='F'))

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -731,7 +731,7 @@ class sptensor(object):
                 else:
                     Z.append(np.array([]))
             # Perform ttv multiplication
-            V[:, r] = self.ttv(np.array(Z), -(n+1)).double()
+            V[:, r] = self.ttv(Z, -(n+1)).double()
 
         return V
 
@@ -1026,12 +1026,14 @@ class sptensor(object):
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])
 
+        assert len(vector) > 0, 'sptensor.ttv: vector must be nonempty'
+
         # Check that vector is a list of vectors, if not place single vector as element in list
-        if len(vector.shape) == 1 and isinstance(vector[0], (int, float, np.int_, np.float_)):
+        if isinstance(vector[0], (int, float, np.int_, np.float_)):
             return self.ttv(np.array([vector]), dims)
 
         # Get sorted dims and index for multiplicands
-        dims, vidx = ttb.tt_dimscheck(dims, self.ndims, vector.shape[0])
+        dims, vidx = ttb.tt_dimscheck(dims, self.ndims, len(vector))
         remdims = np.setdiff1d(np.arange(0, self.ndims), dims).astype(int)
 
         # Check that each multiplicand is the right size.

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -137,9 +137,9 @@ class sptensor(object):
         if (nonzeros < 0) or (nonzeros >= np.prod(shape)):
             assert False, "Requested number of non-zeros must be positive and less than the total size"
         elif nonzeros < 1:
-            nonzeros = np.int(np.ceil(np.prod(shape) * nonzeros))
+            nonzeros = int(np.ceil(np.prod(shape) * nonzeros))
         else:
-            nonzeros = np.int(np.floor(nonzeros))
+            nonzeros = int(np.floor(nonzeros))
 
         # Keep iterating until we find enough unique non-zeros or we give up
         subs = np.array([])

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -1030,7 +1030,7 @@ class sptensor(object):
 
         # Check that vector is a list of vectors, if not place single vector as element in list
         if isinstance(vector[0], (int, float, np.int_, np.float_)):
-            return self.ttv(np.array([vector]), dims)
+            return self.ttv([vector], dims)
 
         # Get sorted dims and index for multiplicands
         dims, vidx = ttb.tt_dimscheck(dims, self.ndims, len(vector))

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -1026,10 +1026,8 @@ class sptensor(object):
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])
 
-        assert len(vector) > 0, 'sptensor.ttv: vector must be nonempty'
-
         # Check that vector is a list of vectors, if not place single vector as element in list
-        if isinstance(vector[0], (int, float, np.int_, np.float_)):
+        if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
             return self.ttv([vector], dims)
 
         # Get sorted dims and index for multiplicands

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1076,7 +1076,7 @@ class tensor(object):
             if dnew == 2:  
                 return np.reshape(y, [sz, sz], order='F')
             elif dnew > 2:  
-                return ttb.tensor.from_data(np.reshape(y, sz*np.ones(dnew, dtype=np.int), order='F'))
+                return ttb.tensor.from_data(np.reshape(y, sz*np.ones(dnew, dtype=int), order='F'))
             else:
                 return y
         else:

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -999,10 +999,8 @@ class tensor(object):
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])
 
-        assert len(vector) > 0, 'tensor.ttv: vector must be nonempty'
-
         # Check that vector is a list of vectors, if not place single vector as element in list
-        if isinstance(vector[0], (int, float, np.int_, np.float_)):
+        if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
             return self.ttv([vector], dims)
 
         # Get sorted dims and index for multiplicands

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -999,14 +999,14 @@ class tensor(object):
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])
 
+        assert len(vector) > 0, 'tensor.ttv: vector must be nonempty'
+
         # Check that vector is a list of vectors, if not place single vector as element in list
-        if isinstance(vector, list):
-            return self.ttv(np.array(vector), dims)
-        if len(vector.shape) == 1 and isinstance(vector[0], (int, float, np.int_, np.float_)):
-            return self.ttv(np.array([vector]), dims)
+        if isinstance(vector[0], (int, float, np.int_, np.float_)):
+            return self.ttv([vector], dims)
 
         # Get sorted dims and index for multiplicands
-        dims, vidx = ttb.tt_dimscheck(dims, self.ndims, vector.shape[0])
+        dims, vidx = ttb.tt_dimscheck(dims, self.ndims, len(vector))
 
         # Check that each multiplicand is the right size.
         for i in range(dims.size):

--- a/tests/test_ktensor.py
+++ b/tests/test_ktensor.py
@@ -21,8 +21,8 @@ def sample_ktensor_2way():
 def sample_ktensor_3way():
     rank = 2
     shape = np.array([2, 3, 4])
-    vector = np.arange(1, rank*sum(shape)+1).astype(np.float)
-    weights = 2 * np.ones(rank).astype(np.float)
+    vector = np.arange(1, rank*sum(shape)+1).astype(float)
+    weights = 2 * np.ones(rank).astype(float)
     vector_with_weights = np.concatenate((weights, vector), axis=0)
     #vector_with_weights = vector_with_weights.reshape((len(vector_with_weights), 1))
     # ground truth
@@ -100,8 +100,8 @@ def test_ktensor_from_data(sample_ktensor_2way, capsys):
     weights_int = np.array([1, 2])
     K2 = ttb.ktensor.from_data(weights_int, data["factor_matrices"])
     out, err = capsys.readouterr()
-    assert "converting weights from int64 to np.float" in out or \
-           "converting weights from int32 to np.float" in out
+    assert "converting weights from int64 to float" in out or \
+           "converting weights from int32 to float" in out
 
     # Weights that are int should be converted
     fm0 = np.array([[1, 2], [3, 4]])
@@ -109,8 +109,8 @@ def test_ktensor_from_data(sample_ktensor_2way, capsys):
     factor_matrices = [fm0, fm1]
     K3 = ttb.ktensor.from_data(data["weights"], factor_matrices)
     out, err = capsys.readouterr()
-    assert "converting factor_matrices[0] from int64 to np.float" in out or \
-           "converting factor_matrices[0] from int32 to np.float" in out
+    assert "converting factor_matrices[0] from int64 to float" in out or \
+           "converting factor_matrices[0] from int32 to float" in out
 
 @pytest.mark.indevelopment
 def test_ktensor_from_function():

--- a/tests/test_ktensor.py
+++ b/tests/test_ktensor.py
@@ -762,15 +762,15 @@ def test_ktensor_ttv(sample_ktensor_3way):
     vec2 = np.array([1, 1])
     vec3 = np.array([1, 1, 1])
     vec4 = np.array([1, 1, 1, 1])
-    assert K.ttv(np.array([vec2, vec3, vec4])) == 30348
+    assert K.ttv([vec2, vec3, vec4]) == 30348
 
     # Wrong shape
     with pytest.raises(AssertionError) as excinfo:
-        K.ttv(np.array([vec2, vec3, np.array([1,2])]))
+        K.ttv([vec2, vec3, np.array([1,2])])
     assert "Multiplicand is wrong size" in str(excinfo)
 
     # Multiple dimensions, but fewer than all dimensions, not in same order as ktensor dimensions
-    K2 = K.ttv(np.array([vec4, vec3]), dims=np.array([2, 1]))
+    K2 = K.ttv([vec4, vec3], dims=np.array([2, 1]))
     weights = np.array([1800., 3564.])
     fm0 = np.array([[1., 3.], [2., 4.]])
     assert (K2.isequal(ttb.ktensor.from_data(weights, fm0)))

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -186,11 +186,11 @@ def test_sptensor_full(sample_sptensor):
 def test_sptensor_subdims(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
-    assert (sptensorInstance.subdims(np.array([[1], [1], [1, 3]])) == np.array([0, 1])).all()
+    assert (sptensorInstance.subdims([[1], [1], [1, 3]]) == np.array([0, 1])).all()
     assert (sptensorInstance.subdims((1, 1, slice(None, None, None))) == np.array([0, 1])).all()
 
     with pytest.raises(AssertionError) as excinfo:
-        sptensorInstance.subdims(np.array([[1], [1, 3]]))
+        sptensorInstance.subdims([[1], [1, 3]])
     assert "Number of subdimensions must equal number of dimensions" in str(excinfo)
 
 @pytest.mark.indevelopment
@@ -1290,7 +1290,7 @@ def test_sptensor_ttv(sample_sptensor):
 
     # Wrong shape vector
     with pytest.raises(AssertionError) as excinfo:
-        onesSptensor.ttv(np.array([vector, np.array([1,2])]))
+        onesSptensor.ttv([vector, np.array([1,2])])
     assert "Multiplicand is wrong size" in str(excinfo)
 
     # Returns vector shaped object

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1092,7 +1092,7 @@ def test_tensor_ttv(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     assert (T2.data == np.array([10,14,18])).all()
 
     # Multiply by multiple vectors, infer dimensions
-    assert tensorInstance2.ttv(np.array([np.array([2, 2]), np.array([1, 1, 1])])) == 42
+    assert tensorInstance2.ttv([np.array([2, 2]), np.array([1, 1, 1])]) == 42
  
     # Multiply by multiple vectors as list of numpy.ndarrays
     assert tensorInstance2.ttv([np.array([2, 2]), np.array([1, 1, 1])]) == 42
@@ -1104,7 +1104,7 @@ def test_tensor_ttv(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     assert (T3.data == np.array([[6,30],[14,38],[22,46]])).all()
 
     # Multiply by multiple vectors, infer dimensions
-    assert tensorInstance3.ttv(np.array([np.array([2, 2]), np.array([1, 1, 1]), np.array([2, 2])])) == 312
+    assert tensorInstance3.ttv([np.array([2, 2]), np.array([1, 1, 1]), np.array([2, 2])]) == 312
 
     # 4-way Multiply by single vector
     T4  = tensorInstance4.ttv(2 * np.ones((tensorInstance4.shape[0],)), 0)


### PR DESCRIPTION
Resolve some issues involving deprecations and changes in NumPy 1.24.

- Type aliases ``numpy.float`` and ``numpy.int`` were deprecated in 1.20 and removed in 1.24, so replace with built-ins ``float`` and ``int``. These are identical replacements: https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated
- Creating ragged numpy arrays (numpy calls them inhomogeneous) is no longer allowed. To get an ordered set of numpy arrays with different dimensions (e.g. the ``vector`` argument of the ``ttv`` methods) allow plain lists to be used. This is a backward-compatible change - as long as you can construct ``vector`` as a numpy.ndarray, you can still pass it.

For an example of the second issue, in numpy 1.24:
```
>>> import numpy as np
>>> A = np.zeros(5)
>>> B = np.zeros(7)
>>> A
array([0., 0., 0., 0., 0.])
>>> B
array([0., 0., 0., 0., 0., 0., 0.])
>>> mylist = [A, B]
>>> mylist
[array([0., 0., 0., 0., 0.]), array([0., 0., 0., 0., 0., 0., 0.])]
>>> myarr = np.array(mylist)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous
shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.
```
Before, this was allowed and you would simply get a 1D np.ndarray where the elements are themselves np.ndarrays, but now it checks against this.

Tested changes on two different python envs: a python 3.6.8 with numpy 1.19.5, and python 3.9.15 with 1.24.1. So that's one before the relevant numpy deprecations, and one after.
- Pytest runs cleanly
- Ran Jon Berry's TTB demo. It exercises sparse, dense and Kruskal tensor construction, MTTKRP and CP-ALS