### PR TITLE
Test coverage

### DIFF
--- a/pyttb/cp_apr.py
+++ b/pyttb/cp_apr.py
@@ -15,7 +15,7 @@ def cp_apr(tensor, rank, algorithm='mu', stoptol=1e-4, stoptime=1e6, maxiters=10
            kappa=0.01, kappatol=1e-10, epsActive=1e-8, mu0=1e-5, precompinds=True, inexact=True,
            lbfgsMem=3):
     """
-    Compute nonnegative CP with alternating Poisson regression.
+    Compute non-negative CP with alternating Poisson regression.
     
     Parameters
     ----------
@@ -376,9 +376,10 @@ def tt_cp_apr_pdnr(tensor, rank, init, stoptol, stoptime, maxiters, maxinneriter
         sparseIx = []
         for n in range(N):
             num_rows = M[n].shape[0]
-            sparseIx.append(np.zeros((num_rows, 1)))
+            row_indices = []
             for jj in range(num_rows):
-                sparseIx[n][jj] = np.where(tensor.subs[:, n] == jj)[0]
+                row_indices.append(np.where(tensor.subs[:, n] == jj)[0])
+            sparseIx.append(row_indices)
 
         if printitn > 0:
             print('done\n')
@@ -426,7 +427,7 @@ def tt_cp_apr_pdnr(tensor, rank, init, stoptol, stoptime, maxiters, maxinneriter
                         M.factor_matrices[n][jj, :] = 0
                         continue
 
-                    x_row = tensor.vals(sparse_indices)
+                    x_row = tensor.vals[sparse_indices]
 
                     # Calculate just the columns of Pi needed for this row.
                     Pi = ttb.tt_calcpi_prowsubprob(tensor, M, rank, n, N, isSparse, sparse_indices)
@@ -683,9 +684,10 @@ def tt_cp_apr_pqnr(tensor, rank, init, stoptol, stoptime, maxiters, maxinneriter
         sparseIx = []
         for n in range(N):
             num_rows = M[n].shape[0]
-            sparseIx.append(np.zeros((num_rows, 1)))
+            row_indices = []
             for jj in range(num_rows):
-                sparseIx[n][jj] = np.where(tensor.subs[:, n] == jj)[0]
+                row_indices.append(np.where(tensor.subs[:, n] == jj)[0])
+            sparseIx.append(row_indices)
 
         if printitn > 0:
             print('done\n')
@@ -726,7 +728,7 @@ def tt_cp_apr_pqnr(tensor, rank, init, stoptol, stoptime, maxiters, maxinneriter
                         M.factor_matrices[n][jj, :] = 0
                         continue
 
-                    x_row = tensor.vals(sparse_indices)
+                    x_row = tensor.vals[sparse_indices]
 
                     # Calculate just the columns of Pi needed for this row.
                     Pi = ttb.tt_calcpi_prowsubprob(tensor, M, rank, n, N, isSparse, sparse_indices)
@@ -1227,7 +1229,7 @@ def tt_loglikelihood_row(isSparse, data_row, model_row, Pi):
     """
     term1 = -np.sum(model_row)
     if isSparse:
-        term2 = np.sum(data_row.transpose() * np.log(model_row.dot(Pi)))
+        term2 = np.sum(data_row.transpose() * np.log(model_row.dot(Pi.transpose())))
     else:
         b_pi = model_row.dot(Pi.transpose())
         term2 = 0

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -2173,15 +2173,14 @@ class sptensor(object):
 
     __str__ = __repr__
 
-    def ttm(self, matrices, mode, dims=None, transpose=False):
+    def ttm(self, matrices, dims=None, transpose=False):
         """
         Sparse tensor times matrix.
 
         Parameters
         ----------
         matrices: A matrix or list of matrices
-        mode:
-        dims:
+        dims: :class:`Numpy.ndarray`, int
         transpose: Transpose matrices to be multiplied
 
         Returns
@@ -2190,10 +2189,15 @@ class sptensor(object):
         """
         if dims is None:
             dims = np.arange(self.ndims)
