### PR TITLE
Lint pyttb_utils and lint/type sptensor

### DIFF
--- a/pyttb/pyttb_utils.py
+++ b/pyttb/pyttb_utils.py
@@ -6,7 +6,6 @@ from inspect import signature
 from typing import Optional, Tuple, overload
 
 import numpy as np
-from scipy import sparse
 
 import pyttb as ttb
 
@@ -70,65 +69,6 @@ def tt_from_dense_matrix(matrix, shape, mode, idx):
         np.concatenate((np.arange(1, mode + 1), [0], np.arange(mode + 1, len(shape))))
     )
     return tensorInstance
-
-
-def tt_to_sparse_matrix(sptensorInstance, mode, transpose=False):
-    """
-    Helper function to unwrap sptensor into sparse matrix, should replace the core need
-    for sptenmat
-
-    Parameters
-    ----------
-    sptensorInstance: :class:`pyttb.sptensor`
-    mode: int
-        Mode around which to unwrap tensor
-    transpose: bool
-        Whether or not to tranpose unwrapped tensor
-
-    Returns
-    -------
-    spmatrix: :class:`Scipy.sparse.coo_matrix`
-    """
-    old = np.setdiff1d(np.arange(sptensorInstance.ndims), mode).astype(int)
-    spmatrix = sptensorInstance.reshape(
-        (np.prod(np.array(sptensorInstance.shape)[old]),), old
-    ).spmatrix()
-    if transpose:
-        return spmatrix.transpose()
-    return spmatrix
-
-
-def tt_from_sparse_matrix(spmatrix, shape, mode, idx):
-    """
-    Helper function to wrap sparse matrix into sptensor.
-    Inverse of :class:`pyttb.tt_to_sparse_matrix`
-
-    Parameters
-    ----------
-    spmatrix: :class:`Scipy.sparse.coo_matrix`
-    mode: int
-        Mode around which tensor was unwrapped
-    idx: int
-        in {0,1}, idx of mode in spmatrix, s.b. 0 for tranpose=True
-
-    Returns
-    -------
-    sptensorInstance: :class:`pyttb.sptensor`
-    """
-    siz = np.array(shape)
-    old = np.setdiff1d(np.arange(len(shape)), mode).astype(int)
-    sptensorInstance = ttb.sptensor.from_tensor_type(sparse.coo_matrix(spmatrix))
-
-    # This expands the compressed dimension back to full size
-    sptensorInstance = sptensorInstance.reshape(siz[old], idx)
-    # This puts the modes in the right order, reshape places modified modes after the
-    # unchanged ones
-    sptensorInstance = sptensorInstance.reshape(
-        shape,
-        np.concatenate((np.arange(1, mode + 1), [0], np.arange(mode + 1, len(shape)))),
-    )
-
-    return sptensorInstance
 
 
 def tt_union_rows(MatrixA, MatrixB):

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -14,6 +14,65 @@ import pyttb as ttb
 from .pyttb_utils import *
 
 
