### PR TITLE
Tensor docs plus Linting and Typing and Black oh my

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -37,7 +37,7 @@ jobs:
 #        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Run tests
       run: |
-        coverage run --source pyttb -m pytest
+        coverage run --source pyttb -m pytest tests/
         coverage report
     - name: Upload coverage to Coveralls
       run: coveralls --service=github

--- a/conftest.py
+++ b/conftest.py
@@ -10,3 +10,13 @@ import pyttb
 def add_packages(doctest_namespace):
     doctest_namespace['np'] = numpy
     doctest_namespace['ttb'] = pyttb
+
+
+def pytest_addoption(parser):
+    parser.addoption('--packaging', action='store_true', dest="packaging",
+                 default=False, help="enable slow packaging tests")
+
+
+def pytest_configure(config):
+    if not config.option.packaging:
+        setattr(config.option, 'markexpr', 'not packaging')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,20 @@ documentation = "https://pyttb.readthedocs.io"
 requires = ["setuptools>=61.0", "numpy", "numpy_groupies", "scipy", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.isort]
+profile = "black"
+
+[tool.pylint]
+# Play nice with black
+max-line-length = 88
+disable="fixme,too-many-lines"
+
+[tool.pylint.basic]
+# To match MATLAB Tensortoolbox styles for clarity
+argument-naming-style = "any"
+class-naming-style = "any"
+variable-naming-style = "any"
+
+[tool.pylint.design]
+# MATLAB Tensortoolbox interface
+max-public-methods = 40

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,16 @@ variable-naming-style = "any"
 [tool.pylint.design]
 # MATLAB Tensortoolbox interface
 max-public-methods = 40
+
+[tool.mypy]
+warn_unused_configs = true
+plugins = "numpy.typing.mypy_plugin"
+
+[[tool.mypy.overrides]]
+module = [
+    "scipy",
+    "scipy.sparse",
+    "scipy.sparse.linalg",
+    "numpy_groupies"
+]
+ignore_missing_imports = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,5 @@ markers =
 
 filterwarnings =
     ignore:.*deprecated.*:
+
+addopts = --doctest-modules pyttb

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     indevelopment: marks tests as in development, should not be run
+    packaging: slow tests that check formatting over function
 
 filterwarnings =
     ignore:.*deprecated.*:

--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -84,7 +84,7 @@ def cp_als(tensor, rank, stoptol=1e-4, maxiters=1000, dimorder=None,
     [[0.1467... 0.0923...]
      [0.1862... 0.3455...]]
     >>> print(output)
-    {'params': (0.0001, 1000, 1, [0, 1]), 'iters': 1, 'normresidual': 1.9073486328125e-06, 'fit': 0.9999999836180988}
+    {'params': (0.0001, 1000, 1, [0, 1]), 'iters': 1, 'normresidual': ..., 'fit': ...}
 
     Example using "nvecs" initialization:
 

--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -3,7 +3,7 @@
 # U.S. Government retains certain rights in this software.
 
 import pyttb as ttb
-from .pyttb_utils import *
+from pyttb.pyttb_utils import *
 import numpy as np
 
 def cp_als(tensor, rank, stoptol=1e-4, maxiters=1000, dimorder=None,
@@ -51,6 +51,8 @@ def cp_als(tensor, rank, stoptol=1e-4, maxiters=1000, dimorder=None,
 
     Example
     -------
+    Random initialization causes slight pertubation in intermediate results.
+    `...` is our place holder for these numeric values.
     Example using default values ("random" initialization):
 
     >>> weights = np.array([1., 2.])
@@ -58,47 +60,47 @@ def cp_als(tensor, rank, stoptol=1e-4, maxiters=1000, dimorder=None,
     >>> fm1 = np.array([[5., 6.], [7., 8.]])
     >>> K = ttb.ktensor.from_data(weights, [fm0, fm1])
     >>> np.random.seed(1)
-    >>> M, Minit, output = ttb.cp_als(K.full(), 2)
+    >>> M, Minit, output = ttb.cp_als(K.full(), 2) # doctest: +ELLIPSIS
     CP_ALS:
-     Iter 0: f = 0.9999999836180988 f-delta = 0.9999999836180988
-     Iter 1: f = 0.9999999836180988 f-delta = 0.0
-     Final f = 0.9999999836180988
-    >>> print(M)
+     Iter 0: f = ... f-delta = ...
+     Iter 1: f = ... f-delta = ...
+     Final f = ...
+    >>> print(M) # doctest: +ELLIPSIS
     ktensor of shape 2 x 2
-    weights=[108.47158396   8.61141076]
+    weights=[108.4715... 8.6114...]
     factor_matrices[0] =
-    [[0.41877462 0.39899343]
-     [0.9080902  0.91695378]]
+    [[0.4187... 0.3989...]
+     [0.9080... 0.9169...]]
     factor_matrices[1] =
-    [[0.61888633 0.25815611]
-     [0.78548056 0.96610322]]
-    >>> print(Minit)
+    [[0.6188... 0.2581...]
+     [0.7854... 0.9661...]]
+    >>> print(Minit) # doctest: +ELLIPSIS
     ktensor of shape 2 x 2
     weights=[1. 1.]
     factor_matrices[0] =
-    [[4.17022005e-01 7.20324493e-01]
-     [1.14374817e-04 3.02332573e-01]]
+    [[4.1702...e-01 7.2032...e-01]
+     [1.1437...e-04 3.0233...e-01]]
     factor_matrices[1] =
-    [[0.14675589 0.09233859]
-     [0.18626021 0.34556073]]
+    [[0.1467... 0.0923...]
+     [0.1862... 0.3455...]]
     >>> print(output)
     {'params': (0.0001, 1000, 1, [0, 1]), 'iters': 1, 'normresidual': 1.9073486328125e-06, 'fit': 0.9999999836180988}
 
     Example using "nvecs" initialization:
 
-    >>> M, Minit, output = ttb.cp_als(K.full(), 2, init="nvecs")
+    >>> M, Minit, output = ttb.cp_als(K.full(), 2, init="nvecs") # doctest: +ELLIPSIS
     CP_ALS:
-     Iter 0: f = 1.0 f-delta = 1.0
-     Iter 1: f = 1.0 f-delta = 0.0
-     Final f = 1.0
+     Iter 0: f = ... f-delta = ...
+     Iter 1: f = ... f-delta = ...
+     Final f = ...
 
     Example using :class:`pyttb.ktensor` initialization:
 
-    >>> M, Minit, output = ttb.cp_als(K.full(), 2, init=K)
+    >>> M, Minit, output = ttb.cp_als(K.full(), 2, init=K) # doctest: +ELLIPSIS
     CP_ALS:
-     Iter 0: f = 0.9999999836180988 f-delta = 0.9999999836180988
-     Iter 1: f = 0.9999999836180988 f-delta = 0.0
-     Final f = 0.9999999836180988
+     Iter 0: f = ... f-delta = ...
+     Iter 1: f = ... f-delta = ...
+     Final f = ...
     """
 
     # Extract number of dimensions and norm of tensor
@@ -246,5 +248,5 @@ def cp_als(tensor, rank, stoptol=1e-4, maxiters=1000, dimorder=None,
 
 if __name__ == "__main__":
     import doctest               # pragma: no cover
-    import pyttb as ttb  # pragma: no cover
+
     doctest.testmod()            # pragma: no cover

--- a/pyttb/khatrirao.py
+++ b/pyttb/khatrirao.py
@@ -24,11 +24,12 @@ def khatrirao(*listOfMatrices, reverse=False):
 
     Examples
     --------
-    >>>A = np.random.norm(size=(5,2))
-    >>>khatrirao(A,B) #<-- Khatri-Rao of A and B
-    >>>>khatrirao(B,A,reverse=True) #<-- same thing as above
-    >>>>khatrirao([A,A,B]) #<-- passing a list
-    >>>>khatrirao([B,A,A},reverse = True) #<-- same as above
+    >>> A = np.random.normal(size=(5,2))
+    >>> B = np.random.normal(size=(5,2))
+    >>> _ = khatrirao(A,B) #<-- Khatri-Rao of A and B
+    >>> _ = khatrirao(B,A,reverse=True) #<-- same thing as above
+    >>> _ = khatrirao([A,A,B]) #<-- passing a list
+    >>> _ = khatrirao([B,A,A],reverse = True) #<-- same as above
     """
     #Determine if list of matrices of multiple matrix arguments
     if isinstance(listOfMatrices[0], list):

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import pyttb as ttb
-from .pyttb_utils import *
+from pyttb.pyttb_utils import *
 import numpy as np
 import warnings
 import scipy.sparse as sparse
@@ -267,21 +267,21 @@ class ktensor(object):
 
         >>> np.random.seed(1)
         >>> K_random = ttb.ktensor.from_function(np.random.random_sample, (2, 3, 4), 2)
-        >>> print(K_random)
+        >>> print(K_random)  # doctest: +ELLIPSIS
         ktensor of shape 2 x 3 x 4
         weights=[1. 1.]
         factor_matrices[0] =
-        [[4.17022005e-01 7.20324493e-01]
-         [1.14374817e-04 3.02332573e-01]]
+        [[4.1702...e-01 7.2032...e-01]
+         [1.1437...e-04 3.0233...e-01]]
         factor_matrices[1] =
-        [[0.14675589 0.09233859]
-         [0.18626021 0.34556073]
-         [0.39676747 0.53881673]]
+        [[0.1467... 0.0923...]
+         [0.1862... 0.3455...]
+         [0.3967... 0.5388...]]
         factor_matrices[2] =
-        [[0.41919451 0.6852195 ]
-         [0.20445225 0.87811744]
-         [0.02738759 0.67046751]
-         [0.4173048  0.55868983]]
+        [[0.4191... 0.6852...]
+         [0.2044... 0.8781...]
+         [0.0273... 0.6704...]
+         [0.4173...  0.5586...]]
 
         Create a `ktensor` with entries equal to 1:
 
@@ -529,41 +529,41 @@ class ktensor(object):
 
         >>> np.random.seed(1)
         >>> K = ttb.ktensor.from_function(np.random.random_sample, (2, 3, 4), 2)
-        >>> print(K)
+        >>> print(K)  # doctest: +ELLIPSIS
         ktensor of shape 2 x 3 x 4
         weights=[1. 1.]
         factor_matrices[0] =
-        [[4.17022005e-01 7.20324493e-01]
-         [1.14374817e-04 3.02332573e-01]]
+        [[4.1702...e-01 7.2032...e-01]
+         [1.1437...e-04 3.0233...e-01]]
         factor_matrices[1] =
-        [[0.14675589 0.09233859]
-         [0.18626021 0.34556073]
-         [0.39676747 0.53881673]]
+        [[0.1467... 0.0923...]
+         [0.1862... 0.3455...]
+         [0.3967... 0.5388...]]
         factor_matrices[2] =
-        [[0.41919451 0.6852195 ]
-         [0.20445225 0.87811744]
-         [0.02738759 0.67046751]
-         [0.4173048  0.55868983]]
+        [[0.4191... 0.6852...]
+         [0.2044... 0.8781...]
+         [0.0273... 0.6704...]
+         [0.4173... 0.5586...]]
 
         Create a copy of the `ktensor` and change the weights:
 
         >>> K1 = K.copy()
         >>> K1.weights = np.array([2., 3.])
-        >>> print(K1)
+        >>> print(K1)  # doctest: +ELLIPSIS
         ktensor of shape 2 x 3 x 4
         weights=[2. 3.]
         factor_matrices[0] =
-        [[4.17022005e-01 7.20324493e-01]
-         [1.14374817e-04 3.02332573e-01]]
+        [[4.1702...e-01 7.2032...e-01]
+         [1.1437...e-04 3.023...e-01]]
         factor_matrices[1] =
-        [[0.14675589 0.09233859]
-         [0.18626021 0.34556073]
-         [0.39676747 0.53881673]]
+        [[0.1467... 0.0923...]
+         [0.1862... 0.3455...]
+         [0.3967... 0.5388...]]
         factor_matrices[2] =
-        [[0.41919451 0.6852195 ]
-         [0.20445225 0.87811744]
-         [0.02738759 0.67046751]
-         [0.4173048  0.55868983]]
+        [[0.4191... 0.6852...]
+         [0.2044... 0.8781...]
+         [0.0273... 0.6704...]
+         [0.4173... 0.5586...]]
         """
         return ttb.ktensor.from_tensor_type(self)
 
@@ -743,15 +743,15 @@ class ktensor(object):
         >>> K2.factor_matrices[0][1, 1] = - K2.factor_matrices[0][1, 1]
         >>> K2.factor_matrices[1][1, 1] = - K2.factor_matrices[1][1, 1]
         >>> K = K.fixsigns(K2)
-        >>> print(K)
+        >>> print(K)  # doctest: +ELLIPSIS
         ktensor of shape 2 x 2
-        weights=[27.20294102 89.4427191 ]
+        weights=[27.2029... 89.4427...]
         factor_matrices[0] =
-        [[ 0.31622777 -0.4472136 ]
-         [ 0.9486833  -0.89442719]]
+        [[ 0.3162... -0.4472...]
+         [ 0.9486... -0.8944...]]
         factor_matrices[1] =
-        [[ 0.58123819 -0.6       ]
-         [ 0.81373347 -0.8       ]]
+        [[ 0.5812... -0.6...]
+         [ 0.8137... -0.8...]]
         """
         if other == None:
             for r in range(self.ncomponents):
@@ -842,6 +842,7 @@ class ktensor(object):
         data[:, :] = 
         [[29. 39.]
          [63. 85.]]
+        <BLANKLINE>
         """
         data = self.weights @ ttb.khatrirao(self.factor_matrices, reverse=True).T
         return ttb.tensor.from_data(data, self.shape)
@@ -993,8 +994,8 @@ class ktensor(object):
 
         >>> W = ttb.tensor.from_data(np.array([[0, 1], [1, 0]]))
         >>> print(K.mask(W))
-        [[39.]
-         [63.]]
+        [[63.]
+         [39.]]
         """
         # Error check
         if len(W.shape) != len(self.shape) or np.any(np.array(W.shape) > np.array(self.shape)):
@@ -1123,16 +1124,16 @@ class ktensor(object):
         Example
         -------
         >>> K = ttb.ktensor.from_function(np.ones, (2, 3, 4), 2)
-        >>> print(K.normalize())
+        >>> print(K.normalize())  # doctest: +ELLIPSIS
         ktensor of shape 2 x 3 x 4
-        weights=[4.89897949 4.89897949]
+        weights=[4.898... 4.898...]
         factor_matrices[0] =
-        [[0.70710678 0.70710678]
-         [0.70710678 0.70710678]]
+        [[0.7071... 0.7071...]
+         [0.7071... 0.7071...]]
         factor_matrices[1] =
-        [[0.57735027 0.57735027]
-         [0.57735027 0.57735027]
-         [0.57735027 0.57735027]]
+        [[0.5773... 0.5773...]
+         [0.5773... 0.5773...]
+         [0.5773... 0.5773...]]
         factor_matrices[2] =
         [[0.5 0.5]
          [0.5 0.5]
@@ -1215,16 +1216,16 @@ class ktensor(object):
 
         >>> K = ttb.ktensor.from_function(np.ones, (2, 3, 4), 2)
         >>> nvecs1 = K.nvecs(0, 1)
-        >>> print(nvecs1)
-        [[0.70710678]
-         [0.70710678]]
+        >>> print(nvecs1) # doctest: +ELLIPSIS
+        [[0.70710678...]
+         [0.70710678...]]
 
         Compute first 2 leading eigenvectors for dimension 0:
 
         >>> nvecs2 = K.nvecs(0, 2)
-        >>> print(nvecs2)
-        [[ 0.70710678  0.70710678]
-         [ 0.70710678 -0.70710678]]
+        >>> print(nvecs2) # doctest: +ELLIPSIS
+        [[ 0.70710678...  0.70710678...]
+         [ 0.70710678... -0.70710678...]]
         """
         M = self.weights[:, None] @ self.weights[:, None].T
         for i in range(self.ndims):
@@ -1410,12 +1411,9 @@ class ktensor(object):
         -------
         Create two `ktensor` instances:
 
-        >>> A = ttb.ktensor.from_data(np.array([2, 1, 3]), np.ones((3,3)), np.ones((4,3)), np.ones((5,3)))
-        >>> B = ttb.ktensor.from_data(np.array([2, 4]), np.ones((3,2)), np.ones((4,2)), np.ones((5,2)))
-
-        Compute `score` using `ktensor.weights`:
-
-        >>> score,Aperm,flag,perm = A.score(B)
+        >>> A = ttb.ktensor.from_data(np.array([2., 1., 3.]), np.ones((3,3)), np.ones((4,3)), np.ones((5,3)))
+        >>> B = ttb.ktensor.from_data(np.array([2., 4.]), np.ones((3,2)), np.ones((4,2)), np.ones((5,2)))
+        >>> score,Aperm,flag,perm = A.score(B)  #  Compute `score` using `ktensor.weights`
         >>> print(score)
         0.875
         >>> print(perm)
@@ -1531,15 +1529,15 @@ class ktensor(object):
         Make the factor matrices of the `ktensor` symmetric:
 
         >>> K1 = K.symmetrize()
-        >>> print(K1)
+        >>> print(K1) # doctest: +ELLIPSIS
         ktensor of shape 2 x 2
         weights=[1. 1.]
         factor_matrices[0] =
-        [[2.34043142 4.95196735]
-         [4.59606911 8.01245149]]
+        [[2.3404... 4.9519...]
+         [4.5960... 8.0124...]]
         factor_matrices[1] =
-        [[2.34043142 4.95196735]
-         [4.59606911 8.01245149]]
+        [[2.3404... 4.9519...]
+         [4.5960... 8.0124...]]
         """
         # Check tensor dimensions for compatibility with symmetrization
         assert (self.shape == self.shape[0]*np.ones(self.ndims)).all(), "Tensor is not cubic -- cannot be symmetrized"
@@ -1607,20 +1605,20 @@ class ktensor(object):
         Spread weights equally to all factors and return list of factor matrices:
 
         >>> fm_list = K.tolist()
-        >>> for fm in fm_list: print(fm)
-        [[1.         2.82842712]
-         [3.         5.65685425]]
-        [[ 5.          8.48528137]
-         [ 7.         11.3137085 ]]
+        >>> for fm in fm_list: print(fm) # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+        [[1. 2.8284...]
+         [3. 5.6568...]]
+        [[ 5. 8.4852...]
+         [ 7. 11.313...]]
 
         Shift weight to single factor matrix and return list of factor matrices:
 
         >>> fm_list = K.tolist(0)
-        >>> for fm in fm_list: print(fm)
-        [[ 8.60232527 40.        ]
-         [25.8069758  80.        ]]
-        [[0.58123819 0.6       ]
-         [0.81373347 0.8       ]]
+        >>> for fm in fm_list: print(fm)  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+        [[ 8.6023... 40. ]
+         [25.8069... 80. ]]
+        [[0.5812... 0.6...]
+         [0.8137... 0.8...]]
         """
         if mode is not None:
             if isinstance(mode, int) and mode in range(self.ndims):
@@ -2167,5 +2165,5 @@ class ktensor(object):
 
 if __name__ == "__main__":
     import doctest               # pragma: no cover
-    import pyttb as ttb  # pragma: no cover
+
     doctest.testmod()            # pragma: no cover

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -1785,13 +1785,13 @@ class ktensor(object):
         >>> vec2 = np.array([1, 1])
         >>> vec3 = np.array([1, 1, 1])
         >>> vec4 = np.array([1, 1, 1, 1])
-        >>> K1 = K.ttv(np.array([vec2, vec3, vec4]))
+        >>> K1 = K.ttv([vec2, vec3, vec4])
         >>> print(K1)
         30348.0
 
         Compute the product of a `ktensor` and multiple vectors out of order (results in a `ktensor`):
 
-        >>> K2 = K.ttv(np.array([vec4, vec3]), np.array([2, 1]))
+        >>> K2 = K.ttv([vec4, vec3], np.array([2, 1]))
         >>> print(K2)
         ktensor of shape 2
         weights=[1800. 3564.]

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -3,6 +3,7 @@
 # U.S. Government retains certain rights in this software.
 
 """Classes and functions for working with Kruskal tensors."""
+from __future__ import annotations
 
 import pyttb as ttb
 from .pyttb_utils import *
@@ -128,7 +129,7 @@ class ktensor(object):
         return k
 
     @classmethod
-    def from_tensor_type(cls, source):
+    def from_tensor_type(cls, source) -> ktensor:
         """
         Construct a ktensor from another ktensor. A deep copy of the data from the input ktensor
         is used for the new ktensor.

--- a/pyttb/pyttb_utils.py
+++ b/pyttb/pyttb_utils.py
@@ -130,7 +130,9 @@ def tt_union_rows(MatrixA, MatrixB):
     >>> a = np.array([[1,2],[3,4]])
     >>> b = np.array([[0,0],[1,2],[3,4],[0,0]])
     >>> ttb.tt_union_rows(a,b)
-    [[1,2],[3,4],[0,0]]
+    array([[0, 0],
+           [1, 2],
+           [3, 4]])
     """
     #TODO ismember and uniqe are very similar in function
     if MatrixA.size > 0:
@@ -329,9 +331,9 @@ def tt_intersect_rows(MatrixA, MatrixB):
     >>> a = np.array([[1,2],[3,4]])
     >>> b = np.array([[0,0],[1,2],[3,4],[0,0]])
     >>> ttb.tt_intersect_rows(a,b)
-    [0,1]
+    array([0, 1])
     >>> ttb.tt_intersect_rows(b,a)
-    [1,2]
+    array([1, 2])
     """
     #TODO ismember and uniqe are very similar in function
     if MatrixA.size > 0:
@@ -500,7 +502,8 @@ def tt_ismember_rows(search, source):
     >>> a = np.array([[4, 6], [1, 9], [2, 6]])
     >>> b = np.array([[1, 7],[1, 8],[2, 6],[2, 1],[2, 4],[4, 6],[4, 7],[5, 9],[5, 2],[5, 1]])
     >>> results = tt_ismember_rows(a,b)
-    array([5 , -1, 2])
+    >>> print(results)
+    [ 5 -1  2]
 
     """
     results = np.ones(shape=search.shape[0])*-1

--- a/pyttb/pyttb_utils.py
+++ b/pyttb/pyttb_utils.py
@@ -6,6 +6,7 @@ import pyttb as ttb
 import numpy as np
 from inspect import signature
 import scipy.sparse as sparse
+from typing import Optional, Tuple, overload
 
 def tt_to_dense_matrix(tensorInstance, mode, transpose= False):
     """
@@ -126,9 +127,9 @@ def tt_union_rows(MatrixA, MatrixB):
 
     Examples
     --------
-    >>>a = np.array([[1,2],[3,4]])
-    >>>b = np.array([[0,0],[1,2],[3,4],[0,0]])
-    >>>ttb.tt_union_rows(a,b)
+    >>> a = np.array([[1,2],[3,4]])
+    >>> b = np.array([[0,0],[1,2],[3,4],[0,0]])
+    >>> ttb.tt_union_rows(a,b)
     [[1,2],[3,4],[0,0]]
     """
     #TODO ismember and uniqe are very similar in function
@@ -146,7 +147,18 @@ def tt_union_rows(MatrixA, MatrixB):
     union = np.vstack((MatrixB[np.sort(idxB[np.where(location < 0)])], MatrixA[np.sort(idxA)]))
     return union
 
-def tt_dimscheck(dims, N, M=None):
+
+@overload
+def tt_dimscheck(dims: np.ndarray, N: int, M: None =None) -> Tuple[np.ndarray, None]:
+    ...
+
+
+@overload
+def tt_dimscheck(dims: np.ndarray, N: int, M: int) -> Tuple[np.ndarray, np.ndarray]:
+    ...
+
+
+def tt_dimscheck(dims: np.ndarray, N: int, M: Optional[int] =None) -> Tuple[np.ndarray, Optional[np.ndarray]]:
     """
     Used to preprocess dimensions for tensor dimensions
 
@@ -314,11 +326,11 @@ def tt_intersect_rows(MatrixA, MatrixB):
 
     Examples
     --------
-    >>>a = np.array([[1,2],[3,4]])
-    >>>b = np.array([[0,0],[1,2],[3,4],[0,0]])
-    >>>ttb.tt_intersect_rows(a,b)
+    >>> a = np.array([[1,2],[3,4]])
+    >>> b = np.array([[0,0],[1,2],[3,4],[0,0]])
+    >>> ttb.tt_intersect_rows(a,b)
     [0,1]
-    >>>ttb.tt_intersect_rows(b,a)
+    >>> ttb.tt_intersect_rows(b,a)
     [1,2]
     """
     #TODO ismember and uniqe are very similar in function
@@ -501,7 +513,7 @@ def tt_ismember_rows(search, source):
     return results.astype(int)
 
 
-def tt_ind2sub(shape, idx):
+def tt_ind2sub(shape: Tuple[int, ...], idx: np.ndarray) -> np.ndarray:
     """
     Multiple subscripts from linear indices.
 

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -176,7 +176,7 @@ class sptensor(object):
         --------
         >>> subs = np.array([[1, 2], [1, 3]])
         >>> vals = np.array([[6], [7]])
-        >>> shape = np.array([4, 4, 4])
+        >>> shape = np.array([4, 4])
         >>> K0 = ttb.sptensor.from_aggregator(subs,vals)
         >>> K1 = ttb.sptensor.from_aggregator(subs,vals,shape)
         >>> function_handle = sum
@@ -691,10 +691,10 @@ class sptensor(object):
         >>> shape = (4, 4, 4)
         >>> sptensorInstance = sptensor.from_data(subs, vals, shape)
         >>> sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 0)
-        [[0, 0, 0, 0],
-        [2, 2, 2, 2],
-        [2.5, 2.5, 2.5, 2.5],
-        [3.5, 3.5, 3.5, 3.5]]
+        array([[0. , 0. , 0. , 0. ],
+               [2. , 2. , 2. , 2. ],
+               [2.5, 2.5, 2.5, 2.5],
+               [3.5, 3.5, 3.5, 3.5]])
 
         """
         # In the sparse case, it is most efficient to do a series of TTV operations
@@ -966,15 +966,14 @@ class sptensor(object):
         >>> vals = np.array([[0.5], [1.5], [2.5], [3.5]])
         >>> shape = (4, 4, 4)
         >>> sp = sptensor.from_data(subs,vals,shape)
-        >>> region = np.ndarray([1, [1], [1,3]])
+        >>> region = [np.array([1]), np.array([1]), np.array([1,3])]
         >>> loc = sp.subdims(region)
         >>> print(loc)
-            loc = [0,1]
+        [0 1]
         >>> region = (1, 1, slice(None, None, None))
         >>> loc = sp.subdims(region)
         >>> print(loc)
-            loc = [0,1]
-
+        [0 1]
         """
         if len(region) != self.ndims:
             assert False, "Number of subdimensions must equal number of dimensions"
@@ -1114,12 +1113,10 @@ class sptensor(object):
 
         Examples
         --------
-        >>> X = sptensor(np.array([[3,3,3],[1,1,0],[1,2,1]]),np.array([3,5,1]),(4,4,4))
-        >>> X[0,1,0] #<-- returns zero
-        >>> X[3,3,3] #<-- returns 3
-        >>> X[2:3,:,:] #<-- returns 1 x 4 x 4 sptensor
-        X = sptensor([6;16;26],[1;1;1],30);
-        X([1:6]') <-- extracts a subtensor
+        >>> X = sptensor.from_data(np.array([[3,3,3],[1,1,0],[1,2,1]]),np.array([3,5,1]),(4,4,4))
+        >>> _ = X[0,1,0] #<-- returns zero
+        >>> _ = X[3,3,3] #<-- returns 3
+        >>> _ = X[2:3,:,:] #<-- returns 1 x 4 x 4 sptensor
         """
         # This does not work like MATLAB TTB; you must call sptensor.extract to get this functionality
         # X([1:6]','extract') %<-- extracts a vector of 6 elements

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -10,6 +10,7 @@ from numpy_groupies import aggregate as accumarray
 import scipy.sparse.linalg
 import warnings
 
+
 class tensor(object):
     """
     TENSOR Class for dense tensors.
@@ -27,9 +28,9 @@ class tensor(object):
     @classmethod
     def from_data(cls, data, shape=None):
         """
-        Creates a tensor from explicit description. Note that 1D tensors (i.e., when len(shape)==1) 
-        contains a data array that follow the Numpy convention of being a row vector, which is 
-        different than in the Matlab Tensor Toolbox.  
+        Creates a tensor from explicit description. Note that 1D tensors (i.e., when len(shape)==1)
+        contains a data array that follow the Numpy convention of being a row vector, which is
+        different than in the Matlab Tensor Toolbox.
 
         Parameters
         ----------
@@ -41,29 +42,32 @@ class tensor(object):
         :class:`pyttb.tensor`
         """
         # CONVERT A MULTIDIMENSIONAL ARRAY
-        if not issubclass(data.dtype.type, np.number) and not issubclass(data.dtype.type, np.bool_):
-            assert False, 'First argument must be a multidimensional array.'
+        if not issubclass(data.dtype.type, np.number) and not issubclass(
+            data.dtype.type, np.bool_
+        ):
+            assert False, "First argument must be a multidimensional array."
 
         # Create or check second argument
         if shape is None:
             shape = data.shape
         else:
             if not isinstance(shape, tuple):
-                assert False, 'Second argument must be a tuple.'
-
+                assert False, "Second argument must be a tuple."
 
         # Make sure the number of elements matches what's been specified
         if len(shape) == 0:
             if data.size > 0:
-                assert False, 'Empty tensor cannot contain any elements'
+                assert False, "Empty tensor cannot contain any elements"
 
         elif np.prod(shape) != data.size:
-            assert False, 'TTB:WrongSize, Size of data does not match specified size of tensor'
+            assert (
+                False
+            ), "TTB:WrongSize, Size of data does not match specified size of tensor"
 
         # Make sure the data is indeed the right shape
         if data.size > 0 and len(shape) > 0:
             # reshaping using Fortran ordering to match Matlab conventions
-            data = np.reshape(data, np.array(shape), order='F')
+            data = np.reshape(data, np.array(shape), order="F")
 
         # Create the tensor
         tensorInstance = cls()
@@ -90,7 +94,17 @@ class tensor(object):
         if isinstance(source, tensor):
             # COPY CONSTRUCTOR
             return cls.from_data(source.data.copy(), source.shape)
-        elif isinstance(source, (ttb.ktensor, ttb.ttensor, ttb.sptensor, ttb.sumtensor, ttb.symtensor, ttb.symktensor)):
+        elif isinstance(
+            source,
+            (
+                ttb.ktensor,
+                ttb.ttensor,
+                ttb.sptensor,
+                ttb.sumtensor,
+                ttb.symtensor,
+                ttb.symktensor,
+            ),
+        ):
             # CONVERSION
             t = source.full()
             return cls.from_data(t.data.copy(), t.shape)
@@ -101,7 +115,7 @@ class tensor(object):
             # it using ipermute.
             shape = source.tshape
             order = np.hstack([source.rindices, source.cindices])
-            data = np.reshape(source.data.copy(), np.array(shape)[order], order='F')
+            data = np.reshape(source.data.copy(), np.array(shape)[order], order="F")
             if order.size > 1:
                 data = np.transpose(data, np.argsort(order))
             return cls.from_data(data, shape)
@@ -124,7 +138,7 @@ class tensor(object):
 
         # Check size
         if not isinstance(shape, tuple):
-            assert False, 'TTB:BadInput, Shape must be a tuple'
+            assert False, "TTB:BadInput, Shape must be a tuple"
 
         # Generate data
         data = function_handle(shape)
@@ -156,13 +170,13 @@ class tensor(object):
 
         dims, _ = tt_dimscheck(dims, self.ndims)
         remdims = np.setdiff1d(np.arange(0, self.ndims), dims)
-        
+
         # Check for the case where we accumulate over *all* dimensions
         if remdims.size == 0:
             if fun == "sum":
-                return sum(self.data.flatten('F'))
+                return sum(self.data.flatten("F"))
             else:
-                return fun(self.data.flatten('F'))
+                return fun(self.data.flatten("F"))
 
         ## Calculate the shape of the result
         newshape = tuple(np.array(self.shape)[remdims])
@@ -221,7 +235,7 @@ class tensor(object):
         x = self.permute(np.concatenate((remdims, np.array([i, j]))))
 
         # Reshape data to be 3D
-        data = np.reshape(x.data, (m, n, n), order='F')
+        data = np.reshape(x.data, (m, n, n), order="F")
 
         # Add diagonal entries for each slice
         newdata = np.zeros((m, 1))
@@ -230,7 +244,7 @@ class tensor(object):
 
         # Reshape result
         if np.prod(newsize) > 1:
-            newdata = np.reshape(newdata, newsize, order='F')
+            newdata = np.reshape(newdata, newsize, order="F")
 
         return ttb.tensor.from_data(newdata, newsize)
 
@@ -297,9 +311,9 @@ class tensor(object):
 
         :return:
         """
-        idx = np.nonzero(np.ravel(self.data,order='F'))[0]
-        subs = ttb.tt_ind2sub(self.shape,idx)
-        vals = self.data[tuple(subs.T)][:,None]
+        idx = np.nonzero(np.ravel(self.data, order="F"))[0]
+        subs = ttb.tt_ind2sub(self.shape, idx)
+        vals = self.data[tuple(subs.T)][:, None]
         return subs, vals
 
     def full(self):
@@ -333,9 +347,9 @@ class tensor(object):
         """
         if isinstance(other, ttb.tensor):
             if self.shape != other.shape:
-                assert False, 'Inner product must be between tensors of the same size'
-            x = np.reshape(self.data, (self.data.size,), order='F')
-            y = np.reshape(other.data, (other.data.size,), order='F')
+                assert False, "Inner product must be between tensors of the same size"
+            x = np.reshape(self.data, (self.data.size,), order="F")
+            y = np.reshape(other.data, (other.data.size,), order="F")
             return x.dot(y)
         elif isinstance(other, (ttb.ktensor, ttb.sptensor, ttb.ttensor)):
             # Reverse arguments and call specializer code
@@ -357,14 +371,17 @@ class tensor(object):
             True if tensors are identical, false otherwise
         """
 
-        if not isinstance(other, (ttb.tensor, ttb.sptensor)) or self.shape != other.shape:
+        if (
+            not isinstance(other, (ttb.tensor, ttb.sptensor))
+            or self.shape != other.shape
+        ):
             return False
         elif isinstance(other, ttb.tensor):
             return np.all(self.data == other.data)
         elif isinstance(other, ttb.sptensor):
             return np.all(self.data == other.full().data)
 
-    def issymmetric(self, grps=None, version=None, return_details = False):
+    def issymmetric(self, grps=None, version=None, return_details=False):
         """
         Determine if a dense tensor is symmetric in specified modes.
 
@@ -392,7 +409,6 @@ class tensor(object):
         # the algorithm is much slower
         if version is None:  # Use new algorithm
             for i in range(0, len(grps)):
-
                 # Extract current group
                 thisgrp = grps[i]
 
@@ -431,10 +447,8 @@ class tensor(object):
             all_diffs = np.zeros((cnt, 1))
             all_perms = np.zeros((cnt, n))
             for i in range(0, len(grps)):
-
                 # Compute the permutations for this group of symmetries
                 for idx, perm in enumerate(permutations(grps[i])):
-
                     all_perms[idx, :] = perm
 
                     # Do the permutation and see if it is a match, if not record the difference.
@@ -442,7 +456,9 @@ class tensor(object):
                     if np.array_equal(self.data, Y.data):
                         all_diffs[idx] = 0
                     else:
-                        all_diffs[idx] = np.max(np.abs(self.data.ravel() - Y.data.ravel()))
+                        all_diffs[idx] = np.max(
+                            np.abs(self.data.ravel() - Y.data.ravel())
+                        )
 
             if return_details == False:
                 return bool((all_diffs == 0).all())
@@ -489,6 +505,7 @@ class tensor(object):
         -------
         :class:`pyttb.tensor`
         """
+
         def tensor_or(x, y):
             return np.logical_or(x, y)
 
@@ -506,6 +523,7 @@ class tensor(object):
         -------
         :class:`pyttb.tensor`
         """
+
         def tensor_xor(x, y):
             return np.logical_xor(x, y)
 
@@ -551,7 +569,7 @@ class tensor(object):
 
         # check that we have a tensor that can perform mttkrp
         if self.ndims < 2:
-            assert False, 'MTTKRP is invalid for tensors with fewer than 2 dimensions'
+            assert False, "MTTKRP is invalid for tensors with fewer than 2 dimensions"
 
         # extract the list of factor matrices if given a ktensor
         if isinstance(U, ttb.ktensor):
@@ -565,11 +583,11 @@ class tensor(object):
 
         # check that we have a list (or list extracted from a ktensor)
         if not isinstance(U, list):
-            assert False, 'Second argument should be a list of arrays or a ktensor'
+            assert False, "Second argument should be a list of arrays or a ktensor"
 
         # check that list is the correct length
         if len(U) != self.ndims:
-            assert False, 'Second argument contains the wrong number of arrays'
+            assert False, "Second argument contains the wrong number of arrays"
 
         if n == 0:
             R = U[1].shape[1]
@@ -581,26 +599,26 @@ class tensor(object):
             if i == n:
                 continue
             if U[i].shape[0] != self.shape[i]:
-                assert False, 'Entry {} of list of arrays is wrong size'.format(i)
+                assert False, "Entry {} of list of arrays is wrong size".format(i)
 
         szl = int(np.prod(self.shape[0:n]))
-        szr = int(np.prod(self.shape[n+1:]))
+        szr = int(np.prod(self.shape[n + 1 :]))
         szn = self.shape[n]
 
         if n == 0:
-            Ur = ttb.khatrirao(U[1:self.ndims], reverse=True)
-            Y = np.reshape(self.data, (szn, szr), order='F')
+            Ur = ttb.khatrirao(U[1 : self.ndims], reverse=True)
+            Y = np.reshape(self.data, (szn, szr), order="F")
             return Y @ Ur
         elif n == self.ndims - 1:
-            Ul = ttb.khatrirao(U[0:self.ndims - 1], reverse=True)
-            Y = np.reshape(self.data, (szl, szn), order='F')
+            Ul = ttb.khatrirao(U[0 : self.ndims - 1], reverse=True)
+            Y = np.reshape(self.data, (szl, szn), order="F")
             return Y.T @ Ul
         else:
-            Ul = ttb.khatrirao(U[n+1:], reverse=True)
-            Ur = np.reshape(ttb.khatrirao(U[0:n], reverse=True), (szl, 1, R), order='F')
-            Y = np.reshape(self.data, (-1, szr), order='F')
+            Ul = ttb.khatrirao(U[n + 1 :], reverse=True)
+            Ur = np.reshape(ttb.khatrirao(U[0:n], reverse=True), (szl, 1, R), order="F")
+            Y = np.reshape(self.data, (-1, szr), order="F")
             Y = Y @ Ul
-            Y = np.reshape(Y, (szl, szn, R), order='F')
+            Y = np.reshape(Y, (szl, szn, R), order="F")
             V = np.zeros((szn, R))
             for r in range(R):
                 V[:, [r]] = Y[:, :, r].T @ Ur[:, :, r]
@@ -647,7 +665,7 @@ class tensor(object):
     def nvecs(self, n, r, flipsign=True):
         """
         Compute the leading mode-n eigenvectors for a tensor
-        
+
         Parameters
         ----------
         n: int
@@ -671,7 +689,7 @@ class tensor(object):
             array([[ 0.40455358,  0.9145143 ],
                    [ 0.9145143 , -0.40455358]])
         """
-        Xn =ttb.tenmat.from_tensor_type(self, rdims=np.array([n])).double()
+        Xn = ttb.tenmat.from_tensor_type(self, rdims=np.array([n])).double()
         y = Xn @ Xn.T
 
         if r < y.shape[0] - 1:
@@ -679,7 +697,9 @@ class tensor(object):
             v = v[:, (-np.abs(w)).argsort()]
             v = v[:, :r]
         else:
-            warnings.warn('Greater than or equal to tensor.shape[n] - 1 eigenvectors requires cast to dense to solve')
+            warnings.warn(
+                "Greater than or equal to tensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
+            )
             w, v = scipy.linalg.eigh(y)
             v = v[:, (-np.abs(w)).argsort()]
             v = v[:, :r]
@@ -734,7 +754,7 @@ class tensor(object):
         if np.prod(self.shape) != np.prod(shape):
             assert False, "Reshaping a tensor cannot change number of elements"
 
-        return ttb.tensor.from_data(np.reshape(self.data, shape, order='F'), shape)
+        return ttb.tensor.from_data(np.reshape(self.data, shape, order="F"), shape)
 
     def squeeze(self):
         """
@@ -792,7 +812,6 @@ class tensor(object):
         if version is None:  # Use default newer faster version
             ngrps = len(grps)
             for i in range(0, ngrps):
-
                 # Extract current group
                 thisgrp = grps[i]
 
@@ -801,8 +820,8 @@ class tensor(object):
                     assert False, "Dimension mismatch for symmetrization"
 
                 # Check for no overlap in the sets
-                if i < ngrps-1:
-                    if not np.intersect1d(thisgrp, grps[i+1:, :]).size == 0:
+                if i < ngrps - 1:
+                    if not np.intersect1d(thisgrp, grps[i + 1 :, :]).size == 0:
                         assert False, "Cannot have overlapping symmetries"
 
                 # Construct matrix ind where each row is the multi-index for one element of tensor
@@ -826,8 +845,8 @@ class tensor(object):
                 classNum = accumarray(linclassidx, 1)
                 # We ignore this division error state because if we don't have an entry in linclassidx we won't
                 # reference the inf or nan in the slice below
-                with np.errstate(divide='ignore', invalid='ignore'):
-                    avg = classSum/classNum
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    avg = classSum / classNum
 
                 newdata = avg[linclassidx]
                 data = np.reshape(newdata, self.shape)
@@ -835,7 +854,6 @@ class tensor(object):
             return ttb.tensor.from_data(data)
 
         else:  # Original version
-
             # Check tensor dimensions for compatibility with symmetrization
             ngrps = len(grps)
             for i in range(0, ngrps):
@@ -846,7 +864,7 @@ class tensor(object):
 
             # Check for no overlap in sets
             for i in range(0, ngrps):
-                for j in range(i+1, ngrps):
+                for j in range(i + 1, ngrps):
                     if not np.intersect1d(grps[i, :], grps[j, :]).size == 0:
                         assert False, "Cannot have overlapping symmetries"
 
@@ -862,7 +880,7 @@ class tensor(object):
             sym_perms = np.tile(np.arange(0, n), [total_perms, 1])
             for i in range(0, ngrps):
                 ntimes = np.prod(combo_lengths[0:i], dtype=int)
-                ncopies = np.prod(combo_lengths[i+1:], dtype=int)
+                ncopies = np.prod(combo_lengths[i + 1 :], dtype=int)
                 nelems = len(combos[i])
 
                 idx = 0
@@ -912,7 +930,7 @@ class tensor(object):
             dims, vidx = ttb.tt_dimscheck(dims, self.ndims, len(matrix))
             # Calculate individual products
             Y = self.ttm(matrix[vidx[0]], dims[0], transpose)
-            for k in range(1,dims.size):
+            for k in range(1, dims.size):
                 Y = Y.ttm(matrix[vidx[k]], dims[k], transpose)
             return Y
 
@@ -925,10 +943,10 @@ class tensor(object):
         # old version (ver=0)
         shape = np.array(self.shape)
         n = dims[0]
-        order = np.array([n] + list(range(0,n)) + list(range(n+1,self.ndims)))
+        order = np.array([n] + list(range(0, n)) + list(range(n + 1, self.ndims)))
         newdata = self.permute(order)
-        ids = np.array(list(range(0,n)) + list(range(n+1,self.ndims)))
-        newdata = np.reshape(newdata.data, (shape[n],np.prod(shape[ids])), order="F")
+        ids = np.array(list(range(0, n)) + list(range(n + 1, self.ndims)))
+        newdata = np.reshape(newdata.data, (shape[n], np.prod(shape[ids])), order="F")
         if transpose:
             newdata = matrix.T @ newdata
             p = matrix.shape[1]
@@ -936,7 +954,9 @@ class tensor(object):
             newdata = matrix @ newdata
             p = matrix.shape[0]
 
-        newshape = np.array([p] + list(shape[range(0,n)]) + list(shape[range(n+1,self.ndims)]))
+        newshape = np.array(
+            [p] + list(shape[range(0, n)]) + list(shape[range(n + 1, self.ndims)])
+        )
         Y = np.reshape(newdata, newshape, order="F")
         Y = np.transpose(Y, np.argsort(order))
         return ttb.tensor.from_data(Y)
@@ -999,15 +1019,19 @@ class tensor(object):
             dims = np.array([dims])
 
         # Check that vector is a list of vectors, if not place single vector as element in list
-        if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
-            return self.ttv([vector], dims)
+        if isinstance(vector, list):
+            return self.ttv(np.array(vector), dims)
+        if len(vector.shape) == 1 and isinstance(
+            vector[0], (int, float, np.int_, np.float_)
+        ):
+            return self.ttv(np.array([vector]), dims)
 
         # Get sorted dims and index for multiplicands
         dims, vidx = ttb.tt_dimscheck(dims, self.ndims, len(vector))
 
         # Check that each multiplicand is the right size.
         for i in range(dims.size):
-            if vector[vidx[i]].shape != (self.shape[dims[i]], ):
+            if vector[vidx[i]].shape != (self.shape[dims[i]],):
                 assert False, "Multiplicand is wrong size"
 
         # Extract the data
@@ -1022,8 +1046,8 @@ class tensor(object):
         n = self.ndims
         sz = np.array(self.shape)[np.concatenate((remdims, dims))]
 
-        for i in range(dims.size-1, -1, -1):
-            c = np.reshape(c, tuple([np.prod(sz[0:n-1]), sz[n-1]]), order='F')
+        for i in range(dims.size - 1, -1, -1):
+            c = np.reshape(c, tuple([np.prod(sz[0 : n - 1]), sz[n - 1]]), order="F")
             c = c.dot(vector[vidx[i]])
             n -= 1
         # If needed, convert the final result back to tensor
@@ -1032,7 +1056,7 @@ class tensor(object):
         else:
             return c[0]
 
-    def ttsv(self, vector, dims=None, version = None):
+    def ttsv(self, vector, dims=None, version=None):
         """
         Tensor times same vector in multiple modes
 
@@ -1053,9 +1077,9 @@ class tensor(object):
             if dims == 0:
                 return self.ttv(X)
             elif (dims == -1) or (dims == -2):  # Return scalar or matrix
-                return (self.ttv(X, -np.arange(1, -dims+1))).double()
+                return (self.ttv(X, -np.arange(1, -dims + 1))).double()
             else:
-                return self.ttv(X, -np.arange(1, -dims+1))
+                return self.ttv(X, -np.arange(1, -dims + 1))
 
         elif version == 2 or version is None:  # Calculate the new way
             d = self.ndims
@@ -1066,14 +1090,16 @@ class tensor(object):
 
             y = self.data
             for i in range(drem, 0, -1):
-                yy = np.reshape(y, (sz**(dnew + i -1), sz), order='F')
+                yy = np.reshape(y, (sz ** (dnew + i - 1), sz), order="F")
                 y = yy.dot(vector)
 
             # Convert to matrix if 2-way or convert back to tensor if result is >= 3-way
-            if dnew == 2:  
-                return np.reshape(y, [sz, sz], order='F')
-            elif dnew > 2:  
-                return ttb.tensor.from_data(np.reshape(y, sz*np.ones(dnew, dtype=int), order='F'))
+            if dnew == 2:
+                return np.reshape(y, [sz, sz], order="F")
+            elif dnew > 2:
+                return ttb.tensor.from_data(
+                    np.reshape(y, sz * np.ones(dnew, dtype=np.int), order="F")
+                )
             else:
                 return y
         else:
@@ -1106,26 +1132,27 @@ class tensor(object):
         X(1,1,4) = 1 %<- grows the size of the tensor
         """
         # Figure out if we are doing a subtensor, a list of subscripts or a list of linear indices
-        type = 'error'
+        type = "error"
         if self.ndims <= 1:
             if isinstance(key, np.ndarray):
-                type = 'subscripts'
+                type = "subscripts"
             else:
-                type = 'subtensor'
+                type = "subtensor"
         else:
             if isinstance(key, np.ndarray):
-                if (len(key.shape) > 1 and key.shape[1] >= self.ndims):
-                    type = 'subscripts'
+                if len(key.shape) > 1 and key.shape[1] >= self.ndims:
+                    type = "subscripts"
                 elif len(key.shape) == 1 or key.shape[1] == 1:
-                    type = 'linear indices'
+                    type = "linear indices"
             elif isinstance(key, tuple):
-                validSubtensor = [isinstance(keyElement, (int, slice)) for keyElement in key]
+                validSubtensor = [
+                    isinstance(keyElement, (int, slice)) for keyElement in key
+                ]
                 if np.all(validSubtensor):
-                    type = 'subtensor'
-
+                    type = "subtensor"
 
         # Case 1: Rectangular Subtensor
-        if type == 'subtensor':
+        if type == "subtensor":
             # Extract array of subscripts
             subs = key
 
@@ -1144,7 +1171,9 @@ class tensor(object):
             if n == 0:
                 newsiz = (bsiz[n:] + 1).astype(int)
             else:
-                newsiz = np.concatenate((np.max((self.shape, bsiz[0:n] + 1), axis=0), bsiz[n :] + 1)).astype(int)
+                newsiz = np.concatenate(
+                    (np.max((self.shape, bsiz[0:n] + 1), axis=0), bsiz[n:] + 1)
+                ).astype(int)
             if (newsiz != self.shape).any():
                 # We need to enlarge x.data.
                 newData = np.zeros(shape=tuple(newsiz))
@@ -1162,13 +1191,17 @@ class tensor(object):
             return
 
         # Case 2a: Subscript indexing
-        if type == 'subscripts':
+        if type == "subscripts":
             # Extract array of subscripts
             subs = key
 
             # Will the size change? If so we first need to resize x
             n = self.ndims
-            if len(subs.shape) == 1 and len(self.shape) == 1 and self.shape[0] < subs.shape[0]:
+            if (
+                len(subs.shape) == 1
+                and len(self.shape) == 1
+                and self.shape[0] < subs.shape[0]
+            ):
                 bsiz = subs
             elif len(subs.shape) == 1:
                 bsiz = np.array([np.max(subs, axis=0)])
@@ -1178,7 +1211,9 @@ class tensor(object):
             if n == 0:
                 newsiz = (bsiz[n:] + 1).astype(int)
             else:
-                newsiz = np.concatenate((np.max((self.shape, bsiz[0:n] + 1), axis=0), bsiz[n:] + 1)).astype(int)
+                newsiz = np.concatenate(
+                    (np.max((self.shape, bsiz[0:n] + 1), axis=0), bsiz[n:] + 1)
+                ).astype(int)
 
             if (newsiz != self.shape).any():
                 # We need to enlarge x.data.
@@ -1200,10 +1235,12 @@ class tensor(object):
             return
 
         # Case 2b: Linear Indexing
-        if type == 'linear indices':
+        if type == "linear indices":
             idx = key
             if (idx > np.prod(self.shape)).any():
-                assert False, 'TTB:BadIndex In assignment X[I] = Y, a tensor X cannot be resized'
+                assert (
+                    False
+                ), "TTB:BadIndex In assignment X[I] = Y, a tensor X cannot be resized"
             idx = tt_ind2sub(self.shape, idx)
             if idx.shape[0] == 1:
                 self.data[tuple(idx[0, :])] = value
@@ -1212,7 +1249,7 @@ class tensor(object):
                 self.data[actualIdx] = value
             return
 
-        assert False, 'Invalid use of tensor setitem'
+        assert False, "Invalid use of tensor setitem"
 
     def __getitem__(self, item):
         """
@@ -1258,7 +1295,11 @@ class tensor(object):
         :class:`pyttb.tensor` or :class:`numpy.ndarray`
         """
         # Case 1: Rectangular Subtensor
-        if isinstance(item, tuple) and len(item) == self.ndims and item[len(item) - 1] != 'extract':
+        if (
+            isinstance(item, tuple)
+            and len(item) == self.ndims
+            and item[len(item) - 1] != "extract"
+        ):
             # Copy the subscripts
             region = item
 
@@ -1267,8 +1308,8 @@ class tensor(object):
 
             # Determine the subscripts
             newsiz = []  # future new size
-            kpdims = []   # dimensions to keep
-            rmdims = []   # dimensions to remove
+            kpdims = []  # dimensions to keep
+            rmdims = []  # dimensions to remove
 
             # Determine the new size and what dimensions to keep
             for i in range(0, len(region)):
@@ -1294,7 +1335,7 @@ class tensor(object):
             return a
 
         # *** CASE 2a: Subscript indexing ***
-        if len(item) > 1 and isinstance(item[-1], str) and item[-1] == 'extract':
+        if len(item) > 1 and isinstance(item[-1], str) and item[-1] == "extract":
             # Extract array of subscripts
             subs = np.array(item[0])
             a = np.squeeze(self.data[tuple(subs.transpose())])
@@ -1303,7 +1344,7 @@ class tensor(object):
 
         # Case 2b: Linear Indexing
         if len(item) >= 2 and not isinstance(item[-1], str):
-            assert False, 'Linear indexing requires single input array'
+            assert False, "Linear indexing requires single input array"
         idx = item[0]
         a = np.squeeze(self.data[tuple(ttb.tt_ind2sub(self.shape, idx).transpose())])
         # Todo if row make column?
@@ -1321,7 +1362,8 @@ class tensor(object):
         -------
         :class:`pyttb.tensor`
         """
-        def tensor_equality(x,y):
+
+        def tensor_equality(x, y):
             return x == y
 
         return ttb.tt_tenfun(tensor_equality, self, other)
@@ -1338,6 +1380,7 @@ class tensor(object):
         -------
         :class:`pyttb.tensor`
         """
+
         def tensor_notEqual(x, y):
             return x != y
 
@@ -1355,6 +1398,7 @@ class tensor(object):
         -------
         :class:`pyttb.tensor`
         """
+
         def ge(x, y):
             return x >= y
 
@@ -1372,6 +1416,7 @@ class tensor(object):
         -------
         :class:`pyttb.tensor`
         """
+
         def le(x, y):
             return x <= y
 
@@ -1425,8 +1470,9 @@ class tensor(object):
         -------
         :class:`pyttb.tensor`
         """
+
         def minus(x, y):
-            return x-y
+            return x - y
 
         return ttb.tt_tenfun(minus, self, other)
 
@@ -1497,8 +1543,9 @@ class tensor(object):
         -------
         :class:`pyttb.tensor`
         """
+
         def mul(x, y):
-            return x*y
+            return x * y
 
         if isinstance(other, (ttb.ktensor, ttb.sptensor, ttb.ttensor)):
             other = other.full()
@@ -1531,10 +1578,11 @@ class tensor(object):
         -------
         :class:`pyttb.tensor`
         """
+
         def div(x, y):
             # We ignore the divide by zero errors because np.inf/np.nan is an appropriate representation
-            with np.errstate(divide='ignore', invalid='ignore'):
-                return x/y
+            with np.errstate(divide="ignore", invalid="ignore"):
+                return x / y
 
         return ttb.tt_tenfun(div, self, other)
 
@@ -1550,10 +1598,11 @@ class tensor(object):
         -------
         :class:`pyttb.tensor`
         """
+
         def div(x, y):
             # We ignore the divide by zero errors because np.inf/np.nan is an appropriate representation
-            with np.errstate(divide='ignore', invalid='ignore'):
-                return x/y
+            with np.errstate(divide="ignore", invalid="ignore"):
+                return x / y
 
         return ttb.tt_tenfun(div, other, self)
 
@@ -1579,7 +1628,7 @@ class tensor(object):
             copy of tensor
         """
 
-        return ttb.tensor.from_data(-1*self.data)
+        return ttb.tensor.from_data(-1 * self.data)
 
     def __repr__(self):
         """
@@ -1591,41 +1640,49 @@ class tensor(object):
             Contains the shape and data as strings on different lines.
         """
         if self.ndims == 0:
-            s = ''
-            s += 'empty tensor of shape '
+            s = ""
+            s += "empty tensor of shape "
             s += str(self.shape)
-            s += '\n'
-            s += 'data = []'
+            s += "\n"
+            s += "data = []"
             return s
 
-        s = ''
-        s += 'tensor of shape '
-        s += (' x ').join([str(int(d)) for d in self.shape])
-        s += '\n'
+        s = ""
+        s += "tensor of shape "
+        s += (" x ").join([str(int(d)) for d in self.shape])
+        s += "\n"
 
         if self.ndims == 1:
-            s += 'data'
+            s += "data"
             if self.ndims == 1:
-                s += '[:]'
-                s += ' = \n'
+                s += "[:]"
+                s += " = \n"
                 s += str(self.data)
-                s += '\n'
+                s += "\n"
                 return s
         for i in np.arange(np.prod(self.shape[:-2])):
-            s += 'data'
+            s += "data"
             if self.ndims == 2:
-                s += '[:, :]'
-                s += ' = \n'
+                s += "[:, :]"
+                s += " = \n"
                 s += str(self.data)
-                s += '\n'
+                s += "\n"
             elif self.ndims > 2:
                 idx = ttb.tt_ind2sub(self.shape[:-2], np.array([i]))
                 s += str(idx[0].tolist())[0:-1]
-                s += ', :, :]'
-                s += ' = \n'
-                s += str(self.data[tuple(np.concatenate((idx[0], np.array([slice(None), slice(None)]))))])
-                s += '\n'
-        #s += '\n'
+                s += ", :, :]"
+                s += " = \n"
+                s += str(
+                    self.data[
+                        tuple(
+                            np.concatenate(
+                                (idx[0], np.array([slice(None), slice(None)]))
+                            )
+                        )
+                    ]
+                )
+                s += "\n"
+        # s += '\n'
         return s
 
     __str__ = __repr__

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1161,11 +1161,7 @@ class tensor:
 
         # Check that vector is a list of vectors, if not place single vector as element
         # in list
-        if isinstance(vector, list):
-            return self.ttv(np.array(vector), dims)
-        if len(vector.shape) == 1 and isinstance(
-            vector[0], (int, float, np.int_, np.float_)
-        ):
+        if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
             return self.ttv(np.array([vector]), dims)
 
         # Get sorted dims and index for multiplicands
@@ -1459,7 +1455,6 @@ class tensor:
             newsiz = []  # future new size
             kpdims = []  # dimensions to keep
             rmdims = []  # dimensions to remove
-
 
             # Determine the new size and what dimensions to keep
             for i, a_region in enumerate(region):

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -325,9 +325,9 @@ class tensor:
         Examples
         --------
         >>> tensor1 = ttb.tensor.from_data(np.array([[1, 2], [3, 4]]))
-        >>> tensor1.exp().data
-        array([[ 2.71828183,  7.3890561 ],
-               [20.08553692, 54.59815003]])
+        >>> tensor1.exp().data  # doctest: +ELLIPSIS
+        array([[ 2.7182...,  7.3890... ],
+               [20.0855..., 54.5981...]])
         """
         return ttb.tensor.from_data(np.exp(self.data))
 
@@ -791,12 +791,12 @@ class tensor:
         Examples
         --------
         >>> tensor1 = ttb.tensor.from_data(np.array([[1, 2], [3, 4]]))
-        >>> tensor1.nvecs(0,1)
-        array([[0.40455358],
-               [0.9145143 ]])
-        >>> tensor1.nvecs(0,2)
-        array([[ 0.40455358,  0.9145143 ],
-               [ 0.9145143 , -0.40455358]])
+        >>> tensor1.nvecs(0,1)  # doctest: +ELLIPSIS
+        array([[0.4045...],
+               [0.9145...]])
+        >>> tensor1.nvecs(0,2)  # doctest: +ELLIPSIS
+        array([[ 0.4045...,  0.9145...],
+               [ 0.9145..., -0.4045...]])
         """
         Xn = ttb.tenmat.from_tensor_type(self, rdims=np.array([n])).double()
         y = Xn @ Xn.T

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -61,7 +61,7 @@ class ttensor(object):
 
         >>> core_values = np.ones((2,2,2))
         >>> core = ttb.tensor.from_data(core_values)
-        >>> factors = [np.ones((1,2))] * len(core_values)
+        >>> factors = [np.ones((1,2))] * len(core_values.shape)
         >>> K0 = ttb.ttensor.from_data(core, factors)
         """
         ttensorInstance = ttensor()
@@ -109,7 +109,7 @@ class ttensor(object):
         core_order = len(self.core.shape)
         num_matrices = len(self.u)
         if core_order != num_matrices:
-            raise ValueError(f"CORE has order {core_order} but there are {num_matrices}")
+            raise ValueError(f"CORE has order {core_order} but there are {num_matrices} factors")
         for factor_idx, factor in enumerate(self.u):
             if factor.shape[-1] != self.core.shape[factor_idx]:
                 raise ValueError(f"Factor matrix {factor_idx} does not have {self.core.shape[factor_idx]} columns")

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
     extras_require={
         'testing': [
             'black',
+            'isort',
+            'pylint',
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
             'black',
             'isort',
             'pylint',
+            'mypy'
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,10 @@ setup(
         "scipy",
         "pytest",
         "sphinx_rtd_theme"
-    ]
+    ],
+    extras_require={
+        'testing': [
+            'black',
+        ]
+    }
 )

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,17 @@
+import black
+import pyttb as ttb
+import pytest
+import os
+import subprocess
+
+
+def test_formatting():
+    """Confirm formatting of the project is consistent"""
+    from pyttb.tensor import tensor
+
+    enforced_files = [
+        __file__,
+        os.path.join(os.path.dirname(ttb.__file__), f"{tensor.__name__}.py"),
+    ]
+    for a_file in enforced_files:
+        subprocess.run(f"black {a_file} --check", check=True)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,17 +1,20 @@
-import black
-import pyttb as ttb
-import pytest
+"""Testing of general package properties such as linting and formatting"""
 import os
 import subprocess
+
+import pyttb as ttb
 
 
 def test_formatting():
     """Confirm formatting of the project is consistent"""
-    from pyttb.tensor import tensor
 
     enforced_files = [
         __file__,
-        os.path.join(os.path.dirname(ttb.__file__), f"{tensor.__name__}.py"),
+        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tensor.__name__}.py"),
     ]
+    root_dir = os.path.dirname(os.path.dirname(__file__))
+    toml_file = os.path.join(root_dir, "pyproject.toml")
     for a_file in enforced_files:
         subprocess.run(f"black {a_file} --check", check=True)
+        subprocess.run(f"isort {a_file} --check --settings-path {root_dir}", check=True)
+        subprocess.run(f"pylint {a_file} --rcfile {toml_file}", check=True)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,9 +2,12 @@
 import os
 import subprocess
 
+import pytest
+
 import pyttb as ttb
 
 
+@pytest.mark.packaging
 def test_formatting():
     """Confirm formatting of the project is consistent"""
 
@@ -13,8 +16,29 @@ def test_formatting():
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tensor.__name__}.py"),
     ]
     root_dir = os.path.dirname(os.path.dirname(__file__))
-    toml_file = os.path.join(root_dir, "pyproject.toml")
     for a_file in enforced_files:
         subprocess.run(f"black {a_file} --check", check=True)
         subprocess.run(f"isort {a_file} --check --settings-path {root_dir}", check=True)
+
+
+@pytest.mark.packaging
+def test_linting():
+    """Confirm linting of the project is enforce"""
+
+    enforced_files = [
+        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tensor.__name__}.py"),
+    ]
+    # TODO pylint fails to import pyttb in tests
+    # add mypy check
+    root_dir = os.path.dirname(os.path.dirname(__file__))
+    toml_file = os.path.join(root_dir, "pyproject.toml")
+    for a_file in enforced_files:
         subprocess.run(f"pylint {a_file} --rcfile {toml_file}", check=True)
+
+
+@pytest.mark.packaging
+def test_typing():
+    """Run type checker on package"""
+    root_dir = os.path.dirname(os.path.dirname(__file__))
+    toml_file = os.path.join(root_dir, "pyproject.toml")
+    subprocess.run(f"mypy -p pyttb  --config-file {toml_file}", check=True)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -694,32 +694,22 @@ def test_tensor_reshape(sample_tensor_2way, sample_tensor_3way, sample_tensor_4w
     # Reshape with tuple
     tensorInstance2 = tensorInstance2.reshape((3, 2))
     if DEBUG_tests:
-        print('\ntensorInstance2.reshape(3, 2):')
-        print(tensorInstance2.reshape(3, 2))
+        print('\ntensorInstance2.reshape((3, 2)):')
+        print(tensorInstance2.reshape((3, 2)))
     assert tensorInstance2.shape == (3, 2)
     data = np.array([[1., 5.], 
                      [4., 3.], 
                      [2., 6.]])
     assert (tensorInstance2.data == data).all()
 
-    # Reshape with multiple arguments
-    tensorInstance2a = tensorInstance2.reshape(2, 3)
-    if DEBUG_tests:
-        print('\ntensorInstance.reshape(2, 3):')
-        print(tensorInstance2.reshape(2, 3))
-    assert tensorInstance2a.shape == (2, 3)
-    data2 = np.array([[1., 2., 3.], 
-                      [4., 5., 6.]])
-    assert (tensorInstance2a.data == data2).all()
-
     with pytest.raises(AssertionError) as excinfo:
-        tensorInstance2.reshape(3, 3)
+        tensorInstance2.reshape((3, 3))
     assert "Reshaping a tensor cannot change number of elements" in str(excinfo)
 
     (params3, tensorInstance3) = sample_tensor_3way
     tensorInstance3 = tensorInstance3.reshape((3, 2, 2))
     if DEBUG_tests:
-        print('\ntensorInstance3.reshape(3, 2, 2):')
+        print('\ntensorInstance3.reshape((3, 2, 2)):')
         print(tensorInstance3)
     assert tensorInstance3.shape == (3, 2, 2)
     data3 = np.array([[[1., 7.], [4., 10.]], 
@@ -730,7 +720,7 @@ def test_tensor_reshape(sample_tensor_2way, sample_tensor_3way, sample_tensor_4w
     (params4, tensorInstance4) = sample_tensor_4way
     tensorInstance4 = tensorInstance4.reshape((1, 3, 3, 9))
     if DEBUG_tests:
-        print('\ntensorInstance4.reshape(1, 3, 3, 9):')
+        print('\ntensorInstance4.reshape((1, 3, 3, 9)):')
         print(tensorInstance4)
     assert tensorInstance4.shape == (1, 3, 3, 9)
     data4 = np.array([[[[ 1, 10, 19, 28, 37, 46, 55, 64, 73], 
@@ -985,7 +975,9 @@ def test_tensor_squeeze(sample_tensor_2way):
     assert (tensorInstance.squeeze().data == params['data']).all()
 
     # All singleton dimensions
-    assert (ttb.tensor.from_data(np.array([[[4]]])).squeeze() == 4)
+    squeeze_result = ttb.tensor.from_data(np.array([[[4]]])).squeeze()
+    assert (squeeze_result == 4)
+    assert np.isscalar(squeeze_result)
 
     # A singleton dimension
     assert (ttb.tensor.from_data(np.array([[1, 2, 3]])).squeeze().data == np.array([1, 2, 3])).all()


### PR DESCRIPTION
This is partially in response to https://github.com/sandialabs/pyttb/issues/20 but is also a proposal/RFC. Depending on opinions can figure out how to break out the pieces of the proposal into separate PRs/issues.

Parts to the proposal:
1. Add autoformatting via black and isort
   - This can be applied automatically across pyttb
   - This should be fast to enforce
1. Add linting checks via pylint
   - This will require either adding the checking and excusing all existing failures or manually applying this file by file
   - This is slow to enforce on the scope of current tests (a few seconds)
1. Add static type checking via mypy
   - We can opt in the whole pyttb right now since there are no types anywhere. Then enforce it as we transition to types
   - This isn't particularly slow to enforce
1. Enforce doctests
   - This is already setup and doesn't really add much overhead to testing
 
Broad justification:
Black/isort are easy and make it easier for contributors to make sure formatting stays consistent. I was able to find bugs when applying/enforcing pylint, mypy, and doctests. How these changes land is probably a matter of preference. It will cause a decent amount of git churn which is why I put together this example of some pretty painless tooling and what the combination of changes look like applied to `tensor`.

Specifics:
1. Pass
1. I like pylint's strong opinions to encourage better practices, call out code smells, and protect against simple things static checkers find
1. Self checking the documentation will hopefully help to ensure things stay up to date. Beyond that Numpy is pushing towards [typing ](https://numpy.org/devdocs/reference/typing.html#d-arrays) that could allow better description of the shapes of types that can be verified statically. Which seems nice from an explicit perspective and from testing. This would also enable people using the toolbox to leverage tensors as types in their code.