+        elif isinstance(dims, list):
+            dims = np.array(dims)
+        elif np.isscalar(dims) or isinstance(dims, list):
+            dims = np.array([dims])
+
         # Handle list of matrices
         if isinstance(matrices, list):
             # Check dimensions are valid
-            [dims, vidx] = tt_dimscheck(mode, self.ndims, len(matrices))
+            [dims, vidx] = tt_dimscheck(dims, self.ndims, len(matrices))
             # Calculate individual products
             Y = self.ttm(matrices[vidx[0]], dims[0], transpose=transpose)
             for i in range(1, dims.size):
@@ -2208,22 +2212,23 @@ class sptensor(object):
         if transpose:
             matrices = matrices.transpose()
 
-        # Check mode
-        if not np.isscalar(mode) or mode < 0 or mode > self.ndims-1:
-            assert False, "Mode must be in [0, ndims)"
+        # Ensure this is the terminal single dimension case
+        if not (dims.size == 1 and np.isin(dims, np.arange(self.ndims))):
+            assert False, "dims must contain values in [0,self.dims)"
+        dims = dims[0]
 
         # Compute the product
 
         # Check that sizes match
-        if self.shape[mode] != matrices.shape[1]:
+        if self.shape[dims] != matrices.shape[1]:
             assert False, "Matrix shape doesn't match tensor shape"
 
         # Compute the new size
         siz = np.array(self.shape)
-        siz[mode] = matrices.shape[0]
+        siz[dims] = matrices.shape[0]
 
         # Compute self[mode]'
-        Xnt = ttb.tt_to_sparse_matrix(self, mode, True)
+        Xnt = ttb.tt_to_sparse_matrix(self, dims, True)
 
         # Reshape puts the reshaped things after the unchanged modes, transpose then puts it in front
         idx = 0
@@ -2231,10 +2236,10 @@ class sptensor(object):
         # Convert to sparse matrix and do multiplication; generally result is sparse
         Z = Xnt.dot(matrices.transpose())
 
-        # Rearrange back into sparse tensor of original shape
-        Ynt = ttb.tt_from_sparse_matrix(Z, self.shape, mode, idx)
+        # Rearrange back into sparse tensor of correct shape
+        Ynt = ttb.tt_from_sparse_matrix(Z, siz, dims, idx)
 
-        if Z.nnz <= 0.5 * np.prod(siz):
+        if not isinstance(Z, np.ndarray) and Z.nnz <= 0.5 * np.prod(siz):
             return Ynt
         else:
             # TODO evaluate performance loss by casting into sptensor then tensor. I assume minimal since we are already

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -380,7 +380,6 @@ class sptensor(object):
         Parameters
         ----------
         k: int Dimension for subscript indexing
-        n: int 1 for linear indexing, ndims for subscript
 
         Returns
         -------
@@ -419,11 +418,14 @@ class sptensor(object):
         invalid = (searchsubs < 0) | (searchsubs >= np.array(self.shape))
         badloc = np.where(np.sum(invalid, axis=1) > 0)
         if badloc[0].size > 0:
-            print('The following subscripts are invalid: \n')
+            error_msg = "The following subscripts are invalid: \n"
             badsubs = searchsubs[badloc, :]
             for i in np.arange(0, badloc[0].size):
-                print('\tsubscript = {}) \n'.format(tt_intvec2str(badsubs[i, :])))
-            assert False, 'Invalid subscripts'
+                error_msg += f"\tsubscript = {tt_intvec2str(badsubs[i, :])} \n"
+            assert False, (
+                f"{error_msg}"
+                'Invalid subscripts'
+            )
 
         # Set the default answer to zero
         a = np.zeros(shape=(p, 1), dtype=self.vals.dtype)
