### PR TITLE
Link in autodocumentation for recently added code

### DIFF
--- a/docs/source/algorithms.rst
+++ b/docs/source/algorithms.rst
@@ -5,3 +5,5 @@ Algorithms
 
     cpals.rst
     cpapr.rst
+    hosvd.rst
+    tuckerals.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,7 +79,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/hosvd.rst
+++ b/docs/source/hosvd.rst
@@ -1,2 +1,7 @@
 pyttb.hosvd
 ===================
+
+.. automodule:: pyttb.hosvd
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/sptensor.rst
+++ b/docs/source/sptensor.rst
@@ -1,7 +1,7 @@
 pyttb.sptensor
 ----------------------
 
-.. autoclass:: pyttb.sptensor
+.. automodule:: pyttb.sptensor
     :members:
     :special-members:
     :exclude-members: __dict__,__weakref__

--- a/docs/source/tensor_classes.rst
+++ b/docs/source/tensor_classes.rst
@@ -7,5 +7,6 @@ Tensor Classes
     ktensor.rst
     sptensor.rst
     tensor.rst
+    ttensor.rst
     tenmat.rst
 

--- a/docs/source/ttensor.rst
+++ b/docs/source/ttensor.rst
@@ -1,2 +1,9 @@
 pyttb.ttensor
-=====================
+--------------------
+
+.. automodule:: pyttb.ttensor
+    :members:
+    :special-members:
+    :exclude-members: __dict__,__weakref__
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tuckerals.rst
+++ b/docs/source/tuckerals.rst
@@ -1,2 +1,7 @@
 pyttb.tucker_als
 ========================
+
+.. automodule:: pyttb.tucker_als
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Should resolve: #97

We could consider a github action to preview the docs but that's probably not high priority. Will try to remember to add this for new code. For most of it the autogeneration will pickup new code added in configured files.