### PR TITLE
TENSOR: Fix slices ref when return value isn't scalar or vector. #41

### DIFF
--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1272,7 +1272,6 @@ class tensor(object):
             rmdims = []   # dimensions to remove
 
             # Determine the new size and what dimensions to keep
-            # Determine the new size and what dimensions to keep
             for i in range(0, len(region)):
                 if isinstance(region[i], slice):
                     newsiz.append(self.shape[i])
@@ -1289,19 +1288,11 @@ class tensor(object):
 
             # If the size is zero, then the result is returned as a scalar
             # otherwise, we convert the result to a tensor
-
             if newsiz.size == 0:
                 a = newdata
             else:
-                if rmdims.size == 0:
-                    a = ttb.tensor.from_data(newdata)
-                else:
-                    # If extracted data is a vector then no need to tranpose it
-                    if len(newdata.shape) == 1:
-                        a = ttb.tensor.from_data(newdata)
-                    else:
-                        a = ttb.tensor.from_data(np.transpose(newdata, np.concatenate((kpdims, rmdims))))
-            return ttb.tt_subsubsref(a, item)
+                a = ttb.tensor.from_data(newdata)
+            return a
 
         # *** CASE 2a: Subscript indexing ***
         if len(item) > 1 and isinstance(item[-1], str) and item[-1] == 'extract':

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -280,6 +280,9 @@ def test_tensor__getitem__(sample_tensor_2way):
     assert tensorInstance[0, 0] == params['data'][0, 0]
     # Case 1 Subtensor
     assert (tensorInstance[:, :] == tensorInstance).data.all()
+    three_way_data = np.random.random((2, 3, 4))
+    two_slices = (slice(None,None,None), 0, slice(None,None,None))
+    assert (ttb.tensor.from_data(three_way_data)[two_slices].double() == three_way_data[two_slices]).all()
     # Case 1 Subtensor
     assert (tensorInstance[np.array([0, 1]), :].data == tensorInstance.data[[0, 1], :]).all()
     # Case 1 Subtensor


### PR DESCRIPTION
A proposed fix to: https://github.com/sandialabs/pyttb/issues/41

For general tensors we should be able to defer to numpy slicing mechanics as the easiest solution. There is some ambiguity when slicing across multiple dimensions when it comes to retaining or dropping singleton dimensions. I don't have MATLAB access so I am not sure how it is handled there. All of our tests still pass and we never specifically enforced this so it might not be an issue.
Example:
```
import numpy
tensor = np.ones((3,3,3,3))
sliced = tensor[:, 0, :, 0]
sliced.shape # in numpy this is a matrix so shape is (3,3) but one could argue (1, 3, 1, 3) is possibly useful/valid
```

This came up when validating TTENSOR implementation so is a pre-requisite for that PR.