### PR TITLE
Tensor indexing

### DIFF
--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 import warnings
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import Any, Callable, List, Optional, Tuple, Union, cast, overload
 
 import numpy as np
@@ -620,7 +620,7 @@ class sptensor:
             if self.shape != other.shape:
                 assert False, "Sptensor and tensor must be same shape for innerproduct"
             [subsSelf, valsSelf] = self.find()
-            valsOther = other[subsSelf, "extract"]
+            valsOther = other[subsSelf.transpose(), "extract"]
             return valsOther.transpose().dot(valsSelf)
 
         if isinstance(other, (ttb.ktensor, ttb.ttensor)):  # pragma: no cover
@@ -685,7 +685,7 @@ class sptensor:
 
         if isinstance(B, ttb.tensor):
             BB = sptensor.from_data(
-                self.subs, B[self.subs, "extract"][:, None], self.shape
+                self.subs, B[self.subs.transpose(), "extract"][:, None], self.shape
             )
             C = self.logical_and(BB)
             return C
@@ -1053,7 +1053,7 @@ class sptensor:
                 assert False, "Size mismatch in scale"
             return ttb.sptensor.from_data(
                 self.subs,
-                self.vals * factor[self.subs[:, dims], "extract"][:, None],
+                self.vals * factor[self.subs[:, dims].transpose(), "extract"][:, None],
                 self.shape,
             )
         if isinstance(factor, ttb.sptensor):
@@ -1660,7 +1660,7 @@ class sptensor:
                     )
                 else:
                     newsz.append(key[n].stop)
-            elif isinstance(key[n], np.ndarray):
+            elif isinstance(key[n], (np.ndarray, Iterable)):
                 newsz.append(max(key[n]) + 1)
             else:
                 newsz.append(key[n] + 1)
@@ -1671,7 +1671,8 @@ class sptensor:
             self.subs = np.append(
                 self.subs,
                 np.zeros(
-                    shape=(self.subs.shape[0], len(self.shape) - self.subs.shape[1])
+                    shape=(self.subs.shape[0], len(self.shape) - self.subs.shape[1]),
+                    dtype=int,
                 ),
                 axis=1,
             )
@@ -1689,7 +1690,7 @@ class sptensor:
         if isinstance(value, (int, float)):
             # Determine number of dimensions (may be larger than current number)
             N = len(key)
-            keyCopy = np.array(key)
+            keyCopy = [None] * N
             # Figure out how many indices are in each dimension
             nssubs = np.zeros((N, 1))
             for n in range(0, N):
@@ -1697,7 +1698,11 @@ class sptensor:
                     # Generate slice explicitly to determine its length
                     keyCopy[n] = np.arange(0, self.shape[n])[key[n]]
                     indicesInN = len(keyCopy[n])
+                elif isinstance(key[n], Iterable):
+                    keyCopy[n] = key[n]
+                    indicesInN = len(key[n])
                 else:
+                    keyCopy[n] = key[n]
                     indicesInN = 1
                 nssubs[n] = indicesInN
 
@@ -1806,7 +1811,7 @@ class sptensor:
             ]
 
             # Find where their nonzeros intersect
-            othervals = other[self.subs, "extract"]
+            othervals = other[self.subs.transpose(), "extract"]
             znzsubs = self.subs[(othervals[:, None] == self.vals).transpose()[0], :]
 
             return sptensor.from_data(
@@ -1887,7 +1892,7 @@ class sptensor:
                 subs1 = np.empty((0, self.subs.shape[1]))
             # find entries where x is nonzero but not equal to y
             subs2 = self.subs[
-                self.vals.transpose()[0] != other[self.subs, "extract"], :
+                self.vals.transpose()[0] != other[self.subs.transpose(), "extract"], :
             ]
             if subs2.size == 0:
                 subs2 = np.empty((0, self.subs.shape[1]))
@@ -2002,7 +2007,7 @@ class sptensor:
             )
         if isinstance(other, ttb.tensor):
             csubs = self.subs
