### PR TITLE
Enable integration with pygenten

### DIFF
--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -143,7 +143,7 @@ def cp_als(tensor, rank, stoptol=1e-4, maxiters=1000, dimorder=None,
     else:
         assert False, "The selected initialization method is not supported"
 
-    if isinstance(tensor, ttb.tensor) and genten_backend:
+    if genten_backend and (isinstance(tensor, ttb.tensor) or isinstance(tensor, ttb.sptensor)):
         # Call pygenten
         args = {}
         args['init'] = init

--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -146,29 +146,21 @@ def cp_als(tensor, rank, stoptol=1e-4, maxiters=1000, dimorder=None,
     if isinstance(tensor, ttb.tensor) and genten_backend:
         print("Genten is supported")
 
-        x = pygenten.Tensor(tensor.data)
-        u = pygenten.Ktensor(init.weights, init.factor_matrices);
-
+        # Call pygenten
         args = {}
-        args['init'] = u
+        args['init'] = init
         args['rank'] = rank
         args['maxiters'] = maxiters
         args['tol'] = stoptol
         args['printitn'] = printitn
-        u, perfInfo = pygenten.cp_als(x, **args)
+        M, perfInfo = pygenten.cp_als(tensor, **args)
 
+        # Set output
         output = {}
         output['params'] = (stoptol, maxiters, printitn, dimorder)
         output['iters'] = perfInfo.lastEntry().iteration
         output['normresidual'] = perfInfo.lastEntry().residual
         output['fit'] = perfInfo.lastEntry().fit
-
-        weights = np.array(u.weights(), copy=True)
-        U = []
-        for i in range(0, N):
-            U.append(np.array(u[i], copy=True))
-
-        M = ttb.ktensor.from_data(weights, U)
 
         # Arrange the final tensor so that the columns are normalized.
         M.arrange()

--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -148,17 +148,19 @@ def cp_als(tensor, rank, stoptol=1e-4, maxiters=1000, dimorder=None,
 
         U = init.copy().factor_matrices
 
-        pygenten.initializeKokkos()
-
         sizes = pygenten.IndxArray(N)
         sizes_np = np.array(sizes, copy=False)
         sizes_np[0:N] = tensor.shape[0:N]
 
         #print(tensor.data.flatten())
-        values = pygenten.Array(tensor.data.flatten())
+
+        # Need to transpose the numpy arrays because it always uses "C"
+        # ordering internally, whereas GenTen uses "F"
+        values = pygenten.Array(tensor.data.transpose().flatten())
         x = pygenten.Tensor(sizes, values)
 
-        weights = pygenten.Array(U[0].shape[1])
+        #weights = pygenten.Array(U[0].shape[1])
+        weights = pygenten.Array(init.weights)
         genten_factor_matrices = pygenten.FacMatArray(N)
         for i in range(0, N):
             factor_matrix = pygenten.FacMatrix(U[i])

--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -144,8 +144,6 @@ def cp_als(tensor, rank, stoptol=1e-4, maxiters=1000, dimorder=None,
         assert False, "The selected initialization method is not supported"
 
     if isinstance(tensor, ttb.tensor) and genten_backend:
-        print("Genten is supported")
-
         # Call pygenten
         args = {}
         args['init'] = init

--- a/pyttb/export_data.py
+++ b/pyttb/export_data.py
@@ -17,6 +17,9 @@ def export_data(data, filename, fmt_data=None, fmt_weights=None):
     if isinstance(data, ttb.tensor):
         print('tensor', file=fp)
         export_size(fp, data.shape)
+        # numpy always writes the array with 'C' ordering, regardless
+        # of the ordering of the array.  So we must transpose it first
+        # to preserve the convention of 'F' ordering of the file.
         export_array(fp, data.data.transpose(), fmt_data)
 
     elif isinstance(data, ttb.sptensor):

--- a/pyttb/export_data.py
+++ b/pyttb/export_data.py
@@ -17,7 +17,7 @@ def export_data(data, filename, fmt_data=None, fmt_weights=None):
     if isinstance(data, ttb.tensor):
         print('tensor', file=fp)
         export_size(fp, data.shape)
-        export_array(fp, data.data, fmt_data)
+        export_array(fp, data.data.transpose(), fmt_data)
 
     elif isinstance(data, ttb.sptensor):
         print('sptensor', file=fp)

--- a/pyttb/import_data.py
+++ b/pyttb/import_data.py
@@ -7,7 +7,7 @@ from .pyttb_utils import *
 import numpy as np
 import os
 
-def import_data(filename):
+def import_data(filename, index_base=1):
 
     # Check if file exists
     if not os.path.isfile(filename):
@@ -33,7 +33,7 @@ def import_data(filename):
     
         shape = import_shape(fp)
         nz = import_nnz(fp)
-        subs, vals = import_sparse_array(fp, len(shape), nz)
+        subs, vals = import_sparse_array(fp, len(shape), nz, index_base)
         return ttb.sptensor().from_data(subs, vals, shape)
  
     elif data_type == 'matrix':         
@@ -80,14 +80,14 @@ def import_rank(fp):
     # Import the rank of something from a file
     return int(fp.readline().strip().split(' ')[0])
 
-def import_sparse_array(fp, n, nz):
+def import_sparse_array(fp, n, nz, index_base=1):
     # Import sparse data subs and vals from coordinate format data
     subs = np.zeros((nz, n), dtype='int64')
     vals = np.zeros((nz, 1))
     for k in range(nz):
         line = fp.readline().strip().split(' ')
         # 1-based indexing in file, 0-based indexing in package
-        subs[k,:] = [np.int64(i)-1 for i in line[:-1]]
+        subs[k,:] = [np.int64(i)-index_base for i in line[:-1]]
         vals[k,0] = line[-1]
     return subs, vals
 

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -58,7 +58,8 @@ class ktensor(object):
         ----------
         weights: :class:`numpy.ndarray`
         factor_matrices: :class:`list` of :class:`numpy.ndarray` or variable number of :class:`numpy.ndarray`
-        copy: Whether to copy `weights` and 'factor_matrices` into new data
+        copy: bool
+          Whether to copy `weights` and 'factor_matrices` into new data
 
         Returns
         -------

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -100,7 +100,7 @@ class ktensor(object):
             "Input parameter 'weights' must be a numpy.array type vector."
 
         # Input can be a list or sequences of factor_matrices
-        if isinstance(factor_matrices[0], list):
+        if isinstance(factor_matrices[0], list) or isinstance(factor_matrices[0], tuple):
             _factor_matrices = [f for f in factor_matrices[0]]
         else:
             _factor_matrices = [f for f in factor_matrices[0:]]

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -47,7 +47,7 @@ class ktensor(object):
         self.factor_matrices = []    # changed from cell array to list; changed name from 'u' to 'factor_matrices'
 
     @classmethod
-    def from_data(cls, weights, *factor_matrices):
+    def from_data(cls, weights, *factor_matrices, copy=True):
         """
         Construct a :class:`pyttb.ktensor` from weights and factor matrices.
 
@@ -58,6 +58,7 @@ class ktensor(object):
         ----------
         weights: :class:`numpy.ndarray`
         factor_matrices: :class:`list` of :class:`numpy.ndarray` or variable number of :class:`numpy.ndarray`
+        copy: Whether to copy `weights` and 'factor_matrices` into new data
 
         Returns
         -------
@@ -100,9 +101,11 @@ class ktensor(object):
 
         # Input can be a list or sequences of factor_matrices
         if isinstance(factor_matrices[0], list):
-            _factor_matrices = [f.copy() for f in factor_matrices[0]]
+            _factor_matrices = [f for f in factor_matrices[0]]
         else:
-            _factor_matrices = [f.copy() for f in factor_matrices[0:]]
+            _factor_matrices = [f for f in factor_matrices[0:]]
+        if copy:
+            _factor_matrices = [f.copy() for f in _factor_matrices]
         for fm in _factor_matrices:
             assert isinstance(fm, np.ndarray), \
                 "Input parameter 'factor_matrices' must be a list of numpy.array's."
@@ -115,7 +118,9 @@ class ktensor(object):
 
         # Create ktensor and populate data members
         k = cls()
-        k.weights = weights.copy()
+        k.weights = weights;
+        if copy:
+            k.weights = weights.copy()
         if k.weights.dtype != np.float:
             print("converting weights from {} to np.float".format(k.weights.dtype))
             k.weights = k.weights.astype(np.float)

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -25,7 +25,7 @@ class tensor(object):
         self.shape = ()
 
     @classmethod
-    def from_data(cls, data, shape=None):
+    def from_data(cls, data, shape=None, copy=True):
         """
         Creates a tensor from explicit description. Note that 1D tensors (i.e., when len(shape)==1) 
         contains a data array that follow the Numpy convention of being a row vector, which is 
@@ -35,6 +35,8 @@ class tensor(object):
         ----------
         data: :class:`numpy.ndarray`
         shape: tuple
+        copy: bool
+          Whether to copy `data` into new data
 
         Returns
         -------
@@ -67,7 +69,10 @@ class tensor(object):
 
         # Create the tensor
         tensorInstance = cls()
-        tensorInstance.data = data.copy()
+        if copy:
+            tensorInstance.data = data.copy()
+        else:
+            tensorInstance.data = data
         tensorInstance.shape = shape
         return tensorInstance
 


### PR DESCRIPTION
The primary purpose of this PR is to enable integration of pygenten with pyttb.  The python package pygenten is a set of python bindings for the [GenTen](https://gitlab.com/tensors/genten) package and provides HPC-oriented implementations of several CP decomposition methods.  The changes here enable pygenten as a back-end implementation of (currently) CP-ALS, if pygenten is available.  It also adds a `copy` argument to several pyttb construction functions to allow conversions between pyttb and pygenten objects without copying the underlying data (defaulting to `True` to preserve prior behavior).  Other small changes include fixing an ordering bug when writing dense tensors to a file that I discovered in this work (numpy always writes files using "C" ordering, regardless of the ordering of the data in memory) and added an `index_base` argument  to `import_data()` to support sparse tensor files using 0-based indexing (such as those produced by GenTen).