@@ -687,7 +689,7 @@ class sptensor(object):
         >>> subs = np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])
         >>> vals = np.array([[0.5], [1.5], [2.5], [3.5]])
         >>> shape = (4, 4, 4)
-        >>> sptensorInstance.from_data(subs, vals, shape)
+        >>> sptensorInstance = sptensor.from_data(subs, vals, shape)
         >>> sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 0)
         [[0, 0, 0, 0],
         [2, 2, 2, 2],
@@ -962,7 +964,7 @@ class sptensor(object):
         --------
         >>> subs = np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])
         >>> vals = np.array([[0.5], [1.5], [2.5], [3.5]])
-        >>> shape = np.array([4, 4, 4])
+        >>> shape = (4, 4, 4)
         >>> sp = sptensor.from_data(subs,vals,shape)
         >>> region = np.ndarray([1, [1], [1,3]])
         >>> loc = sp.subdims(region)
@@ -1706,7 +1708,7 @@ class sptensor(object):
 
         Parameters
         ----------
-        :class:`pyttb.sptensor`, :class:`pyttb.tensor`, float, int
+        other: :class:`pyttb.sptensor`, :class:`pyttb.tensor`, float, int
 
         Returns
         -------
@@ -1748,7 +1750,7 @@ class sptensor(object):
 
         Parameters
         ----------
-        float, int
+        other: float, int
 
         Returns
         -------

--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -13,7 +13,7 @@ class tenmat(object):
 
     """
 
-    def __init__(self, *args):
+    def __init__(self):
         """
         TENSOR Create empty tensor.
         """
@@ -190,10 +190,7 @@ class tenmat(object):
         -------
         int
         """
-        if self.shape == (0,):
-            return 0
-        else:
-            return len(self.shape)
+        return len(self.shape)
 
     def norm(self):
         """

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -103,7 +103,6 @@ class tensor(object):
             order = np.hstack([source.rindices, source.cindices])
             data = np.reshape(source.data.copy(), np.array(shape)[order], order='F')
             if order.size > 1:
-                # data = ipermute(data, order)
                 data = np.transpose(data, np.argsort(order))
             return cls.from_data(data, shape)
 
@@ -944,7 +943,7 @@ class tensor(object):
 
     def ttt(self, other, selfdims=None, otherdims=None):
         """
-        Tensor mulitplication (tensor times tensor)
+        Tensor multiplication (tensor times tensor)
 
         Parameters
         ----------
@@ -1464,7 +1463,7 @@ class tensor(object):
 
     def __radd__(self, other):
         """
-        Reverse binary addition (+) for tensors
+        Right binary addition (+) for tensors
 
         Parameters
         ----------

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -921,7 +921,7 @@ class tensor(object):
             assert False, "matrix must be of type numpy.ndarray"
 
         if not (dims.size == 1 and np.isin(dims, np.arange(self.ndims))):
-            assert False, "dims must contain values in [0,self.dims]"
+            assert False, "dims must contain values in [0,self.dims)"
 
         # old version (ver=0)
         shape = np.array(self.shape)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,10 @@
+import pyttb as ttb
+import pytest
+
+
+def test_package_smoke():
+    """A few sanity checks to make sure things don't explode"""
+    assert len(ttb.__version__) > 0
+    # Make sure warnings filter doesn't crash
+    ttb.ignore_warnings(False)
+    ttb.ignore_warnings(True)

--- a/tests/test_pyttb_utils.py
+++ b/tests/test_pyttb_utils.py
@@ -3,6 +3,7 @@
 # U.S. Government retains certain rights in this software.
 
 import pyttb as ttb
+import logging
 import numpy as np
 import pytest
 import scipy.sparse as sparse
@@ -172,8 +173,6 @@ def test_tt_tenfun():
     assert "Tensor 2 is not the same size as the first tensor input" in str(excinfo)
 
 
-
-
 @pytest.mark.indevelopment
 def test_tt_setdiff_rows():
     a = np.array([[4, 6], [1, 9], [2, 6], [2, 6], [99, 0]])
