### PR TITLE
Remove warning for nvecs:

### DIFF
--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -5,6 +5,7 @@
 """Classes and functions for working with Kruskal tensors."""
 from __future__ import annotations
 
+import logging
 import warnings
 
 import numpy as np
@@ -1295,7 +1296,7 @@ class ktensor(object):
             v = v[:, (-np.abs(w)).argsort()]
             v = v[:, :r]
         else:
-            warnings.warn(
+            logging.debug(
                 "Greater than or equal to ktensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
             )
             w, v = scipy.linalg.eigh(y)

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -4,6 +4,7 @@
 """Sparse Tensor Implementation"""
 from __future__ import annotations
 
+import logging
 import warnings
 from collections.abc import Sequence
 from typing import Any, Callable, List, Optional, Tuple, Union, cast, overload
@@ -934,7 +935,7 @@ class sptensor:
         if r < y.shape[0] - 1:
             _, v = scipy.sparse.linalg.eigs(y, r)
         else:
-            warnings.warn(
+            logging.debug(
                 "Greater than or equal to sptensor.shape[n] - 1 eigenvectors requires"
                 " cast to dense to solve"
             )

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -4,7 +4,7 @@
 """Dense Tensor Implementation"""
 from __future__ import annotations
 
-import warnings
+import logging
 from itertools import permutations
 from math import factorial
 from typing import Any, Callable, List, Optional, Tuple, Union
@@ -790,7 +790,7 @@ class tensor:
             v = v[:, (-np.abs(w)).argsort()]
             v = v[:, :r]
         else:
-            warnings.warn(
+            logging.debug(
                 "Greater than or equal to tensor.shape[n] - 1 eigenvectors"
                 " requires cast to dense to solve"
             )

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -2,8 +2,8 @@
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
 
+import logging
 import textwrap
-import warnings
 
 import numpy as np
 import scipy
@@ -574,7 +574,7 @@ class ttensor(object):
             v = v[:, (-np.abs(w)).argsort()]
             v = v[:, :r]
         else:
-            warnings.warn(
+            logging.debug(
                 "Greater than or equal to tensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
             )
             w, v = scipy.linalg.eigh(Y)

--- a/tests/test_cp_als.py
+++ b/tests/test_cp_als.py
@@ -38,12 +38,7 @@ def test_cp_als_tensor_default_init(capsys, sample_tensor):
 @pytest.mark.indevelopment
 def test_cp_als_tensor_nvecs_init(capsys, sample_tensor):
     (data, T) = sample_tensor
-    with pytest.warns(Warning) as record:
-        (M, Minit, output) = ttb.cp_als(T, 1, init="nvecs")
-    assert (
-        "Greater than or equal to tensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
-        in str(record[0].message)
-    )
+    (M, Minit, output) = ttb.cp_als(T, 1, init="nvecs")
     capsys.readouterr()
     assert pytest.approx(output["fit"], 1) == 0
 
@@ -87,12 +82,7 @@ def test_cp_als_sptensor_default_init(capsys, sample_sptensor):
 @pytest.mark.indevelopment
 def test_cp_als_sptensor_nvecs_init(capsys, sample_sptensor):
     (data, T) = sample_sptensor
-    with pytest.warns(Warning) as record:
-        (M, Minit, output) = ttb.cp_als(T, 1, init="nvecs")
-    assert (
-        "Greater than or equal to sptensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
-        in str(record[0].message)
-    )
+    (M, Minit, output) = ttb.cp_als(T, 1, init="nvecs")
     capsys.readouterr()
     assert pytest.approx(output["fit"], 1) == 0
 

--- a/tests/test_ktensor.py
+++ b/tests/test_ktensor.py
@@ -710,47 +710,32 @@ def test_ktensor_normalize(sample_ktensor_2way, sample_ktensor_3way):
 def test_ktensor_nvecs(sample_ktensor_3way):
     (data, K) = sample_ktensor_3way
 
-    with pytest.warns(Warning) as record:
-        assert np.allclose(
-            K.nvecs(0, 1), np.array([[0.5731077440321353], [0.8194800264377384]])
-        )
-    assert (
-        "Greater than or equal to ktensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
-        in str(record[0].message)
+    assert np.allclose(
+        K.nvecs(0, 1), np.array([[0.5731077440321353], [0.8194800264377384]])
     )
-    with pytest.warns(Warning) as record:
-        assert np.allclose(
-            K.nvecs(0, 2),
-            np.array(
-                [
-                    [0.5731077440321353, 0.8194800264377384],
-                    [0.8194800264377384, -0.5731077440321353],
-                ]
-            ),
-        )
-    assert (
-        "Greater than or equal to ktensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
-        in str(record[0].message)
+    assert np.allclose(
+        K.nvecs(0, 2),
+        np.array(
+            [
+                [0.5731077440321353, 0.8194800264377384],
+                [0.8194800264377384, -0.5731077440321353],
+            ]
+        ),
     )
 
     assert np.allclose(
         K.nvecs(1, 1),
         np.array([[0.5048631426517823], [0.5745404391632514], [0.6442177356747206]]),
     )
-    with pytest.warns(Warning) as record:
-        assert np.allclose(
-            K.nvecs(1, 2),
-            np.array(
-                [
-                    [0.5048631426517821, 0.7605567306550753],
-                    [0.5745404391632517, 0.0568912743440822],
-                    [0.6442177356747206, -0.6467741818894517],
-                ]
-            ),
-        )
-    assert (
-        "Greater than or equal to ktensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
-        in str(record[0].message)
+    assert np.allclose(
+        K.nvecs(1, 2),
+        np.array(
+            [
+                [0.5048631426517821, 0.7605567306550753],
+                [0.5745404391632517, 0.0568912743440822],
+                [0.6442177356747206, -0.6467741818894517],
+            ]
+        ),
     )
 
     assert np.allclose(
@@ -777,12 +762,7 @@ def test_ktensor_nvecs(sample_ktensor_3way):
     )
 
     # Test for r >= N-1, requires cast to dense
-    with pytest.warns(Warning) as record:
-        K.nvecs(1, 3)
-    assert (
-        "Greater than or equal to ktensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
-        in str(record[0].message)
-    )
+    K.nvecs(1, 3)
 
 
 @pytest.mark.indevelopment

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -1625,16 +1625,11 @@ def test_sptensor_nvecs(sample_sptensor):
     )
 
     # Test for r >= N-1, requires cast to dense
-    with pytest.warns(Warning) as record:
-        ans = np.zeros((4, 3))
-        ans[3, 0] = 1
-        ans[2, 1] = 1
-        ans[1, 2] = 1
-        assert np.allclose((sptensorInstance.nvecs(1, 3)), ans)
-    assert (
-        "Greater than or equal to sptensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
-        in str(record[0].message)
-    )
+    ans = np.zeros((4, 3))
+    ans[3, 0] = 1
+    ans[2, 1] = 1
+    ans[1, 2] = 1
+    assert np.allclose((sptensorInstance.nvecs(1, 3)), ans)
 
     # Negative test, check for only singleton dims
     with pytest.raises(ValueError):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1626,12 +1626,7 @@ def test_tensor_nvecs(sample_tensor_2way):
     assert np.allclose((tensorInstance.nvecs(1, 1)), nv1)
 
     # Test for r >= N-1, requires cast to dense
-    with pytest.warns(Warning) as record:
-        assert np.allclose((tensorInstance.nvecs(1, 2)), nv2)
-    assert (
-        "Greater than or equal to tensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
-        in str(record[0].message)
-    )
+    assert np.allclose((tensorInstance.nvecs(1, 2)), nv2)
 
 
 def test_tenones():

--- a/tests/test_ttensor.py
+++ b/tests/test_ttensor.py
@@ -367,12 +367,7 @@ def test_ttensor_nvecs(random_ttensor):
     n = 1
     r = 2
     full_eigvals = ttensorInstance.full().nvecs(n, r)
-    with pytest.warns(Warning) as record:
-        ttensor_eigvals = ttensorInstance.nvecs(n, r)
-    assert (
-        "Greater than or equal to tensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
-        in str(record[0].message)
-    )
+    ttensor_eigvals = ttensorInstance.nvecs(n, r)
     assert np.allclose(ttensor_eigvals, full_eigvals)
 
     # Negative Tests


### PR DESCRIPTION
I think an enhancement that probably isn't blocking for 2.0 is considering a more standard logging control. Some algorithms take log levels that aren't consistent with each other and use prints. I've been move more things over to `logging` we can probably add a `pyttb` level logging control rather than the root logger for a file. This allows a more standard way to control verbosity.

All of that to say for now I moved the warning to a debug level log, because I think we added the warning initially in case someone hit some weird numeric behavior with the cast (I don't remember entirely).