### PR TITLE
Exclude dims

### DIFF
--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -1866,7 +1866,7 @@ class ktensor(object):
          [2. 4.]]
         """
 
-        if dims is None:
+        if dims is None and exclude_dims is None:
             dims = np.array([])
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -1792,7 +1792,7 @@ class ktensor(object):
         #         offset += f.shape[0]
         return x
 
-    def ttv(self, vector, dims=None):
+    def ttv(self, vector, dims=None, exclude_dims=None):
         """
         `Tensor` times vector for `ktensors`.
 
@@ -1833,7 +1833,7 @@ class ktensor(object):
         >>> weights = 2 * np.ones(rank)
         >>> weights_and_data = np.concatenate((weights, data), axis=0)
         >>> K = ttb.ktensor.from_vector(weights_and_data[:], shape, True)
-        >>> K0 = K.ttv(np.array([1, 1, 1]), dims=1) # compute along a single dimension
+        >>> K0 = K.ttv(np.array([1, 1, 1]),dims=1) # compute along a single dimension
         >>> print(K0)
         ktensor of shape 2 x 4
         weights=[36. 54.]
@@ -1857,7 +1857,7 @@ class ktensor(object):
 
         Compute the product of a `ktensor` and multiple vectors out of order (results in a `ktensor`):
 
-        >>> K2 = K.ttv([vec4, vec3], np.array([2, 1]))
+        >>> K2 = K.ttv([vec4, vec3],np.array([2, 1]))
         >>> print(K2)
         ktensor of shape 2
         weights=[1800. 3564.]
@@ -1871,12 +1871,15 @@ class ktensor(object):
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])
 
+        if isinstance(exclude_dims, (float, int)):
+            exclude_dims = np.array([exclude_dims])
+
         # Check that vector is a list of vectors, if not place single vector as element in list
         if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
             return self.ttv([vector], dims)
 
         # Get sorted dims and index for multiplicands
-        dims, vidx = ttb.tt_dimscheck(dims, self.ndims, len(vector))
+        dims, vidx = ttb.tt_dimscheck(self.ndims, len(vector), dims, exclude_dims)
 
         # Check that each multiplicand is the right size.
         for i in range(dims.size):