+def tt_to_sparse_matrix(sptensorInstance, mode, transpose=False):
+    """
+    Helper function to unwrap sptensor into sparse matrix, should replace the core need
+    for sptenmat
+
+    Parameters
+    ----------
+    sptensorInstance: :class:`pyttb.sptensor`
+    mode: int
+        Mode around which to unwrap tensor
+    transpose: bool
+        Whether or not to tranpose unwrapped tensor
+
+    Returns
+    -------
+    spmatrix: :class:`Scipy.sparse.coo_matrix`
+    """
+    old = np.setdiff1d(np.arange(sptensorInstance.ndims), mode).astype(int)
+    spmatrix = sptensorInstance.reshape(
+        (np.prod(np.array(sptensorInstance.shape)[old]),), old
+    ).spmatrix()
+    if transpose:
+        return spmatrix.transpose()
+    return spmatrix
+
+
+def tt_from_sparse_matrix(spmatrix, shape, mode, idx):
+    """
+    Helper function to wrap sparse matrix into sptensor.
+    Inverse of :class:`pyttb.tt_to_sparse_matrix`
+
+    Parameters
+    ----------
+    spmatrix: :class:`Scipy.sparse.coo_matrix`
+    mode: int
+        Mode around which tensor was unwrapped
+    idx: int
+        in {0,1}, idx of mode in spmatrix, s.b. 0 for tranpose=True
+
+    Returns
+    -------
+    sptensorInstance: :class:`pyttb.sptensor`
+    """
+    siz = np.array(shape)
+    old = np.setdiff1d(np.arange(len(shape)), mode).astype(int)
+    sptensorInstance = ttb.sptensor.from_tensor_type(sparse.coo_matrix(spmatrix))
+
+    # This expands the compressed dimension back to full size
+    sptensorInstance = sptensorInstance.reshape(siz[old], idx)
+    # This puts the modes in the right order, reshape places modified modes after the
+    # unchanged ones
+    sptensorInstance = sptensorInstance.reshape(
+        shape,
+        np.concatenate((np.arange(1, mode + 1), [0], np.arange(mode + 1, len(shape)))),
+    )
+
+    return sptensorInstance
+
+
 class sptensor(object):
     """
     SPTENSOR Class for sparse tensors.
@@ -2433,7 +2492,7 @@ class sptensor(object):
         siz[dims] = matrices.shape[0]
 
         # Compute self[mode]'
-        Xnt = ttb.tt_to_sparse_matrix(self, dims, True)
+        Xnt = tt_to_sparse_matrix(self, dims, True)
 
         # Reshape puts the reshaped things after the unchanged modes, transpose then puts it in front
         idx = 0
@@ -2442,7 +2501,7 @@ class sptensor(object):
         Z = Xnt.dot(matrices.transpose())
 
         # Rearrange back into sparse tensor of correct shape
-        Ynt = ttb.tt_from_sparse_matrix(Z, siz, dims, idx)
+        Ynt = tt_from_sparse_matrix(Z, siz, dims, idx)
 
         if not isinstance(Z, np.ndarray) and Z.nnz <= 0.5 * np.prod(siz):
             return Ynt

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -413,7 +413,7 @@ class tensor:
             return other.innerprod(self)
         assert False, "Inner product between tensor and that class is not supported"
 
-    def isequal(self, other: Union[tensor, ttb.sptensor]) -> Union[bool, np.bool_]:
+    def isequal(self, other: Union[tensor, ttb.sptensor]) -> bool:
         """
         Exact equality for tensors
 
@@ -429,9 +429,9 @@ class tensor:
         False
         """
         if isinstance(other, ttb.tensor):
-            return np.all(self.data == other.data)
+            return bool(np.all(self.data == other.data))
         if isinstance(other, ttb.sptensor):
-            return np.all(self.data == other.full().data)
+            return bool(np.all(self.data == other.full().data))
         return False
 
     # TODO: We should probably always return details and let caller drop them

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import warnings
 from itertools import permutations
 from math import factorial
-from typing import Any, Callable, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import numpy as np
 import scipy.sparse.linalg
@@ -179,9 +179,7 @@ class tensor:
     def collapse(
         self,
         dims: Optional[np.ndarray] = None,
-        fun: Union[
-            Literal["sum"], Callable[[np.ndarray], Union[float, np.ndarray]]
-        ] = "sum",
+        fun: Callable[[np.ndarray], Union[float, np.ndarray]] = np.sum,
     ) -> Union[float, np.ndarray, tensor]:
         """
         Collapse tensor along specified dimensions.
@@ -200,7 +198,7 @@ class tensor:
         >>> X = ttb.tensor.from_data(np.ones((2,2)))
         >>> X.collapse()
         4.0
