### PR TITLE
TENSOR: Indexing is complicated.

### DIFF
--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -624,7 +624,7 @@ class sptensor:
             if self.shape != other.shape:
                 assert False, "Sptensor and tensor must be same shape for innerproduct"
             [subsSelf, valsSelf] = self.find()
-            valsOther = other[subsSelf.transpose(), "extract"]
+            valsOther = other[subsSelf, "extract"]
             return valsOther.transpose().dot(valsSelf)
 
         if isinstance(other, (ttb.ktensor, ttb.ttensor)):  # pragma: no cover
@@ -686,7 +686,7 @@ class sptensor:
 
         if isinstance(B, ttb.tensor):
             BB = sptensor.from_data(
-                self.subs, B[self.subs.transpose(), "extract"][:, None], self.shape
+                self.subs, B[self.subs, "extract"][:, None], self.shape
             )
             C = self.logical_and(BB)
             return C
@@ -1047,7 +1047,7 @@ class sptensor:
                 assert False, "Size mismatch in scale"
             return ttb.sptensor.from_data(
                 self.subs,
-                self.vals * factor[self.subs[:, dims].transpose(), "extract"][:, None],
+                self.vals * factor[self.subs[:, dims], "extract"][:, None],
                 self.shape,
             )
         if isinstance(factor, ttb.sptensor):
@@ -1807,7 +1807,7 @@ class sptensor:
             ]
 
             # Find where their nonzeros intersect
-            othervals = other[self.subs.transpose(), "extract"]
+            othervals = other[self.subs, "extract"]
             znzsubs = self.subs[(othervals[:, None] == self.vals).transpose()[0], :]
 
             return sptensor.from_data(
@@ -1888,7 +1888,7 @@ class sptensor:
                 subs1 = np.empty((0, self.subs.shape[1]))
             # find entries where x is nonzero but not equal to y
             subs2 = self.subs[
-                self.vals.transpose()[0] != other[self.subs.transpose(), "extract"], :
+                self.vals.transpose()[0] != other[self.subs, "extract"], :
             ]
             if subs2.size == 0:
                 subs2 = np.empty((0, self.subs.shape[1]))
@@ -2003,7 +2003,7 @@ class sptensor:
             )
         if isinstance(other, ttb.tensor):
             csubs = self.subs
-            cvals = self.vals * other[csubs.transpose(), "extract"][:, None]
+            cvals = self.vals * other[csubs, "extract"][:, None]
             return ttb.sptensor.from_data(csubs, cvals, self.shape)
         if isinstance(other, ttb.ktensor):
             csubs = self.subs
@@ -2125,7 +2125,7 @@ class sptensor:
 
             # self nonzero
             subs2 = self.subs[
-                self.vals.transpose()[0] <= other[self.subs.transpose(), "extract"], :
+                self.vals.transpose()[0] <= other[self.subs, "extract"], :
             ]
 
             # assemble
@@ -2213,9 +2213,7 @@ class sptensor:
             subs1 = subs1[ttb.tt_setdiff_rows(subs1, self.subs), :]
 
             # self nonzero
-            subs2 = self.subs[
-                self.vals.transpose()[0] < other[self.subs.transpose(), "extract"], :
-            ]
+            subs2 = self.subs[self.vals.transpose()[0] < other[self.subs, "extract"], :]
 
             # assemble
             subs = np.vstack((subs1, subs2))
@@ -2270,9 +2268,7 @@ class sptensor:
 
             # self nonzero
             subs2 = self.subs[
-                (
-                    self.vals >= other[self.subs.transpose(), "extract"][:, None]
-                ).transpose()[0],
+                (self.vals >= other[self.subs, "extract"][:, None]).transpose()[0],
                 :,
             ]
 
@@ -2331,9 +2327,7 @@ class sptensor:
 
             # self and other nonzero
             subs2 = self.subs[
-                (
-                    self.vals > other[self.subs.transpose(), "extract"][:, None]
-                ).transpose()[0],
+                (self.vals > other[self.subs, "extract"][:, None]).transpose()[0],
                 :,
             ]
 
