### PR TITLE
Coveralls: Try updating to default suggestion

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install coverage coveralls sphinx_rtd_theme
+        python -m pip install --upgrade coverage coveralls sphinx_rtd_theme
         pip install ".[dev]"
     - name: Check auto-formatters
       run: |
@@ -44,4 +44,7 @@ jobs:
         coverage run --source pyttb -m pytest tests/ --packaging
         coverage report
     - name: Upload coverage to Coveralls
-      uses: coverallsapp/github-action@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        coveralls --service=github


### PR DESCRIPTION
Following the coveralls python package suggestion here seems to resolve our issues with weird coverage in our github action. https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support

NOTE: Do we use the sphinx_rtd_theme anywhere for our current testing/deployment? I don't think so. If we do we should probably update our automation to `pip install .[dev,doc]` instead of manually specifiying the theme (manually specifying coveralls since that is only for the action makes sense still). But that's more energy than I have for this tonight.