--- a/pyttb/pyttb_utils.py
+++ b/pyttb/pyttb_utils.py
@@ -163,7 +163,7 @@ def tt_dimscheck(
             raise ValueError(
                 f"Exclude dims provided: {exclude_dims} "
                 f"but, {exclude_dims[invalid_indices]} were out of valid range"
-                f"[0,{N+1}]"
+                f"[0,{N}]"
             )
         dim_array = np.setdiff1d(np.arange(0, N), exclude_dims)
 

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -2545,8 +2545,8 @@ class sptensor:
         if transpose:
             matrices = matrices.transpose()
 
-        # FIXME: Check this
-        if not isinstance(dims, np.ndarray):
+        # FIXME: This made typing happy but shouldn't be possible
+        if not isinstance(dims, np.ndarray):  # pragma: no cover
             raise ValueError("Dims should be an array here")
 
         # Ensure this is the terminal single dimension case

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -382,7 +382,7 @@ class sptensor:
         if dims is None:
             dims = np.arange(0, self.ndims)
 
-        dims, _ = tt_dimscheck(dims, self.ndims)
+        dims, _ = tt_dimscheck(self.ndims, dims=dims)
         remdims = np.setdiff1d(np.arange(0, self.ndims), dims)
 
         # Check for the case where we accumulate over *all* dimensions
@@ -882,7 +882,7 @@ class sptensor:
                 else:
                     Z.append(np.array([]))
             # Perform ttv multiplication
-            V[:, r] = self.ttv(Z, -(n + 1)).double()
+            V[:, r] = self.ttv(Z, exclude_dims=n).double()
 
         return V
 
@@ -1044,7 +1044,7 @@ class sptensor:
         """
         if isinstance(dims, (float, int)):
             dims = np.array([dims])
-        dims, _ = ttb.tt_dimscheck(dims, self.ndims)
+        dims, _ = ttb.tt_dimscheck(self.ndims, dims=dims)
 
         if isinstance(factor, ttb.tensor):
             shapeArray = np.array(self.shape)
@@ -1181,6 +1181,7 @@ class sptensor:
         self,
         vector: Union[np.ndarray, List[np.ndarray]],
         dims: Optional[Union[int, np.ndarray]] = None,
+        exclude_dims: Optional[Union[int, np.ndarray]] = None,
     ) -> Union[sptensor, ttb.tensor]:
         """
         Sparse tensor times vector
@@ -1189,20 +1190,24 @@ class sptensor:
         ----------
         vector: Vector(s) to multiply against
         dims: Dimensions to multiply with vector(s)
+        exclude_dims: Use all dimensions but these
         """
 
-        if dims is None:
+        if dims is None and exclude_dims is None:
             dims = np.array([])
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])
 
+        if isinstance(exclude_dims, (float, int)):
+            exclude_dims = np.array([exclude_dims])
+
         # Check that vector is a list of vectors,
         # if not place single vector as element in list
         if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
-            return self.ttv(np.array([vector]), dims)
+            return self.ttv(np.array([vector]), dims, exclude_dims)
 
         # Get sorted dims and index for multiplicands
-        dims, vidx = ttb.tt_dimscheck(dims, self.ndims, len(vector))
+        dims, vidx = ttb.tt_dimscheck(self.ndims, len(vector), dims, exclude_dims)
         remdims = np.setdiff1d(np.arange(0, self.ndims), dims).astype(int)
 
         # Check that each multiplicand is the right size.
@@ -2495,6 +2500,7 @@ class sptensor:
         self,
         matrices: Union[np.ndarray, List[np.ndarray]],
         dims: Optional[Union[float, np.ndarray]] = None,
+        exclude_dims: Optional[Union[float, np.ndarray]] = None,
         transpose: bool = False,
     ):
         """
@@ -2503,24 +2509,28 @@ class sptensor:
         Parameters
         ----------
         matrices: A matrix or list of matrices
-        dims: :class:`Numpy.ndarray`, int
+        dims: Dimensions to multiply against
+        exclude_dims: Use all dimensions but these
         transpose: Transpose matrices to be multiplied
 
         Returns
         -------
 
         """
-        if dims is None:
+        if dims is None and exclude_dims is None:
             dims = np.arange(self.ndims)
         elif isinstance(dims, list):
             dims = np.array(dims)
         elif isinstance(dims, (float, int, np.generic)):
             dims = np.array([dims])
 
+        if isinstance(exclude_dims, (float, int)):
+            exclude_dims = np.array([exclude_dims])
+
         # Handle list of matrices
         if isinstance(matrices, list):
             # Check dimensions are valid
-            [dims, vidx] = tt_dimscheck(dims, self.ndims, len(matrices))
+            [dims, vidx] = tt_dimscheck(self.ndims, len(matrices), dims, exclude_dims)
             # Calculate individual products
             Y = self.ttm(matrices[vidx[0]], dims[0], transpose=transpose)
             for i in range(1, dims.size):
@@ -2534,6 +2544,10 @@ class sptensor:
         # Flip matrices if transposed
         if transpose:
             matrices = matrices.transpose()
+
+        # FIXME: Check this
+        if not isinstance(dims, np.ndarray):
+            raise ValueError("Dims should be an array here")
 
         # Ensure this is the terminal single dimension case
         if not (dims.size == 1 and np.isin(dims, np.arange(self.ndims))):

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1035,7 +1035,6 @@ class tensor:
         exclude_dims: Use all dimensions but these
         transpose: Transpose matrices during multiplication
         """
-
         if dims is None and exclude_dims is None:
             dims = np.arange(self.ndims)
         elif isinstance(dims, list):
@@ -1065,12 +1064,15 @@ class tensor:
             assert False, "dims must contain values in [0,self.dims)"
 
         # old version (ver=0)
-        shape = np.array(self.shape)
+        shape = np.array(self.shape, dtype=int)
         n = dims[0]
         order = np.array([n] + list(range(0, n)) + list(range(n + 1, self.ndims)))
         newdata = self.permute(order).data
         ids = np.array(list(range(0, n)) + list(range(n + 1, self.ndims)))
-        newdata = np.reshape(newdata, (shape[n], np.prod(shape[ids])), order="F")
+        second_dim = 1
+        if len(ids) > 0:
+            second_dim = np.prod(shape[ids])
+        newdata = np.reshape(newdata, (shape[n], second_dim), order="F")
         if transpose:
             newdata = matrix.T @ newdata
             p = matrix.shape[1]
@@ -1126,8 +1128,6 @@ class tensor:
         # Avoid transpose by reshaping self and computing result = self * other
         amatrix = ttb.tenmat.from_tensor_type(self, cdims=selfdims)
         bmatrix = ttb.tenmat.from_tensor_type(other, rdims=otherdims)
-        print(amatrix)
-        print(bmatrix)
         cmatrix = amatrix * bmatrix
 
         # Check whether or not the result is a scalar

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -323,7 +323,7 @@ class ttensor(object):
         vector: :class:`Numpy.ndarray`, list[:class:`Numpy.ndarray`]
         dims: :class:`Numpy.ndarray`, int
         """
-        if dims is None:
+        if dims is None and exclude_dims is None:
             dims = np.array([])
         # TODO make helper function to check scalar since re-used many places
         elif isinstance(dims, (float, int)):
@@ -334,7 +334,7 @@ class ttensor(object):
 
         # Check that vector is a list of vectors, if not place single vector as element in list
         if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
-            return self.ttv(np.array([vector]), dims)
+            return self.ttv(np.array([vector]), dims, exclude_dims)
 
         # Get sorted dims and index for multiplicands
         dims, vidx = ttb_utils.tt_dimscheck(self.ndims, len(vector), dims, exclude_dims)
@@ -348,7 +348,7 @@ class ttensor(object):
         remdims = np.setdiff1d(np.arange(0, self.ndims), dims)
 
         # Create W to multiply with core, only populated remaining dims
-        W = [None] * len(dims)
+        W = [None] * self.ndims
         for i in range(dims.size):
             dim_idx = dims[i]
             W[dim_idx] = self.u[dim_idx].transpose().dot(vector[vidx[i]])

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -314,7 +314,7 @@ class ttensor(object):
             return self.__mul__(other)
         raise ValueError("This object cannot be multiplied by ttensor")
 
-    def ttv(self, vector, dims=None):
+    def ttv(self, vector, dims=None, exclude_dims=None):
         """
         TTensor times vector
 
@@ -329,12 +329,15 @@ class ttensor(object):
         elif isinstance(dims, (float, int)):
             dims = np.array([dims])
 
+        if isinstance(exclude_dims, (float, int)):
+            exclude_dims = np.array([exclude_dims])
+
         # Check that vector is a list of vectors, if not place single vector as element in list
         if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
             return self.ttv(np.array([vector]), dims)
 
         # Get sorted dims and index for multiplicands
-        dims, vidx = ttb_utils.tt_dimscheck(dims, self.ndims, len(vector))
+        dims, vidx = ttb_utils.tt_dimscheck(self.ndims, len(vector), dims, exclude_dims)
 
         # Check that each multiplicand is the right size.
         for i in range(dims.size):
@@ -420,7 +423,7 @@ class ttensor(object):
         new_u = [self.u[idx] for idx in order]
         return ttensor.from_data(new_core, new_u)
 
-    def ttm(self, matrix, dims=None, transpose=False):
+    def ttm(self, matrix, dims=None, exclude_dims=None, transpose=False):
         """
         Tensor times matrix for ttensor
 
@@ -430,7 +433,7 @@ class ttensor(object):
         dims: :class:`Numpy.ndarray`, int
         transpose: bool
         """
-        if dims is None:
+        if dims is None and exclude_dims is None:
             dims = np.arange(self.ndims)
         elif isinstance(dims, list):
             dims = np.array(dims)
@@ -439,11 +442,14 @@ class ttensor(object):
                 raise ValueError("Negative dims is currently unsupported, see #62")
             dims = np.array([dims])
 
+        if isinstance(exclude_dims, (float, int)):
+            exclude_dims = np.array([exclude_dims])
+
         if not isinstance(matrix, list):
-            return self.ttm([matrix], dims, transpose)
+            return self.ttm([matrix], dims, exclude_dims, transpose)
 
         # Check that the dimensions are valid
-        dims, vidx = ttb_utils.tt_dimscheck(dims, self.ndims, len(matrix))
+        dims, vidx = ttb_utils.tt_dimscheck(self.ndims, len(matrix), dims, exclude_dims)
 
         # Determine correct size index
         size_idx = int(not transpose)

--- a/pyttb/tucker_als.py
+++ b/pyttb/tucker_als.py
@@ -124,11 +124,7 @@ def tucker_als(
 
         # Iterate over all N modes of the tensor
         for n in dimorder:
-            # TODO proposal to change ttm to include_dims and exclude_dims to resolve -0 ambiguity
-            dims = np.arange(0, tensor.ndims)
-            dims = dims[dims != n]
-            Utilde = tensor.ttm(U, dims, transpose=True)
-            print(f"Utilde[{n}] = {Utilde}")
+            Utilde = tensor.ttm(U, exclude_dims=n, transpose=True)
             # Maximize norm(Utilde x_n W') wrt W and
             # maintain orthonormality of W
             U[n] = Utilde.nvecs(n, rank[n])

--- a/pyttb/tucker_als.py
+++ b/pyttb/tucker_als.py
@@ -127,14 +127,14 @@ def tucker_als(
             # TODO proposal to change ttm to include_dims and exclude_dims to resolve -0 ambiguity
             dims = np.arange(0, tensor.ndims)
             dims = dims[dims != n]
-            Utilde = tensor.ttm(U, dims, True)
+            Utilde = tensor.ttm(U, dims, transpose=True)
             print(f"Utilde[{n}] = {Utilde}")
             # Maximize norm(Utilde x_n W') wrt W and
             # maintain orthonormality of W
             U[n] = Utilde.nvecs(n, rank[n])
 
         # Assemble the current approximation
-        core = Utilde.ttm(U, n, True)
+        core = Utilde.ttm(U, n, transpose=True)
 
         # Compute fit
         normresidual = np.sqrt(abs(normX**2 - core.norm() ** 2))

--- a/tests/test_ktensor.py
+++ b/tests/test_ktensor.py
@@ -1005,6 +1005,11 @@ def test_ktensor_ttv(sample_ktensor_3way):
     vec4 = np.array([1, 1, 1, 1])
     assert K.ttv([vec2, vec3, vec4]) == 30348
 
+    # Exclude dims should mirror dims
+    assert K.ttv([vec2, vec3], dims=np.array([0, 1])).isequal(
+        K.ttv([vec2, vec3], exclude_dims=2)
+    )
+
     # Wrong shape
     with pytest.raises(AssertionError) as excinfo:
         K.ttv([vec2, vec3, np.array([1, 2])])

--- a/tests/test_pyttb_utils.py
+++ b/tests/test_pyttb_utils.py
@@ -106,6 +106,16 @@ def test_tt_dimscheck():
         ttb.tt_dimscheck(6, 4, exclude_dims=np.array([0]))
     assert "Invalid number of multiplicands" in str(excinfo)
 
+    # Both dims and exclude dims
+    with pytest.raises(ValueError) as excinfo:
+        ttb.tt_dimscheck(6, dims=[], exclude_dims=[])
+    assert "not both" in str(excinfo)
+
+    # We no longer support negative dims. Make sure that is explicit
+    with pytest.raises(ValueError) as excinfo:
+        ttb.tt_dimscheck(6, dims=np.array([-1]))
+    assert "Negative dims" in str(excinfo), f"{str(excinfo)}"
+
 
 @pytest.mark.indevelopment
 def test_tt_tenfun():

--- a/tests/test_pyttb_utils.py
+++ b/tests/test_pyttb_utils.py
@@ -67,43 +67,43 @@ def test_tt_union_rows():
 @pytest.mark.indevelopment
 def test_tt_dimscheck():
     #  Empty
-    rdims, ridx = ttb.tt_dimscheck(np.array([]), 6)
+    rdims, ridx = ttb.tt_dimscheck(6, dims=np.array([]))
     assert (rdims == np.array([0, 1, 2, 3, 4, 5])).all()
     assert ridx is None
 
-    # Minus
-    rdims, ridx = ttb.tt_dimscheck(np.array([-1]), 6)
-    assert (rdims == np.array([1, 2, 3, 4, 5])).all()
+    # Exclude Dims
+    rdims, ridx = ttb.tt_dimscheck(6, exclude_dims=np.array([1]))
+    assert (rdims == np.array([0, 2, 3, 4, 5])).all()
     assert ridx is None
 
     # Invalid minus
-    with pytest.raises(AssertionError) as excinfo:
-        ttb.tt_dimscheck(np.array([-7]), 6, 6)
-    assert "Invalid magnitude for negative dims selection" in str(excinfo)
+    with pytest.raises(ValueError) as excinfo:
+        ttb.tt_dimscheck(6, 6, exclude_dims=np.array([7]))
+    assert "Exclude dims" in str(excinfo)
 
     # Positive
-    rdims, ridx = ttb.tt_dimscheck(np.array([5]), 6)
+    rdims, ridx = ttb.tt_dimscheck(6, dims=np.array([5]))
     assert (rdims == np.array([5])).all()
     assert ridx is None
 
     # M==P
-    rdims, ridx = ttb.tt_dimscheck(np.array([-1]), 6, 5)
+    rdims, ridx = ttb.tt_dimscheck(6, 5, exclude_dims=np.array([0]))
     assert (rdims == np.array([1, 2, 3, 4, 5])).all()
     assert (ridx == np.arange(0, 5)).all()
 
     # M==N
-    rdims, ridx = ttb.tt_dimscheck(np.array([-1]), 6, 6)
+    rdims, ridx = ttb.tt_dimscheck(6, 6, exclude_dims=np.array([0]))
     assert (rdims == np.array([1, 2, 3, 4, 5])).all()
     assert (ridx == rdims).all()
 
     # M>N
     with pytest.raises(AssertionError) as excinfo:
-        ttb.tt_dimscheck(np.array([-1]), 6, 7)
+        ttb.tt_dimscheck(6, 7, exclude_dims=np.array([0]))
     assert "Cannot have more multiplicands than dimensions" in str(excinfo)
 
     # M!=P and M!=N
     with pytest.raises(AssertionError) as excinfo:
-        ttb.tt_dimscheck(np.array([-1]), 6, 4)
+        ttb.tt_dimscheck(6, 4, exclude_dims=np.array([0]))
     assert "Invalid number of multiplicands" in str(excinfo)
 
 

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -1667,6 +1667,9 @@ def test_sptensor_ttm(sample_sptensor):
     assert sptensorInstance.ttm(list_of_matrices, dims=[0, 1, 2]).isequal(
         sptensorInstance
     )
+    assert sptensorInstance.ttm(list_of_matrices, exclude_dims=2).isequal(
+        sptensorInstance.ttm(list_of_matrices[0:-1], dims=[0, 1])
+    )
 
     with pytest.raises(AssertionError) as excinfo:
         sptensorInstance.ttm(sparse.coo_matrix(np.ones((5, 5))), dims=0)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1102,7 +1102,7 @@ def test_tensor_ttm(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     assert (T3.data == data3).all()
 
     # 3-way, two matrices, negative dimension
-    T3 = tensorInstance3.ttm([M2, M2], -2)
+    T3 = tensorInstance3.ttm([M2, M2], exclude_dims=1)
     assert isinstance(T3, ttb.tensor)
     assert T3.shape == (2, 3, 2)
     data3 = np.array(
@@ -1258,20 +1258,20 @@ def test_tensor_ttsv(sample_tensor_4way):
     vector3 = np.array([4, 3, 2, 1])
     assert tensorInstance3.ttsv(vector3, version=1) == 1000
     assert (
-        tensorInstance3.ttsv(vector3, dims=-1, version=1) == 100 * np.ones((4,))
+        tensorInstance3.ttsv(vector3, skip_dim=0, version=1) == 100 * np.ones((4,))
     ).all()
     assert (
-        tensorInstance3.ttsv(vector3, dims=-2, version=1) == 10 * np.ones((4, 4))
+        tensorInstance3.ttsv(vector3, skip_dim=1, version=1) == 10 * np.ones((4, 4))
     ).all()
 
     # Invalid dims
-    with pytest.raises(AssertionError) as excinfo:
-        tensorInstance3.ttsv(vector3, dims=1)
+    with pytest.raises(ValueError) as excinfo:
+        tensorInstance3.ttsv(vector3, skip_dim=-1)
     assert "Invalid modes in ttsv" in str(excinfo)
 
     # 4-way tensor
     (params4, tensorInstance4) = sample_tensor_4way
-    T4ttsv = tensorInstance4.ttsv(np.array([1, 2, 3]), -3, version=1)
+    T4ttsv = tensorInstance4.ttsv(np.array([1, 2, 3]), 2, version=1)
     data4_3 = np.array(
         [
             [[222, 276, 330], [240, 294, 348], [258, 312, 366]],
@@ -1284,7 +1284,7 @@ def test_tensor_ttsv(sample_tensor_4way):
     # 5-way dense tensor
     shape = (3, 3, 3, 3, 3)
     T5 = ttb.tensor.from_data(np.arange(1, np.prod(shape) + 1), shape)
-    T5ttsv = T5.ttsv(np.array([1, 2, 3]), -3, version=1)
+    T5ttsv = T5.ttsv(np.array([1, 2, 3]), 2, version=1)
     data5_3 = np.array(
         [
             [[5220, 5544, 5868], [5328, 5652, 5976], [5436, 5760, 6084]],
@@ -1298,16 +1298,16 @@ def test_tensor_ttsv(sample_tensor_4way):
 
     # 3-way
     assert tensorInstance3.ttsv(vector3) == 1000
-    assert (tensorInstance3.ttsv(vector3, dims=-1) == 100 * np.ones((4,))).all()
-    assert (tensorInstance3.ttsv(vector3, dims=-2) == 10 * np.ones((4, 4))).all()
+    assert (tensorInstance3.ttsv(vector3, 0) == 100 * np.ones((4,))).all()
+    assert (tensorInstance3.ttsv(vector3, 1) == 10 * np.ones((4, 4))).all()
 
     # 4-way tensor
-    T4ttsv2 = tensorInstance4.ttsv(np.array([1, 2, 3]), -3)
+    T4ttsv2 = tensorInstance4.ttsv(np.array([1, 2, 3]), 2)
     assert (T4ttsv2.data == data4_3).all()
 
     # Incorrect version requested
     with pytest.raises(AssertionError) as excinfo:
-        tensorInstance4.ttsv(np.array([1, 2, 3]), -3, version=3)
+        tensorInstance4.ttsv(np.array([1, 2, 3]), 2, version=3)
     assert "Invalid value for version; should be None, 1, or 2" in str(excinfo)
 
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1200,6 +1200,12 @@ def test_tensor_ttv(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     assert T2.shape == (3,)
     assert (T2.data == np.array([10, 14, 18])).all()
 
+    # 2-way Multiply by single vector (exclude dims)
+    T2 = tensorInstance2.ttv(np.array([2, 2]), exclude_dims=1)
+    assert isinstance(T2, ttb.tensor)
+    assert T2.shape == (3,)
+    assert (T2.data == np.array([10, 14, 18])).all()
+
     # Multiply by multiple vectors, infer dimensions
     assert tensorInstance2.ttv([np.array([2, 2]), np.array([1, 1, 1])]) == 42
 
@@ -1226,6 +1232,18 @@ def test_tensor_ttv(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
         tensorInstance4.shape[2],
         tensorInstance4.shape[3],
     )
+
+    # 4-way Multiply by single vector (exclude dims)
+    T4 = tensorInstance4.ttv(
+        2 * np.ones((tensorInstance4.shape[0],)), exclude_dims=np.array([1, 2, 3])
+    )
+    assert isinstance(T4, ttb.tensor)
+    assert T4.shape == (
+        tensorInstance4.shape[1],
+        tensorInstance4.shape[2],
+        tensorInstance4.shape[3],
+    )
+
     data4 = np.array(
         [
             [[12, 174, 336], [66, 228, 390], [120, 282, 444]],

--- a/tests/test_ttensor.py
+++ b/tests/test_ttensor.py
@@ -232,6 +232,11 @@ def test_ttensor_ttv(sample_ttensor):
         ttensorInstance.full().ttv(trivial_vectors[0], 0).double(),
     )
 
+    assert np.allclose(
+        ttensorInstance.ttv(trivial_vectors[0:2], exclude_dims=0).double(),
+        ttensorInstance.full().ttv(trivial_vectors[0:2], exclude_dims=0).double(),
+    )
+
     # Negative tests
     wrong_shape_vector = trivial_vectors.copy()
     wrong_shape_vector[0] = np.array([mul_factor, mul_factor])
@@ -292,6 +297,11 @@ def test_ttensor_ttm(random_ttensor):
         matrices, list(range(len(matrices)))
     )  # Dims as list
     assert final_value.isequal(reverse_value)
+
+    # Exclude Dims
+    assert ttensorInstance.ttm(matrices[1:], exclude_dims=0).isequal(
+        ttensorInstance.ttm(matrices[1:], dims=np.array([1, 2]))
+    )
 
     single_tensor_result = ttensorInstance.ttm(matrices[0], 0)
     single_tensor_full_result = ttensorInstance.full().ttm(matrices[0], 0)


### PR DESCRIPTION
This should be the general solution to this unless I missed something https://github.com/sandialabs/pyttb/issues/62

I moved from:
`tt_dimscheck(dims: np.ndarray, N: int, M: None = None)`
to:
`tt_dimscheck(N: int, M: None = None, dims: Optional[np.ndarray] = None, exclude_dims: Optional[np.ndarray] = None)`
If anyone really relied on our interface that is a breaking change, but the right one in my opinion. Since user base is small PROBABLY ok to just do 1.6.0 (since this util is mostly used internally). This interface change then worked its way out to <tensor,ttensor,ktensor,sptensor>.<ttv,ttm> which were also breaking changes but more minor. We could do this more gently if worried about compatibility.

Notes:
* For tensor.ttsv I changed the name entirely since the use of dim is quite different there. Open to other names if they are clearer.

* Found one bug in tensor.ttm shape generation when validating ttensor.ttv with exclude.

* These changes were all pretty intertwined so my commits aren't really logical pieces more of a PR in two parts