@@ -184,12 +183,21 @@ def test_tt_setdiff_rows():
     b = np.array([[1, 7], [1, 8]])
     assert (ttb.tt_setdiff_rows(a, b) == np.array([0, 1])).all()
 
+    a = np.array([[4, 6], [1, 9]])
+    b = np.array([])
+    assert (ttb.tt_setdiff_rows(a, b) == np.arange(a.shape[0])).all()
+    assert (ttb.tt_setdiff_rows(b, a) == b).all()
 
 @pytest.mark.indevelopment
 def test_tt_intersect_rows():
     a = np.array([[4, 6], [1, 9], [2, 6], [2, 6]])
     b = np.array([[1, 7], [1, 8], [2, 6], [2, 1], [2, 4], [4, 6], [4, 7], [5, 9], [5, 2], [5, 1]])
     assert (ttb.tt_intersect_rows(a, b) == np.array([2, 0])).all()
+
+    a = np.array([[4, 6], [1, 9]])
+    b = np.array([])
+    assert (ttb.tt_intersect_rows(a, b) == b).all()
+    assert (ttb.tt_intersect_rows(a, b) == ttb.tt_intersect_rows(b, a)).all()
 
 
 @pytest.mark.indevelopment
@@ -330,13 +338,13 @@ def test_tt_ind2sub_valid():
     subs = np.array([[0, 0, 0], [1, 1, 1], [3, 3, 3]])
     idx = np.array([0, 21, 63])
     shape = (4, 4, 4)
-    print(f'\nttb.tt_ind2sub(shape, idx): {ttb.tt_ind2sub(shape, idx)}')
+    logging.debug(f'\nttb.tt_ind2sub(shape, idx): {ttb.tt_ind2sub(shape, idx)}')
     assert (ttb.tt_ind2sub(shape, idx) == subs).all()
 
     subs = np.array([[1, 0], [0, 1]])
     idx = np.array([1, 2])
     shape = (2, 2)
-    print(f'\nttb.tt_ind2sub(shape, idx): {ttb.tt_ind2sub(shape, idx)}')
+    logging.debug(f'\nttb.tt_ind2sub(shape, idx): {ttb.tt_ind2sub(shape, idx)}')
     assert (ttb.tt_ind2sub(shape, idx) == subs).all()
 
     empty = np.array([])

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -1365,25 +1365,25 @@ def test_sptensor_ttm(sample_sptensor):
     result[:, 3, 3] = 3.5
     result = ttb.tensor.from_data(result)
     result = ttb.sptensor.from_tensor_type(result)
-    assert sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), mode=0).isequal(result)
-    assert sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), mode=0, transpose=True).isequal(result)
+    assert sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), dims=0).isequal(result)
+    assert sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), dims=0, transpose=True).isequal(result)
 
     # This is a multiway multiplication yielding a sparse tensor, yielding a dense tensor relies on tensor.ttm
     matrix = sparse.coo_matrix(np.eye(4))
     list_of_matrices = [matrix, matrix, matrix]
-    assert sptensorInstance.ttm(list_of_matrices, mode=np.array([0, 1, 2])).isequal(sptensorInstance)
+    assert sptensorInstance.ttm(list_of_matrices, dims=np.array([0, 1, 2])).isequal(sptensorInstance)
 
     with pytest.raises(AssertionError) as excinfo:
-        sptensorInstance.ttm(sparse.coo_matrix(np.ones((5, 5))), mode=0)
+        sptensorInstance.ttm(sparse.coo_matrix(np.ones((5, 5))), dims=0)
     assert "Matrix shape doesn't match tensor shape" in str(excinfo)
 
     with pytest.raises(AssertionError) as excinfo:
-        sptensorInstance.ttm(np.array([1, 2, 3, 4]), mode=0)
+        sptensorInstance.ttm(np.array([1, 2, 3, 4]), dims=0)
     assert "Sptensor.ttm: second argument must be a matrix" in str(excinfo)
 
     with pytest.raises(AssertionError) as excinfo:
-        sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), mode=4)
-    assert "Mode must be in [0, ndims)" in str(excinfo)
+        sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), dims=4)
+    assert "dims must contain values in [0,self.dims)" in str(excinfo)
 
     sptensorInstance[0, :, :] = 1
     sptensorInstance[3, :, :] = 1
@@ -1397,17 +1397,20 @@ def test_sptensor_ttm(sample_sptensor):
     # TODO: Ensure mode mappings are consistent between matlab and numpy
     # MATLAB is opposite orientation so the mapping from matlab to numpy is
     # {3:0, 2:2, 1:1}
-    assert (sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), mode=1).isequal(ttb.tensor.from_data(result)))
+    assert (sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), dims=1).isequal(ttb.tensor.from_data(result)))
 
     result = 2*np.ones((4, 4, 4))
     result[:, 1, 1] = 2.5
     result[:, 1, 3] = 3.5
     result[:, 2, 2] = 4.5
-    assert (sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), mode=0).isequal(ttb.tensor.from_data(result)))
+    assert (sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), dims=0).isequal(ttb.tensor.from_data(result)))
 
     result = np.zeros((4, 4, 4))
     result[0, :, :] = 4.0
     result[3, :, :] = 4.0
     result[1, 1, :] = 2
     result[2, 2, :] = 2.5