-            cvals = self.vals * other[csubs, "extract"][:, None]
+            cvals = self.vals * other[csubs.transpose(), "extract"][:, None]
             return ttb.sptensor.from_data(csubs, cvals, self.shape)
         if isinstance(other, ttb.ktensor):
             csubs = self.subs
@@ -2124,7 +2129,7 @@ class sptensor:
 
             # self nonzero
             subs2 = self.subs[
-                self.vals.transpose()[0] <= other[self.subs, "extract"], :
+                self.vals.transpose()[0] <= other[self.subs.transpose(), "extract"], :
             ]
 
             # assemble
@@ -2212,7 +2217,9 @@ class sptensor:
             subs1 = subs1[ttb.tt_setdiff_rows(subs1, self.subs), :]
 
             # self nonzero
-            subs2 = self.subs[self.vals.transpose()[0] < other[self.subs, "extract"], :]
+            subs2 = self.subs[
+                self.vals.transpose()[0] < other[self.subs.transpose(), "extract"], :
+            ]
 
             # assemble
             subs = np.vstack((subs1, subs2))
@@ -2267,7 +2274,10 @@ class sptensor:
 
             # self nonzero
             subs2 = self.subs[
-                (self.vals >= other[self.subs, "extract"][:, None]).transpose()[0], :
+                (
+                    self.vals >= other[self.subs.transpose(), "extract"][:, None]
+                ).transpose()[0],
+                :,
             ]
 
             # assemble
@@ -2325,7 +2335,10 @@ class sptensor:
 
             # self and other nonzero
             subs2 = self.subs[
-                (self.vals > other[self.subs, "extract"][:, None]).transpose()[0], :
+                (
+                    self.vals > other[self.subs.transpose(), "extract"][:, None]
+                ).transpose()[0],
+                :,
             ]
 
             # assemble
@@ -2428,7 +2441,7 @@ class sptensor:
 
         if isinstance(other, ttb.tensor):
             csubs = self.subs
-            cvals = self.vals / other[csubs, "extract"][:, None]
+            cvals = self.vals / other[csubs.transpose(), "extract"][:, None]
             return ttb.sptensor.from_data(csubs, cvals, self.shape)
         if isinstance(other, ttb.ktensor):
             # TODO consider removing epsilon and generating nans consistent with above

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -1647,6 +1647,8 @@ class sptensor:
                     newsz.append(self.shape[n])
                 else:
                     newsz.append(max([self.shape[n], key[n].stop]))
+            elif isinstance(key[n], Iterable):
+                newsz.append(max([self.shape[n], max(key[n]) + 1]))
             else:
                 newsz.append(max([self.shape[n], key[n] + 1]))
 

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -1368,9 +1368,9 @@ class sptensor:
         if (
             isinstance(item, np.ndarray)
             and len(item.shape) == 2
-            and item.shape[1] == self.ndims
+            and item.shape[0] == self.ndims
         ):
-            srchsubs = np.array(item)
+            srchsubs = np.array(item.transpose())
 
         # *** CASE 2b: Linear indexing ***
         else:
@@ -1463,21 +1463,21 @@ class sptensor:
         tt_subscheck(newsubs, nargout=False)
 
         # Error check on subscripts
-        if newsubs.shape[1] < self.ndims:
+        if newsubs.shape[0] < self.ndims:
             assert False, "Invalid subscripts"
 
         # Check for expanding the order
-        if newsubs.shape[1] > self.ndims:
+        if newsubs.shape[0] > self.ndims:
             newshape = list(self.shape)
             # TODO no need for loop, just add correct size
