### PR TITLE
Sptensor clarification

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,16 @@ Python API
 
    reference.rst
 
+How to Cite
+==============
+Please see `references`_ for how to cite a variety of algorithms implemented in this project.
+
+.. _references: bibtex.html
+
+.. toctree::
+   :maxdepth: 2
+
+   bibtex.rst
 
 Contact
 ================

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -122,6 +122,9 @@ class sptensor:
     ) -> sptensor:
         """
         Construct an sptensor from fully defined SUB, VAL and SIZE matrices.
+        This does no validation to optimize for speed when components are known.
+        For default initializer with error checking see
+        :func:`~pyttb.sptensor.sptensor.from_aggregator`.
 
         Parameters
         ----------


### PR DESCRIPTION
This is simpler solution to the confusion here https://github.com/sandialabs/pyttb/issues/113 basically from_data does no validation but that is not explicit in the doc string so add the clarification. More broadly I know you discussed trying to unify our constructors so the user doesn't necessarily need to think about it. It is a little verbose that the `standard` way to construct with validation is `from_aggregator`.

Also while I was checking the generated doc I saw the warning that we've never actually linked in our bibtex
 doc. We can probably provide a nicer sentence/cleanup but I figured it would be good to at least generate the set of references to original algorithms on our read the docs. It might be worth getting a fresh set of eyes from @DeepBlockDeepak on the read the docs to see what might make the documentation friendlier (probably overlaps with the tutorials and other efforts)