-        >>> X.collapse(np.arange(X.ndims), lambda values: sum(values))
+        >>> X.collapse(np.arange(X.ndims), sum)
         4.0
         """
         if self.data.size == 0:
@@ -217,8 +215,6 @@ class tensor:
 
         # Check for the case where we accumulate over *all* dimensions
         if remdims.size == 0:
-            if fun == "sum":
-                return sum(self.data.flatten("F"))
             return fun(self.data.flatten("F"))
 
         ## Calculate the shape of the result
@@ -230,10 +226,7 @@ class tensor:
         ## Apply the collapse function
         B = np.zeros((A.shape[0], 1))
         for i in range(0, A.shape[0]):
-            if fun == "sum":
-                B[i] = np.sum(A[i, :])
-            else:
-                B[i] = fun(A[i, :])
+            B[i] = fun(A[i, :])
 
         ## Form and return the final result
         return ttb.tensor.from_data(B, newshape)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -23,6 +23,7 @@ def test_linting():
 
     enforced_files = [
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tensor.__name__}.py"),
+        ttb.pyttb_utils.__file__,
     ]
     # TODO pylint fails to import pyttb in tests
     # add mypy check

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -23,6 +23,7 @@ def test_linting():
 
     enforced_files = [
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tensor.__name__}.py"),
+        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.sptensor.__name__}.py"),
         ttb.pyttb_utils.__file__,
     ]
     # TODO pylint fails to import pyttb in tests

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -30,8 +30,9 @@ def test_linting():
     # add mypy check
     root_dir = os.path.dirname(os.path.dirname(__file__))
     toml_file = os.path.join(root_dir, "pyproject.toml")
-    for a_file in enforced_files:
-        subprocess.run(f"pylint {a_file} --rcfile {toml_file}", check=True)
+    subprocess.run(
+        f"pylint {' '.join(enforced_files)} --rcfile {toml_file} -j0", check=True
+    )
 
 
 @pytest.mark.packaging

--- a/tests/test_pyttb_utils.py
+++ b/tests/test_pyttb_utils.py
@@ -52,42 +52,6 @@ def test_sptensor_from_dense_matrix():
 
 
 @pytest.mark.indevelopment
-def test_sptensor_to_sparse_matrix():
-    subs = np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])
-    vals = np.array([[0.5], [1.5], [2.5], [3.5]])
-    shape = (4, 4, 4)
-    mode0 = sparse.coo_matrix(([0.5, 1.5, 2.5, 3.5], ([5, 13, 10, 15], [1, 1, 2, 3])))
-    mode1 = sparse.coo_matrix(([0.5, 1.5, 2.5, 3.5], ([5, 13, 10, 15], [1, 1, 2, 3])))
-    mode2 = sparse.coo_matrix(([0.5, 1.5, 2.5, 3.5], ([5, 5, 10, 15], [1, 3, 2, 3])))
-    Ynt = [mode0, mode1, mode2]
-    sptensorInstance = ttb.sptensor().from_data(subs, vals, shape)
-
-    for mode in range(sptensorInstance.ndims):
-        Xnt = ttb.tt_to_sparse_matrix(sptensorInstance, mode, True)
-        assert (Xnt != Ynt[mode]).nnz == 0
-        assert Xnt.shape == Ynt[mode].shape
-
-
-@pytest.mark.indevelopment
-def test_sptensor_from_sparse_matrix():
-    subs = np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])
-    vals = np.array([[0.5], [1.5], [2.5], [3.5]])
-    shape = (4, 4, 4)
-    sptensorInstance = ttb.sptensor().from_data(subs, vals, shape)
-    for mode in range(sptensorInstance.ndims):
-        sptensorCopy = ttb.sptensor.from_tensor_type(sptensorInstance)
-        Xnt = ttb.tt_to_sparse_matrix(sptensorCopy, mode, True)
-        Ynt = ttb.tt_from_sparse_matrix(Xnt, sptensorCopy.shape, mode, 0)
-        assert sptensorCopy.isequal(Ynt)
-
-    for mode in range(sptensorInstance.ndims):
-        sptensorCopy = ttb.sptensor.from_tensor_type(sptensorInstance)
-        Xnt = ttb.tt_to_sparse_matrix(sptensorCopy, mode, False)
-        Ynt = ttb.tt_from_sparse_matrix(Xnt, sptensorCopy.shape, mode, 1)
-        assert sptensorCopy.isequal(Ynt)
-
-
-@pytest.mark.indevelopment
 def test_tt_union_rows():
     a = np.array([[4, 6], [1, 9], [2, 6], [2, 6], [99, 0]])
     b = np.array([[1, 7], [1, 8], [2, 6]])

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -9,6 +9,7 @@ import pytest
 import scipy.sparse as sparse
 
 import pyttb as ttb
+from pyttb.sptensor import tt_from_sparse_matrix, tt_to_sparse_matrix
 
 
 @pytest.fixture()
@@ -1708,3 +1709,39 @@ def test_sptensor_ttm(sample_sptensor):
         4,
         1,
     )
+
+
+@pytest.mark.indevelopment
+def test_sptensor_to_sparse_matrix():
+    subs = np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])
+    vals = np.array([[0.5], [1.5], [2.5], [3.5]])
+    shape = (4, 4, 4)
+    mode0 = sparse.coo_matrix(([0.5, 1.5, 2.5, 3.5], ([5, 13, 10, 15], [1, 1, 2, 3])))
+    mode1 = sparse.coo_matrix(([0.5, 1.5, 2.5, 3.5], ([5, 13, 10, 15], [1, 1, 2, 3])))
+    mode2 = sparse.coo_matrix(([0.5, 1.5, 2.5, 3.5], ([5, 5, 10, 15], [1, 3, 2, 3])))
+    Ynt = [mode0, mode1, mode2]
+    sptensorInstance = ttb.sptensor().from_data(subs, vals, shape)
+
+    for mode in range(sptensorInstance.ndims):
+        Xnt = tt_to_sparse_matrix(sptensorInstance, mode, True)
+        assert (Xnt != Ynt[mode]).nnz == 0
+        assert Xnt.shape == Ynt[mode].shape
+
+
+@pytest.mark.indevelopment
+def test_sptensor_from_sparse_matrix():
+    subs = np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])
+    vals = np.array([[0.5], [1.5], [2.5], [3.5]])
+    shape = (4, 4, 4)
+    sptensorInstance = ttb.sptensor().from_data(subs, vals, shape)
+    for mode in range(sptensorInstance.ndims):
+        sptensorCopy = ttb.sptensor.from_tensor_type(sptensorInstance)
+        Xnt = tt_to_sparse_matrix(sptensorCopy, mode, True)
+        Ynt = tt_from_sparse_matrix(Xnt, sptensorCopy.shape, mode, 0)
+        assert sptensorCopy.isequal(Ynt)
+
+    for mode in range(sptensorInstance.ndims):
+        sptensorCopy = ttb.sptensor.from_tensor_type(sptensorInstance)
+        Xnt = tt_to_sparse_matrix(sptensorCopy, mode, False)
+        Ynt = tt_from_sparse_matrix(Xnt, sptensorCopy.shape, mode, 1)
+        assert sptensorCopy.isequal(Ynt)

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -231,6 +231,9 @@ def test_sptensor_subdims(sample_sptensor):
         sptensorInstance.subdims([[1], [1, 3]])
     assert "Number of subdimensions must equal number of dimensions" in str(excinfo)
 
+    with pytest.raises(ValueError):
+        sptensorInstance.subdims(("bad", "region", "types"))
+
 
 @pytest.mark.indevelopment
 def test_sptensor_ndims(sample_sptensor):
@@ -1632,6 +1635,13 @@ def test_sptensor_nvecs(sample_sptensor):
         "Greater than or equal to sptensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
         in str(record[0].message)
     )
+
+    # Negative test, check for only singleton dims
+    with pytest.raises(ValueError):
+        single_val_sptensor = ttb.sptensor.from_data(
+            np.array([[0, 0]]), np.array([1]), shape=(1, 1)
+        )
+        single_val_sptensor.nvecs(0, 0)
 
 
 @pytest.mark.indevelopment

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -1132,7 +1132,7 @@ def test_sptensor_innerprod(sample_sptensor):
     # Wrong type for innerprod
     with pytest.raises(AssertionError) as excinfo:
         sptensorInstance.innerprod(5)
-    assert "Inner product between sptensor and that class not supported" in str(excinfo)
+    assert f"Inner product between sptensor and {type(5)} not supported" in str(excinfo)
 
 
 @pytest.mark.indevelopment


### PR DESCRIPTION
Related to https://github.com/sandialabs/pyttb/issues/63
The commits mostly break down the work but this covers pyttb_utils and sptensor for pylint, but just sptensor for typing. I think will need the tensor implementations to be typed for the utils that act on tensors to place nice with types.

Continuing to add typing across the base classes. The native python numeric types vs numpy numeric types isn't generally resolved yet. I think the typing is helping to see all the places we use it but I probably need to make an issue to track this globally. I've moved towards `isinstance(variable, (int,float,np.generic))` to basically catch numpy scalars but I'd need to dig around a bit more to see if there is a standard for switching back and forth while also playing nicely with typing.

I mentioned before that our pyttb_utils today are both used by the tensor types internally but also act on tensor types. It might be clearer to split those out. I moved the pyttb_utils that ONLY sptensor uses internally into the sptensor file. I think after some other changes this wasn't strictly necessary, so can move them back if preferred.