-            for _ in range(self.ndims, newsubs.shape[1]):
+            for _ in range(self.ndims, newsubs.shape[0]):
                 newshape.append(1)
             if self.subs.size > 0:
                 self.subs = np.concatenate(
                     (
                         self.subs,
                         np.ones(
-                            (self.shape[0], newsubs.shape[1] - self.ndims),
+                            (self.shape[0], newsubs.shape[0] - self.ndims),
                             dtype=int,
                         ),
                     ),
@@ -1497,7 +1497,7 @@ class sptensor:
 
         # Determine number of nonzeros being inserted.
         # (This is determined by number of subscripts)
-        newnnz = newsubs.shape[0]
+        newnnz = newsubs.shape[1]
 
         # Error check on size of newvals
         if newvals.size == 1:
@@ -1510,7 +1510,7 @@ class sptensor:
             assert False, "Number of subscripts and number of values do not match!"
 
         # Remove duplicates and print warning if any duplicates were removed
-        newsubs, idx = np.unique(newsubs, axis=0, return_index=True)
+        newsubs, idx = np.unique(newsubs.transpose(), axis=0, return_index=True)
         if newsubs.shape[0] != newnnz:
             warnings.warn("Duplicate assignments discarded")
 

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1514,10 +1514,21 @@ class tensor:
             return a
 
         # *** CASE 2a: Subscript indexing ***
-        if len(item) > 1 and isinstance(item[-1], str) and item[-1] == "extract":
+        if isinstance(item, np.ndarray) and len(item) > 1:
             # Extract array of subscripts
+            subs = np.array(item)
+            a = np.squeeze(self.data[tuple(subs)])
+            # TODO if is row make column?
+            return ttb.tt_subsubsref(a, subs)
+        if (
+            len(item) > 1
+            and isinstance(item[0], np.ndarray)
+            and isinstance(item[-1], str)
+            and item[-1] == "extract"
+        ):
+            # TODO dry this up
             subs = np.array(item[0])
-            a = np.squeeze(self.data[tuple(subs.transpose())])
+            a = np.squeeze(self.data[tuple(subs)])
             # TODO if is row make column?
             return ttb.tt_subsubsref(a, subs)
 

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1276,7 +1276,6 @@ class tensor:
         """
         # Figure out if we are doing a subtensor, a list of subscripts or a list of
         # linear indices
-        # print(f"Key: {key} {type(key)}")
         access_type = "error"
         # TODO pull out this big decision tree into a function
         if isinstance(key, (float, int, np.generic, slice)):
@@ -1296,15 +1295,11 @@ class tensor:
                 validSubtensor = [
                     isinstance(keyElement, (int, slice, Iterable)) for keyElement in key
                 ]
-                # TODO probably need to confirm the Iterable is in fact numeric
                 if np.all(validSubtensor):
                     access_type = "subtensor"
             elif isinstance(key, Iterable):
                 key = np.array(key)
-                # Clean up copy paste
-                if len(key.shape) > 1 and key.shape[1] >= self.ndims:
-                    access_type = "subscripts"
-                elif len(key.shape) == 1 or key.shape[1] == 1:
+                if len(key.shape) == 1 or key.shape[1] == 1:
                     access_type = "linear indices"
 
         # Case 1: Rectangular Subtensor
@@ -1351,6 +1346,12 @@ class tensor:
                 else:
                     sliceCheck.append(element.stop)
             elif isinstance(element, Iterable):
+                if any(
+                    not isinstance(entry, (float, int, np.generic)) for entry in element
+                ):
+                    raise ValueError(
+                        f"Entries for setitem must be numeric but recieved, {element}"
+                    )
                 sliceCheck.append(max(element))
             else:
                 sliceCheck.append(element)

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -293,9 +293,9 @@ def test_sptensor__getitem__(sample_sptensor):
 
     # TODO need to understand what this intends to do
     ## Case 2 subscript indexing
-    assert sptensorInstance[np.array([[1, 2, 1]])] == np.array([[0]])
+    assert sptensorInstance[np.array([[1], [2], [1]])] == np.array([[0]])
     assert (
-        sptensorInstance[np.array([[1, 2, 1], [1, 3, 1]])] == np.array([[0], [0]])
+        sptensorInstance[np.array([[1, 1], [2, 3], [1, 1]])] == np.array([[0], [0]])
     ).all()
 
     ## Case 2 Linear Indexing
@@ -551,12 +551,14 @@ def test_sptensor_setitem_Case2(sample_sptensor):
 
     # Case II: Too few keys in setitem for number of assignement values
     with pytest.raises(AssertionError) as excinfo:
-        sptensorInstance[np.array([1, 1, 1]).astype(int)] = np.array([[999.0], [888.0]])
+        sptensorInstance[np.array([[1], [1], [1]]).astype(int)] = np.array(
+            [[999.0], [888.0]]
+        )
     assert "Number of subscripts and number of values do not match!" in str(excinfo)
 
     # Case II: Warning For duplicates
     with pytest.warns(Warning) as record:
-        sptensorInstance[np.array([[1, 1, 1], [1, 1, 1]]).astype(int)] = np.array(
+        sptensorInstance[np.array([[1, 1], [1, 1], [1, 1]]).astype(int)] = np.array(
             [[999.0], [999.0]]
         )
     assert "Duplicate assignments discarded" in str(record[0].message)
@@ -567,54 +569,54 @@ def test_sptensor_setitem_Case2(sample_sptensor):
     assert np.all(empty_tensor[np.array([[0, 1], [2, 2]])] == 4)
 
     # Case II: Single entry, for single sub that exists
-    sptensorInstance[np.array([1, 1, 1]).astype(int)] = 999.0
-    assert (sptensorInstance[np.array([[1, 1, 1]])] == np.array([[999]])).all()
+    sptensorInstance[np.array([[1], [1], [1]]).astype(int)] = 999.0
+    assert (sptensorInstance[np.array([[1], [1], [1]])] == np.array([[999]])).all()
     assert (sptensorInstance.subs == data["subs"]).all()
 
     # Case II: Single entry, for multiple subs that exist
     (data, sptensorInstance) = sample_sptensor
-    sptensorInstance[np.array([[1, 1, 1], [1, 1, 3]]).astype(int)] = 999.0
+    sptensorInstance[np.array([[1, 1], [1, 1], [1, 3]]).astype(int)] = 999.0
     assert (
-        sptensorInstance[np.array([[1, 1, 1], [1, 1, 3]])] == np.array([[999], [999]])
+        sptensorInstance[np.array([[1, 1], [1, 1], [1, 3]])] == np.array([[999], [999]])
     ).all()
     assert (sptensorInstance.subs == data["subs"]).all()
 
     # Case II: Multiple entries, for multiple subs that exist
     (data, sptensorInstance) = sample_sptensor
-    sptensorInstance[np.array([[1, 1, 1], [1, 1, 3]]).astype(int)] = np.array(
+    sptensorInstance[np.array([[1, 1], [1, 1], [1, 3]]).astype(int)] = np.array(
         [[888], [999]]
     )
     assert (
-        sptensorInstance[np.array([[1, 1, 3], [1, 1, 1]])] == np.array([[999], [888]])
+        sptensorInstance[np.array([[1, 1], [1, 1], [3, 1]])] == np.array([[999], [888]])
     ).all()
     assert (sptensorInstance.subs == data["subs"]).all()
 
     # Case II: Single entry, for single sub that doesn't exist
     (data, sptensorInstance) = sample_sptensor
     copy = ttb.sptensor.from_tensor_type(sptensorInstance)
-    copy[np.array([[1, 1, 2]]).astype(int)] = 999.0
-    assert (copy[np.array([[1, 1, 2]])] == np.array([999])).all()
+    copy[np.array([[1], [1], [2]]).astype(int)] = 999.0
+    assert (copy[np.array([[1], [1], [2]])] == np.array([999])).all()
     assert (copy.subs == np.concatenate((data["subs"], np.array([[1, 1, 2]])))).all()
 
     # Case II: Single entry, for single sub that doesn't exist, expand dimensions
     (data, sptensorInstance) = sample_sptensor
     copy = ttb.sptensor.from_tensor_type(sptensorInstance)
-    copy[np.array([[1, 1, 2, 1]]).astype(int)] = 999.0
-    assert (copy[np.array([[1, 1, 2, 1]])] == np.array([999])).all()
+    copy[np.array([[1], [1], [2], [1]]).astype(int)] = 999.0
+    assert (copy[np.array([[1], [1], [2], [1]])] == np.array([999])).all()
     # assert (copy.subs == np.concatenate((data['subs'], np.array([[1, 1, 2]])))).all()
 
     # Case II: Single entry, for multiple subs one that exists and the other doesn't
     (data, sptensorInstance) = sample_sptensor
     copy = ttb.sptensor.from_tensor_type(sptensorInstance)
-    copy[np.array([[1, 1, 1], [2, 1, 3]]).astype(int)] = 999.0
-    assert (copy[np.array([[2, 1, 3]])] == np.array([999])).all()
+    copy[np.array([[1, 2], [1, 1], [1, 3]]).astype(int)] = 999.0
+    assert (copy[np.array([[2], [1], [3]])] == np.array([999])).all()
     assert (copy.subs == np.concatenate((data["subs"], np.array([[2, 1, 3]])))).all()
 
     # Case II: Multiple entries, for multiple subs that don't exist
     (data, sptensorInstance) = sample_sptensor
     copy = ttb.sptensor.from_tensor_type(sptensorInstance)
-    copy[np.array([[1, 1, 2], [2, 1, 3]]).astype(int)] = np.array([[888], [999]])
-    assert (copy[np.array([[1, 1, 2], [2, 1, 3]])] == np.array([[888], [999]])).all()
+    copy[np.array([[1, 2], [1, 1], [2, 3]]).astype(int)] = np.array([[888], [999]])
+    assert (copy[np.array([[1, 2], [1, 1], [2, 3]])] == np.array([[888], [999]])).all()
     assert (
         copy.subs == np.concatenate((data["subs"], np.array([[1, 1, 2], [2, 1, 3]])))
     ).all()
@@ -622,8 +624,8 @@ def test_sptensor_setitem_Case2(sample_sptensor):
     # Case II: Multiple entries, for multiple subs that exist and need to be removed
     (data, sptensorInstance) = sample_sptensor
     copy = ttb.sptensor.from_tensor_type(sptensorInstance)
-    copy[np.array([[1, 1, 1], [1, 1, 3]]).astype(int)] = np.array([[0], [0]])
-    assert (copy[np.array([[1, 1, 2], [2, 1, 3]])] == np.array([[0], [0]])).all()
+    copy[np.array([[1, 1], [1, 1], [1, 3]]).astype(int)] = np.array([[0], [0]])
+    assert (copy[np.array([[1, 2], [1, 1], [1, 3]])] == np.array([[0], [0]])).all()
     assert (copy.subs == np.array([[2, 2, 2], [3, 3, 3]])).all()
 
 

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -533,6 +533,18 @@ def test_sptensor_setitem_Case1(sample_sptensor):
     assert (sptensorInstance.vals == np.vstack((data["vals"], np.array([[7]])))).all()
     assert sptensorInstance.shape == data["shape"]
 
+    # Case I(b)ii: Set with scalar, iterable index, empty sptensor
+    someTensor = ttb.sptensor()
+    someTensor[[0, 1], 0] = 1
+    assert someTensor[0, 0] == 1
+    assert someTensor[1, 0] == 1
+    assert np.all(someTensor[[0, 1], 0].vals == 1)
+    # Case I(b)ii: Set with scalar, iterable index, non-empty sptensor
+    someTensor[[0, 1], 1] = 2
+    assert someTensor[0, 1] == 2
+    assert someTensor[1, 1] == 2
+    assert np.all(someTensor[[0, 1], 1].vals == 2)
+
     # Case I: Assign with non-scalar or sptensor
     sptensorInstanceLarger = ttb.sptensor.from_tensor_type(sptensorInstance)
     with pytest.raises(AssertionError) as excinfo:

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -313,9 +313,10 @@ def test_tensor__setitem__(sample_tensor_2way):
     )
 
     # Attempting to set some other way
-    with pytest.raises(AssertionError) as excinfo:
+    # TODO either catch this error ourselves or specify more specific exception we expect here
+    with pytest.raises(Exception) as excinfo:
         tensorInstance[0, "a", 5] = 13.0
-    assert "Invalid use of tensor setitem" in str(excinfo)
+    # assert "Invalid use of tensor setitem" in str(excinfo)
 
 
 @pytest.mark.indevelopment
@@ -343,7 +344,7 @@ def test_tensor__getitem__(sample_tensor_2way):
     assert tensorInstance[np.array([0, 0]), "extract"] == params["data"][0, 0]
     assert (
         tensorInstance[np.array([[0, 0], [1, 1]]), "extract"]
-        == params["data"][([0, 1], [0, 1])]
+        == params["data"][([0, 0], [1, 1])]
     ).all()
 
     # Case 2b: Linear Indexing

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -280,6 +280,14 @@ def test_tensor__setitem__(sample_tensor_2way):
     dataGrowth[np.unravel_index([0], dataGrowth.shape, "F")] = 13.0
     assert (tensorInstance.data == dataGrowth).all()
 
+    tensorInstance[0] = 14.0
+    dataGrowth[np.unravel_index([0], dataGrowth.shape, "F")] = 14.0
+    assert (tensorInstance.data == dataGrowth).all()
+
+    tensorInstance[0:1] = 14.0
+    dataGrowth[np.unravel_index([0], dataGrowth.shape, "F")] = 14.0
+    assert (tensorInstance.data == dataGrowth).all()
+
     # Linear Index with constant
     tensorInstance[np.array([0, 3, 4])] = 13.0
     dataGrowth[np.unravel_index([0, 3, 4], dataGrowth.shape, "F")] = 13
@@ -340,6 +348,8 @@ def test_tensor__getitem__(sample_tensor_2way):
 
     # Case 2b: Linear Indexing
     assert tensorInstance[np.array([0])] == params["data"][0, 0]
+    assert tensorInstance[0] == params["data"][0, 0]
+    assert np.array_equal(tensorInstance[0:1], params["data"][0, 0])
     with pytest.raises(AssertionError) as excinfo:
         tensorInstance[np.array([0]), np.array([0]), np.array([0])]
     assert "Linear indexing requires single input array" in str(excinfo)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -251,6 +251,13 @@ def test_tensor__setitem__(sample_tensor_2way):
     # Subtensor add dimension
     empty_tensor[0, 0, 0] = 2
 
+    # Subtensor with lists
+    some_tensor = ttb.tenones((3, 3))
+    some_tensor[[0, 1], [0, 1]] = 11
+    assert some_tensor[0, 0] == 11
+    assert some_tensor[1, 1] == 11
+    assert np.all(some_tensor[[0, 1], [0, 1]].data == 11)
+
     # Subscripts with constant
     tensorInstance[np.array([[1, 1]])] = 13.0
     dataGrowth[1, 1] = 13.0
@@ -293,6 +300,13 @@ def test_tensor__setitem__(sample_tensor_2way):
     dataGrowth[np.unravel_index([0, 3, 4], dataGrowth.shape, "F")] = 13
     assert (tensorInstance.data == dataGrowth).all()
 
+    # Linear index with multiple indicies
+    some_tensor = ttb.tenones((3, 3))
+    some_tensor[[0, 1]] = 2
+    assert some_tensor[0] == 2
+    assert some_tensor[1] == 2
+    assert np.array_equal(some_tensor[[0, 1]], [2, 2])
+
     # Test Empty Tensor Set Item, subtensor
     emptyTensor = ttb.tensor.from_data(np.array([]))
     emptyTensor[0, 0, 0] = 0
@@ -313,10 +327,17 @@ def test_tensor__setitem__(sample_tensor_2way):
     )
 
     # Attempting to set some other way
-    # TODO either catch this error ourselves or specify more specific exception we expect here
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         tensorInstance[0, "a", 5] = 13.0
-    # assert "Invalid use of tensor setitem" in str(excinfo)
+    assert "must be numeric" in str(excinfo)
+
+    with pytest.raises(AssertionError) as excinfo:
+
+        class BadKey:
+            pass
+
+        tensorInstance[BadKey] = 13.0
+    assert "Invalid use of tensor setitem" in str(excinfo)
 
 
 @pytest.mark.indevelopment
@@ -345,6 +366,11 @@ def test_tensor__getitem__(sample_tensor_2way):
     assert (
         tensorInstance[np.array([[0, 0], [1, 1]]), "extract"]
         == params["data"][([0, 0], [1, 1])]
+    ).all()
+    # Case 2a: Extract doesn't seem to be needed
+    assert tensorInstance[np.array([0, 0])] == params["data"][0, 0]
+    assert (
+        tensorInstance[np.array([[0, 0], [1, 1]])] == params["data"][([0, 0], [1, 1])]
     ).all()
 
     # Case 2b: Linear Indexing


### PR DESCRIPTION
There is definitely cleanup that could be done around our indexing tests and potentially the logic. There are a lot of different paths through the code based on a variety of conditions that makes it complicated to reason about.

This proposes a solution to: https://github.com/sandialabs/pyttb/issues/108

Here are all the different combinations that I could think of and expected behavior based on Danny's description in the linked issue/discussion. I basically used this as my burn down list to confirm consistency. If there are disagreements here I think the small examples help for concreteness (and I baked some into our unit tests). The fundamental problem was the sub-scripts had different meanings in pyttb between sptensor and tensor. Ultimately, that made me question how everything interacted so I just explored the intuitiveness of a variety of access patterns that seemed reasonable. One note, do we even need the `extract` keyword? It doesn't seem to work as described in matlab (unless I broke my local version).
```matlab
 >> X = tensor(rand(3,4,2,1),[3 4 2 1]);
 >> a = X([1:6]');
 >> b = X([1:6]', 'extract');
 >> class(a)
ans =
    'double'
>> class(b)
ans =
    'double'
```

Big decision tree covering functionality that this PR now supports
## Tensor
### Linear
1. Single index
```python
        from pyttb import tenones
        b = tenones((3,3))
        b[0] = 9
        assert b[0] == 9
```
2. Multiple linear indices
```python
        from pyttb import tenones
        b[[0,1]] = 2
        assert b[0] == 2
        assert b[1] == 2
        assert np.array_equal(b[[0,1]], [2,2])
```
### Sub-tensor:
1. Singular indices
```python
        from pyttb import tenones
        b = tenones((3,3))
        b[0,0] = 9
        assert b[0,0] = 9
        #(with growth)
        b[0, 0, 0] = 11
        assert b[0,0,0] == 1
```
2. With slices
```python
        from pyttb import tenones
        b = tenones((3,3))
        b[:, 0] = 11
        assert b[0,0] == 11
        assert b[1,0] == 11
        assert b[2,0] == 11
        assert np.all(b[:,0].data == 11)
```
3. With multi-indices (not range since python has slices)
```python
        from pyttb import tenones
        b = tenones((3,3))
        b[[0,1],[0,1]] = 11
        assert b[0,0] == 11
        assert b[1,1] == 11
        assert np.all(b[[0,1],[0,1]].data == 11)
```
### Sub-scripts:
1. Only one option of being explicit
```python
        b = tenones((3,3))
        b[np.array([[1,1],[0,2]])] = 2
        assert np.all(b[np.array([[1,1],[0,2]])] == 2)
```
## SPTENSOR:
### Sub-tensor:
1. Singular indices
```python
        from pyttb import sptensor
        a = sptensor()
        a[0,0] = 1
        assert a[0,0] == 1
```
2. Slices
```python
        from pyttb import sptensor
        a = sptensor()
        a[2,2] = 1
        a[:, 2] = 2
        assert a[0, 0] == 2
        assert a[1, 0] == 2
        assert a[2, 0] = 2
        assert np.all(a[:, 2].vals == 2)
```        
3. Multi-indices
```python
        from pyttb import sptensor
        a = sptensor()
        a[[0,1], 0] = 1
        assert a[0,0] == 1
        assert a[1,0] == 1
        assert np.all(a[[0,1], 0].vals == 1)
```
### Sub-scripts:
1. Only one option of being explicit
```python
        a = sptensor()
        a[np.array([[1,1],[0,2]])] = 2
        np.array_equal(a[np.array([[1,1],[0,2]])], np.array([[2]]*2))
```