@@ -2437,7 +2431,7 @@ class sptensor:
 
         if isinstance(other, ttb.tensor):
             csubs = self.subs
-            cvals = self.vals / other[csubs.transpose(), "extract"][:, None]
+            cvals = self.vals / other[csubs, "extract"][:, None]
             return ttb.sptensor.from_data(csubs, cvals, self.shape)
         if isinstance(other, ttb.ktensor):
             # TODO consider removing epsilon and generating nans consistent with above

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -364,14 +364,19 @@ def test_tensor__getitem__(sample_tensor_2way):
     # Case 2a:
     assert tensorInstance[np.array([0, 0]), "extract"] == params["data"][0, 0]
     assert (
-        tensorInstance[np.array([[0, 0], [1, 1]]), "extract"]
-        == params["data"][([0, 0], [1, 1])]
+        tensorInstance[np.array([[0, 2], [1, 1], [1, 2]]), "extract"]
+        == params["data"][([0, 1, 1], [2, 1, 2])]
     ).all()
     # Case 2a: Extract doesn't seem to be needed
-    assert tensorInstance[np.array([0, 0])] == params["data"][0, 0]
+    assert tensorInstance[np.array([[0, 0]])] == params["data"][0, 0]
     assert (
-        tensorInstance[np.array([[0, 0], [1, 1]])] == params["data"][([0, 0], [1, 1])]
+        tensorInstance[np.array([[0, 2], [1, 1], [1, 2]])]
+        == params["data"][([0, 1, 1], [2, 1, 2])]
     ).all()
+    with pytest.raises(AssertionError) as excinfo:
+        # Must use numpy arrays for subscripts
+        tensorInstance[[[0, 2], [1, 1], [1, 2]]]
+    assert "Invalid use of tensor getitem" in str(excinfo)
 
     # Case 2b: Linear Indexing
     assert tensorInstance[np.array([0])] == params["data"][0, 0]
@@ -380,6 +385,9 @@ def test_tensor__getitem__(sample_tensor_2way):
     with pytest.raises(AssertionError) as excinfo:
         tensorInstance[np.array([0]), np.array([0]), np.array([0])]
     assert "Linear indexing requires single input array" in str(excinfo)
+    assert np.array_equal(
+        tensorInstance[[0, 1, 2]], tensorInstance[np.array([0, 1, 2])]
+    )
 
 
 @pytest.mark.indevelopment


### PR DESCRIPTION
Our indexing always makes my head hurt because of the variety of paths through the logic but I think we are getting simpler/more robust. Adding this as a single commit so @DeepBlockDeepak can cherry-pick if desired to test if this unblocks the tensor tutorial work. Otherwise we can merge and iterate. See commit for the couple of changes I made. I updated our tests to cover the failure modes you described but let me know if you think I need to add something additional. 

Interface Note: MATLAB uses a lot of column vectors to resolve ambiguities but those are generally less common in python since numpy defaults to a more generic `(length,)` array. My preference is to take a list or effective row vector for linear indices and force people trying to use subscripts to always to provide a matrix `np.array([[0,1,2]])` even if the nesting isn't generically necessary.

For the exact motivation, here is the behavior off the branch which I believe aligns mostly with expectations.
```python
>>> import pyttb as ttb
>>> import numpy as np
>>> X = ttb.tensor.from_data(np.arange(1,25),(3,4,2,1))
>>> S = [[0,0,0,0],[2,3,1,0]]
>>> X[S]
Traceback (most recent call last):
  File "<path>\Anaconda3\envs\pyttb\lib\site-packages\IPython\core\interactiveshell.py", line 3505, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-6-7b0c9de99a5d>", line 1, in <module>
    X[S]
  File "<path>\pyttb\pyttb\tensor.py", line 1573, in __getitem__
    assert False, "Invalid use of tensor getitem"
AssertionError: Invalid use of tensor getitem
>>> S = np.array([[0,0,0,0],[1,1,1,0],[2,3,1,0]])
>>> X[S]
array([ 1, 17, 24])
>>> S = [0,5,6,22]
>>> X[S]
array([ 1,  6,  7, 23])
>>> X[np.array(S)]
array([ 1,  6,  7, 23])
```