-    assert (sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), mode=2).isequal(ttb.tensor.from_data(result)))
+    assert (sptensorInstance.ttm(sparse.coo_matrix(np.ones((4, 4))), dims=2).isequal(ttb.tensor.from_data(result)))
+
+    # Confirm reshape for non-square matrix
+    assert sptensorInstance.ttm(sparse.coo_matrix(np.ones((1, 4))), dims=2).shape == (4,4,1)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1054,7 +1054,7 @@ def test_tensor_ttm(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     # 3-way, dims must be in range [0,self.ndims]
     with pytest.raises(AssertionError) as excinfo:
         tensorInstance3.ttm(M2, tensorInstance3.ndims + 1)
-    assert "dims must contain values in [0,self.dims]" in str(excinfo)
+    assert "dims must contain values in [0,self.dims)" in str(excinfo)
 
 @pytest.mark.indevelopment
 def test_tensor_ttt(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -199,7 +199,7 @@ def test_tensor_ndims(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
     assert ttb.tensor.from_data(np.array([])) == 0
 
 @pytest.mark.indevelopment
-def test_tensor_setitem(sample_tensor_2way):
+def test_tensor__setitem__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Subtensor assign with constant
@@ -564,6 +564,9 @@ def test_tensor__add__(sample_tensor_2way):
     # Tensor + scalar
     assert ((tensorInstance + 1).data == 1 + (params['data'])).all()
 
+    # scalar + Tensor
+    assert ((1 + tensorInstance).data == 1 + (params['data'])).all()
+
 @pytest.mark.indevelopment
 def test_tensor__sub__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
@@ -861,6 +864,14 @@ def test_tensor_collapse(sample_tensor_2way, sample_tensor_3way, sample_tensor_4
     tensorCollapse4Max = tensorInstance4.collapse(np.array([0, 2]), fun=np.max)
     assert (tensorCollapse4Max.data == data4max).all()
 
+    # Empty tensor collapse
+    empty_data = np.array([])
+    empty_tensor = ttb.tensor.from_data(empty_data)
+    assert np.all(empty_tensor.collapse() == empty_data)
+
+    # Empty dims
+    assert tensorInstance2.collapse(empty_data).isequal(tensorInstance2)
+
 @pytest.mark.indevelopment
 def test_tensor_contract(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     (params2, tensorInstance2) = sample_tensor_2way
@@ -1072,6 +1083,17 @@ def test_tensor_ttt(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     assert (TTT1[:,0,0,0,0,0].data == data11).all()
     assert (TTT1[:,1,1,1,1,1].data == data12).all()
     assert (TTT1[:,2,1,2,3,1].data == data13).all()
+
+    TTT1_with_dims = M31.ttt(M31, selfdims=np.array([0,1,2]), otherdims=np.array([0,1,2]))
+    assert np.allclose(TTT1_with_dims, M31.innerprod(M31))
+
+    # Negative tests
+    with pytest.raises(AssertionError):
+        invalid_tensor_type = []
+        M31.ttt(invalid_tensor_type)
+
+    with pytest.raises(AssertionError):
+        M31.ttt(M31, selfdims=np.array([0, 1, 2]), otherdims=np.array([0, 2, 1]))
 
 
 @pytest.mark.indevelopment


### PR DESCRIPTION
Improvements towards https://github.com/sandialabs/pyttb/issues/14 doesn't get to 100% but cuts uncovered lines by about half.

NOTE: The first commit (to avoid a mess) is included in https://github.com/sandialabs/pyttb/pull/51 but the two PRs aren't mutually exclusive. It's fine to go in with either since I think it is justified in isolation.

Before:
```
Name                   Stmts   Miss  Cover   Missing
----------------------------------------------------
pyttb\__init__.py         23      1    96%   31
pyttb\cp_als.py           87      0   100%
pyttb\cp_apr.py          567     78    86%   84, 86, 88, 110, 197-198, 229, 247-249, 342, 351, 374-384, 419-432, 46
4-469, 495, 536, 540-541, 649, 658, 681-691, 719-732, 781-786, 808, 813, 819, 871-872, 1016, 1034-1037, 1044-1045,
1230, 1297-1299, 1343
pyttb\export_data.py      63      1    98%   54
pyttb\import_data.py      60      4    93%   14, 24, 61, 72
pyttb\khatrirao.py        22      0   100%
pyttb\ktensor.py         512      7    99%   772, 812-816, 1448, 1475
pyttb\pyttb_utils.py     237      2    99%   293, 328
pyttb\sptenmat.py          4      0   100%
pyttb\sptensor3.py         4      0   100%
pyttb\sptensor.py        915      2    99%   117, 1189
pyttb\sumtensor.py         4      0   100%
pyttb\symktensor.py        4      0   100%
pyttb\symtensor.py         4      0   100%
pyttb\tenmat.py          190      1    99%   194
pyttb\tensor.py          644     10    98%   150, 156, 957, 963, 969, 972, 985, 1191, 1305, 1480
pyttb\ttensor.py           4      0   100%
----------------------------------------------------
TOTAL                   3344    106    97%
```

After:
```
Name                   Stmts   Miss  Cover   Missing
----------------------------------------------------
pyttb\__init__.py         23      0   100%
pyttb\cp_als.py           87      0   100%
pyttb\cp_apr.py          569     28    95%   197-198, 229, 465-470, 496, 537, 650, 728-729, 783-788, 810, 815, 821,
 1018, 1036-1039, 1046-1047, 1299-1301
pyttb\export_data.py      63      1    98%   54
pyttb\import_data.py      60      4    93%   14, 24, 61, 72
pyttb\khatrirao.py        22      0   100%
pyttb\ktensor.py         512      7    99%   772, 812-816, 1448, 1475
pyttb\pyttb_utils.py     237      0   100%
pyttb\sptenmat.py          4      0   100%
pyttb\sptensor3.py         4      0   100%
pyttb\sptensor.py        920      1    99%   2193
pyttb\sumtensor.py         4      0   100%
pyttb\symktensor.py        4      0   100%
pyttb\symtensor.py         4      0   100%
pyttb\tenmat.py          188      0   100%
pyttb\tensor.py          644      2    99%   1190, 1304
pyttb\ttensor.py           4      0   100%
----------------------------------------------------
TOTAL                   3349     43    99%
```