### PR TITLE
HOSVD: Negative signs can be permuted for equivalent decomposition

### DIFF
--- a/tests/test_hosvd.py
+++ b/tests/test_hosvd.py
@@ -115,7 +115,9 @@ def test_hosvd_3way(capsys, sample_tensor_3way):
             [-8.359253825873615e-01, -3.668270547267537e-01],
         ]
     )
-    assert np.allclose(M.core.data, core)
-    assert np.allclose(M.u[0], fm0)
-    assert np.allclose(M.u[1], fm1)
-    assert np.allclose(M.u[2], fm2)
+    expected = ttb.ttensor.from_data(ttb.tensor.from_data(core), [fm0, fm1, fm2])
+    assert np.allclose(M.double(), expected.double())
+    assert np.allclose(np.abs(M.core.data), np.abs(core))
+    assert np.allclose(np.abs(M.u[0]), np.abs(fm0))
+    assert np.allclose(np.abs(M.u[1]), np.abs(fm1))
+    assert np.allclose(np.abs(M.u[2]), np.abs(fm2))


### PR DESCRIPTION
This https://github.com/sandialabs/pyttb/pull/79 seems to assume the core and factors must match exactly.
However, if the negative sign is switched from the core to a factor the decomposition is still equivalent.
Updated the test to confirm reconstruction and magnitudes.
If we expect the match to be perfect then need to dig into this deeper.
I reverted my pr https://github.com/sandialabs/pyttb/pull/77 and still saw the failure so I a not sure why you didn't see it when you opened your pr.