### PR TITLE
Finish Core Typing

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,12 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
@@ -17,7 +23,6 @@ sphinx:
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,6 +61,7 @@ myst_enable_extensions = [
 ]
 
 nb_execution_raise_on_error = True
+nb_execution_timeout = 60
 
 napoleon_use_param = False
 napoleon_use_rtype = False

--- a/docs/source/tutorial/CP_APR.ipynb
+++ b/docs/source/tutorial/CP_APR.ipynb
@@ -51,6 +51,7 @@
     "\n",
     "# Generate factor matrices with a few large entries in each column\n",
     "# this will be the basis of our solution.\n",
+    "np.random.seed(0) # Set seed for reproducibility\n",
     "A = []\n",
     "for n in range(len(sz)):\n",
     "    A.append(np.random.uniform(size=(sz[n], R)))\n",
@@ -80,7 +81,8 @@
    "outputs": [],
    "source": [
     "# Compute a solution\n",
-    "M = ttb.cp_apr(X, R, printitn = 10);"
+    "short_tutorial = 2  # Cut off solve early for demo\n",
+    "M = ttb.cp_apr(X, R, printitn = 10, stoptime = short_tutorial);"
    ]
   }
  ],

--- a/docs/source/tutorial/CP_APR.ipynb
+++ b/docs/source/tutorial/CP_APR.ipynb
@@ -46,7 +46,7 @@
    "outputs": [],
    "source": [
     "# Pick the size and rank\n",
-    "sz = (100, 80, 60)\n",
+    "sz = (10, 8, 6)\n",
     "R = 5\n",
     "\n",
     "# Generate factor matrices with a few large entries in each column\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ packages = ["pyttb"]
 [tool.setuptools.dynamic]
 version = {attr = "pyttb.__version__"}
 
+[tool.setuptools.package-data]
+"pyttb" = ["py.typed"]
+
 [build-system]
 requires = ["setuptools>=61.0", "numpy", "numpy_groupies", "scipy", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyttb/__init__.py
+++ b/pyttb/__init__.py
@@ -1,8 +1,10 @@
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
+from __future__ import annotations
 
 __version__ = "1.6.2"
+
 
 import warnings
 

--- a/pyttb/pyttb_utils.py
+++ b/pyttb/pyttb_utils.py
@@ -13,27 +13,26 @@ import numpy as np
 import pyttb as ttb
 
 
-def tt_to_dense_matrix(tensorInstance, mode, transpose=False):
+def tt_to_dense_matrix(
+    tensorInstance: Union[ttb.tensor, ttb.ktensor], mode: int, transpose: bool = False
+) -> np.ndarray:
     """
     Helper function to unwrap tensor into dense matrix, should replace the core need
     for tenmat
 
     Parameters
     ----------
-    tensorInstance: :class:`pyttb.tensor` or :class:`pyttb.tensor`
-        Ktensor->matrix is supported but the inverse is not
-    mode: int
-        Mode around which to unwrap tensor
-    transpose: bool
-        Whether or not to tranpose unwrapped tensor
+    tensorInstance: Tensor to matricize
+    mode: Mode around which to unwrap tensor
+    transpose: Whether or not to tranpose unwrapped tensor
 
     Returns
     -------
-    matrix: :class:`numpy.ndarray`
+    Resultant matrix.
     """
     siz = np.array(tensorInstance.shape).astype(int)
     old = np.setdiff1d(np.arange(tensorInstance.ndims), mode).astype(int)
-    permutation = np.concatenate(([mode], old))
+    permutation: np.ndarray = np.concatenate((np.array([mode]), old))
     # This mimics how tenmat handles ktensors
     # TODO check if full can be done after permutation and reshape for efficiency
     if isinstance(tensorInstance, ttb.ktensor):
@@ -47,45 +46,50 @@ def tt_to_dense_matrix(tensorInstance, mode, transpose=False):
     return matrix
 
 
-def tt_from_dense_matrix(matrix, shape, mode, idx):
+def tt_from_dense_matrix(
+    matrix: np.ndarray,
+    shape: Tuple[int, ...],
+    mode: int,
+    idx: int,
+) -> ttb.tensor:
     """
     Helper function to wrap dense matrix into tensor.
     Inverse of :class:`pyttb.tt_to_dense_matrix`
 
     Parameters
     ----------
-    matrix: :class:`numpy.ndarray`
-    mode: int
-        Mode around which tensor was unwrapped
-    idx: int
-        in {0,1}, idx of mode in matrix, s.b. 0 for tranpose=True
+    matrix: Matrix to (re-)create tensor from.
+    mode: Mode around which tensor was unwrapped
+    idx: In {0,1}, idx of mode in matrix, s.b. 0 for tranpose=True
 
     Returns
     -------
-    tensorInstance: :class:`pyttb.tensor`
+    Dense tensor.
     """
     tensorInstance = ttb.tensor.from_data(matrix)
     if idx == 0:
         tensorInstance = tensorInstance.permute(np.array([1, 0]))
     tensorInstance = tensorInstance.reshape(shape)
     tensorInstance = tensorInstance.permute(
-        np.concatenate((np.arange(1, mode + 1), [0], np.arange(mode + 1, len(shape))))
+        np.concatenate(
+            (np.arange(1, mode + 1), np.array([0]), np.arange(mode + 1, len(shape)))
+        )
     )
     return tensorInstance
 
 
-def tt_union_rows(MatrixA, MatrixB):
+def tt_union_rows(MatrixA: np.ndarray, MatrixB: np.ndarray) -> np.ndarray:
     """
     Helper function to reproduce functionality of MATLABS intersect(a,b,'rows')
 
     Parameters
     ----------
-    MatrixA: :class:`numpy.ndarray`
-    MatrixB: :class:`numpy.ndarray`
+    MatrixA: First matrix.
+    MatrixB: Second matrix.
 
     Returns
     -------
-    location: :class:`numpy.ndarray` list of intersection indices
+    location: List of intersection indices
 
     Examples
     --------
@@ -311,18 +315,18 @@ def tt_tenfun(function_handle, *inputs):  # pylint:disable=too-many-branches
     return Z
 
 
-def tt_setdiff_rows(MatrixA, MatrixB):
+def tt_setdiff_rows(MatrixA: np.ndarray, MatrixB: np.ndarray) -> np.ndarray:
     """
     Helper function to reproduce functionality of MATLABS setdiff(a,b,'rows')
 
     Parameters
     ----------
-    MatrixA: :class:`numpy.ndarray`
-    MatrixB: :class:`numpy.ndarray`
+    MatrixA: First matrix.
+    MatrixB: Second matrix.
 
     Returns
     -------
-    location: :class:`numpy.ndarray` list of set difference indices
+    List of set difference indices.
     """
     # TODO intersect and setdiff are very similar in function
     if MatrixA.size > 0:
@@ -339,18 +343,18 @@ def tt_setdiff_rows(MatrixA, MatrixB):
     return np.setdiff1d(idxA, location[np.where(location >= 0)])
 
 
-def tt_intersect_rows(MatrixA, MatrixB):
+def tt_intersect_rows(MatrixA: np.ndarray, MatrixB: np.ndarray) -> np.ndarray:
     """
     Helper function to reproduce functionality of MATLABS intersect(a,b,'rows')
 
     Parameters
     ----------
-    MatrixA: :class:`numpy.ndarray`
-    MatrixB: :class:`numpy.ndarray`
+    MatrixA: First matrix.
+    MatrixB: Second matrix.
 
     Returns
     -------
-    location: :class:`numpy.ndarray` list of intersection indices
+    location: List of intersection indices.
 
     Examples
     --------
@@ -411,7 +415,9 @@ def tt_irenumber(t: ttb.sptensor, shape: Tuple[int, ...], number_range) -> np.nd
     return newsubs
 
 
-def tt_renumber(subs, shape, number_range):
+def tt_renumber(
+    subs: np.ndarray, shape: Tuple[int, ...], number_range
+) -> Tuple[np.ndarray, Tuple[int, ...]]:
     """
     RENUMBER indices for sptensor subsref
 
@@ -424,13 +430,13 @@ def tt_renumber(subs, shape, number_range):
     Parameters
     ----------
     subs: :class:`numpy.ndarray`
-    shape: tuple
+    shape: Shape of source tensor.
     range:
 
     Returns
     -------
-    newsubs: :class:`numpy.ndarray`
-    newshape: tuple
+    newsubs: Updated subscripts.
+    newshape: Resulting shape.
     """
     newshape = np.array(shape)
     newsubs = subs
@@ -453,7 +459,7 @@ def tt_renumber(subs, shape, number_range):
     return newsubs, tuple(newshape)
 
 
-def tt_renumberdim(idx, shape, number_range):
+def tt_renumberdim(idx: np.ndarray, shape: int, number_range) -> Tuple[int, int]:
     """
     RENUMBERDIM helper function for RENUMBER
 
@@ -492,7 +498,7 @@ def tt_renumberdim(idx, shape, number_range):
 # pylint: disable=line-too-long
 # https://stackoverflow.com/questions/22699756/python-version-of-ismember-with-rows-and-index
 # For thoughts on how to speed this up
-def tt_ismember_rows(search, source):
+def tt_ismember_rows(search: np.ndarray, source: np.ndarray) -> np.ndarray:
     """
     Find location of search rows in source array
 
@@ -569,7 +575,7 @@ def tt_subsubsref(obj, s):  # pylint: disable=unused-argument
     return obj
 
 
-def tt_intvec2str(v):
+def tt_intvec2str(v: np.ndarray) -> str:
     """
     Print integer vector to a string with brackets. Numpy should already handle this so
     it is a placeholder stub
@@ -584,7 +590,7 @@ def tt_intvec2str(v):
     return np.array2string(v)
 
 
-def tt_sub2ind(shape, subs):
+def tt_sub2ind(shape: Tuple[int, ...], subs: np.ndarray) -> np.ndarray:
     """
     Converts multidimensional subscripts to linear indices.
 
@@ -610,7 +616,7 @@ def tt_sub2ind(shape, subs):
     return idx
 
 
-def tt_sizecheck(shape, nargout=True):
+def tt_sizecheck(shape: Tuple[int, ...], nargout: bool = True) -> bool:
     """
     TT_SIZECHECK Checks that the shape is valid.
 
@@ -652,7 +658,7 @@ def tt_sizecheck(shape, nargout=True):
     return ok
 
 
-def tt_subscheck(subs, nargout=True):
+def tt_subscheck(subs: np.ndarray, nargout: bool = True) -> bool:
     """
     TT_SUBSCHECK Checks for valid subscripts.
 
@@ -694,7 +700,7 @@ def tt_subscheck(subs, nargout=True):
     return ok
 
 
-def tt_valscheck(vals, nargout=True):
+def tt_valscheck(vals: np.ndarray, nargout: bool = True) -> bool:
     """
     TT_VALSCHECK Checks for valid values.
 
@@ -723,7 +729,7 @@ def tt_valscheck(vals, nargout=True):
     return ok
 
 
-def isrow(v):
+def isrow(v: np.ndarray) -> bool:
     """
     ISROW Checks if vector is a row vector.
 
@@ -741,7 +747,7 @@ def isrow(v):
     return v.ndim == 2 and v.shape[0] == 1 and v.shape[1] >= 1
 
 
-def isvector(a):
+def isvector(a: np.ndarray) -> bool:
     """
     ISVECTOR Checks if vector is a row vector.
 
@@ -760,7 +766,7 @@ def isvector(a):
 
 # TODO: this is a challenge, since it may need to apply to either Python built in types
 #  or numpy types
-def islogical(a):
+def islogical(a: np.ndarray) -> bool:
     """
     ISLOGICAL Checks if vector is a logical vector.
 

--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -154,7 +154,7 @@ class tenmat:
                         )
                     else:
                         assert False, (
-                            'Unrecognized value for cdims_cyclic pattern, must be '
+                            "Unrecognized value for cdims_cyclic pattern, must be "
                             '"fc" or "bc".'
                         )
 
@@ -189,6 +189,9 @@ class tenmat:
             tenmatInstance.cindices = cdims.copy()
             tenmatInstance.data = data.copy()
             return tenmatInstance
+        raise ValueError(
+            f"Can only create tenmat from tensor or tenmat but recieved {type(source)}"
+        )
 
     def ctranspose(self):
         """
@@ -277,15 +280,13 @@ class tenmat:
         """
         if self.data.shape == (0,):
             return ()
-        else:
-            return self.data.shape
+        return self.data.shape
 
     def __setitem__(self, key, value):
         """
         SUBSASGN Subscripted assignment for a tensor.
         """
         self.data[key] = value
-        return
 
     def __getitem__(self, item):
         """
@@ -318,7 +319,7 @@ class tenmat:
             Z = ttb.tenmat.from_tensor_type(self)
             Z.data = Z.data * other
             return Z
-        elif isinstance(other, tenmat):
+        if isinstance(other, tenmat):
             # Check that data shapes are compatible
             if not self.shape[1] == other.shape[0]:
                 assert False, (
@@ -337,19 +338,15 @@ class tenmat:
 
             if tshape == ():
                 return (self.data @ other.data)[0, 0]
-            else:
-                tenmatInstance = tenmat()
-                tenmatInstance.tshape = tshape
-                tenmatInstance.rindices = np.arange(len(self.rindices))
-                tenmatInstance.cindices = np.arange(len(other.cindices)) + len(
-                    self.rindices
-                )
-                tenmatInstance.data = self.data @ other.data
-                return tenmatInstance
-        else:
-            assert (
-                False
-            ), "tenmat multiplication only valid with scalar or tenmat objects."
+            tenmatInstance = tenmat()
+            tenmatInstance.tshape = tshape
+            tenmatInstance.rindices = np.arange(len(self.rindices))
+            tenmatInstance.cindices = np.arange(len(other.cindices)) + len(
+                self.rindices
+            )
+            tenmatInstance.data = self.data @ other.data
+            return tenmatInstance
+        assert False, "tenmat multiplication only valid with scalar or tenmat objects."
 
     def __rmul__(self, other):
         """
@@ -383,7 +380,7 @@ class tenmat:
             Z = ttb.tenmat.from_tensor_type(self)
             Z.data = Z.data + other
             return Z
-        elif isinstance(other, tenmat):
+        if isinstance(other, tenmat):
             # Check that data shapes agree
             if not self.shape == other.shape:
                 assert False, "tenmat shape mismatch."
@@ -391,8 +388,7 @@ class tenmat:
             Z = ttb.tenmat.from_tensor_type(self)
             Z.data = Z.data + other.data
             return Z
-        else:
-            assert False, "tenmat addition only valid with scalar or tenmat objects."
+        assert False, "tenmat addition only valid with scalar or tenmat objects."
 
     def __radd__(self, other):
         """
@@ -426,7 +422,7 @@ class tenmat:
             Z = ttb.tenmat.from_tensor_type(self)
             Z.data = Z.data - other
             return Z
-        elif isinstance(other, tenmat):
+        if isinstance(other, tenmat):
             # Check that data shapes agree
             if not self.shape == other.shape:
                 assert False, "tenmat shape mismatch."
@@ -434,8 +430,7 @@ class tenmat:
             Z = ttb.tenmat.from_tensor_type(self)
             Z.data = Z.data - other.data
             return Z
-        else:
-            assert False, "tenmat subtraction only valid with scalar or tenmat objects."
+        assert False, "tenmat subtraction only valid with scalar or tenmat objects."
 
     def __rsub__(self, other):
         """
@@ -455,7 +450,7 @@ class tenmat:
             Z = ttb.tenmat.from_tensor_type(self)
             Z.data = other - Z.data
             return Z
-        elif isinstance(other, tenmat):
+        if isinstance(other, tenmat):
             # Check that data shapes agree
             if not self.shape == other.shape:
                 assert False, "tenmat shape mismatch."
@@ -463,8 +458,7 @@ class tenmat:
             Z = ttb.tenmat.from_tensor_type(self)
             Z.data = other.data - Z.data
             return Z
-        else:
-            assert False, "tenmat subtraction only valid with scalar or tenmat objects."
+        assert False, "tenmat subtraction only valid with scalar or tenmat objects."
 
     def __pos__(self):
         """

--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -79,7 +79,7 @@ class tenmat:
             assert False, "tshape must be a tuple."
 
         # check that data.shape and tshape agree
-        if not np.prod(data.shape) == np.prod(tshape):
+        if np.prod(data.shape) != np.prod(tshape):
             assert False, (
                 "Incorrect dimensions specified: products of data.shape and tuple do "
                 "not match"
@@ -98,6 +98,7 @@ class tenmat:
         )
 
     @classmethod
+    # pylint: disable=too-many-branches
     def from_tensor_type(cls, source, rdims=None, cdims=None, cdims_cyclic=None):
         """
         Converts other tensor types into a tenmat
@@ -143,14 +144,13 @@ class tenmat:
                     if cdims_cyclic == "fc":
                         # cdims = [rdims+1:n, 1:rdims-1];
                         cdims = np.array(
-                            [i for i in range(rdims[0] + 1, n)]
-                            + [i for i in range(rdims[0])]
+                            list(range(rdims[0] + 1, n)) + list(range(rdims[0]))
                         )
                     elif cdims_cyclic == "bc":
                         # cdims = [rdims-1:-1:1, n:-1:rdims+1];
                         cdims = np.array(
-                            [i for i in range(rdims[0] - 1, -1, -1)]
-                            + [i for i in range(n - 1, rdims[0], -1)]
+                            list(range(rdims[0] - 1, -1, -1))
+                            + list(range(n - 1, rdims[0], -1))
                         )
                     else:
                         assert False, (
@@ -336,7 +336,7 @@ class tenmat:
                 )
             )
 
-            if tshape == ():
+            if not tshape:
                 return (self.data @ other.data)[0, 0]
             tenmatInstance = tenmat()
             tenmatInstance.tshape = tshape

--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -1,12 +1,12 @@
+"""Matricized Tensor Representation"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
+from __future__ import annotations
 
 import numpy as np
 
 import pyttb as ttb
-
-from .pyttb_utils import *
 
 
 class tenmat:
@@ -17,7 +17,7 @@ class tenmat:
 
     def __init__(self):
         """
-        TENSOR Create empty tensor.
+        Create empty tenmat.
         """
 
         # Case 0a: Empty Contructor
@@ -28,6 +28,20 @@ class tenmat:
 
     @classmethod
     def from_data(cls, data, rdims, cdims=None, tshape=None):
+        """
+        Creates a tenmat from explicit description.
+
+        Parameters
+        ----------
+        data: Tensor source data
+        rdims:
+        cdims:
+        tshape:
+
+        Returns
+        -------
+        Constructed tenmat
+        """
         # CONVERT A MULTIDIMENSIONAL ARRAY
 
         # Verify that data is a numeric numpy.ndarray
@@ -36,7 +50,8 @@ class tenmat:
         ):
             assert False, "First argument must be a numeric numpy.ndarray."
 
-        # data is empty, return empty tenmat unless rdims, cdims, or tshape are not empty
+        # data is empty, return empty tenmat unless rdims, cdims, or tshape are
+        # not empty
         if data.size == 0:
             if not rdims.size == 0 or not cdims.size == 0 or not tshape == ():
                 assert (
@@ -65,9 +80,10 @@ class tenmat:
 
         # check that data.shape and tshape agree
         if not np.prod(data.shape) == np.prod(tshape):
-            assert (
-                False
-            ), "Incorrect dimensions specified: products of data.shape and tuple do not match"
+            assert False, (
+                "Incorrect dimensions specified: products of data.shape and tuple do "
+                "not match"
+            )
 
         # check that data.shape and product of dimensions agree
         if not np.prod(np.array(tshape)[rdims]) * np.prod(
@@ -83,6 +99,20 @@ class tenmat:
 
     @classmethod
     def from_tensor_type(cls, source, rdims=None, cdims=None, cdims_cyclic=None):
+        """
+        Converts other tensor types into a tenmat
+
+        Parameters
+        ----------
+        source: Tensor type to create dense tensor from
+        rdims:
+        cdims:
+        cdims_cyclic:
+
+        Returns
+        -------
+        Constructed tenmat
+        """
         # Case 0b: Copy Contructor
         if isinstance(source, tenmat):
             # Create tenmat
@@ -123,9 +153,10 @@ class tenmat:
                             + [i for i in range(n - 1, rdims[0], -1)]
                         )
                     else:
-                        assert (
-                            False
-                        ), 'Unrecognized value for cdims_cyclic pattern, must be "fc" or "bc".'
+                        assert False, (
+                            'Unrecognized value for cdims_cyclic pattern, must be '
+                            '"fc" or "bc".'
+                        )
 
                 else:
                     # Multiple row mapping
@@ -142,9 +173,10 @@ class tenmat:
             else:
                 dims = np.hstack([rdims, cdims])
             if not len(dims) == n or not (alldims == np.sort(dims)).all():
-                assert (
-                    False
-                ), "Incorrect specification of dimensions, the sorted concatenation of rdims and cdims must be range(source.ndims)."
+                assert False, (
+                    "Incorrect specification of dimensions, the sorted concatenation "
+                    "of rdims and cdims must be range(source.ndims)."
+                )
 
             rprod = 1 if rdims.size == 0 else np.prod(np.array(tshape)[rdims])
             cprod = 1 if cdims.size == 0 else np.prod(np.array(tshape)[cdims])
@@ -228,10 +260,11 @@ class tenmat:
         -------
         float
         """
-        # default of np.linalg.norm is to vectorize the data and compute the vector norm, which is equivalent to
-        # the Frobenius norm for multidimensional arrays. However, the argument 'fro' only workks for 1-D and 2-D
+        # default of np.linalg.norm is to vectorize the data and compute the vector
+        # norm, which is equivalent to the Frobenius norm for multidimensional arrays.
+        # However, the argument 'fro' only workks for 1-D and 2-D
         # arrays currently.
-        return np.linalg.norm(self.data)
+        return float(np.linalg.norm(self.data))
 
     @property
     def shape(self):
@@ -288,9 +321,10 @@ class tenmat:
         elif isinstance(other, tenmat):
             # Check that data shapes are compatible
             if not self.shape[1] == other.shape[0]:
-                assert (
-                    False
-                ), "tenmat shape mismatch: number or columns of left operand must match number of rows of right operand."
+                assert False, (
+                    "tenmat shape mismatch: number or columns of left operand must "
+                    "match number of rows of right operand."
+                )
 
             tshape = tuple(
                 np.hstack(
@@ -332,7 +366,6 @@ class tenmat:
         return self.__mul__(other)
 
     def __add__(self, other):
-        pass
         """
         Binary addition (+) for tenmats
 
@@ -376,7 +409,6 @@ class tenmat:
         return self.__add__(other)
 
     def __sub__(self, other):
-        pass
         """
         Binary subtraction (-) for tenmats
 
@@ -470,7 +502,8 @@ class tenmat:
         Returns
         -------
         str
-            Contains the shape, row indices (rindices), column indices (cindices) and data as strings on different lines.
+            Contains the shape, row indices (rindices), column indices (cindices) and
+            data as strings on different lines.
         """
         s = ""
         s += "matrix corresponding to a tensor of shape "

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -752,7 +752,7 @@ class tensor:
         """
         return np.count_nonzero(self.data)
 
-    def norm(self) -> np.floating:
+    def norm(self) -> float:
         """
         Frobenius Norm of Tensor
 
@@ -765,7 +765,7 @@ class tensor:
         # default of np.linalg.norm is to vectorize the data and compute the vector
         # norm, which is equivalent to the Frobenius norm for multidimensional arrays.
         # However, the argument 'fro' only works for 1-D and 2-D arrays currently.
-        return np.linalg.norm(self.data)
+        return float(np.linalg.norm(self.data))
 
     def nvecs(self, n: int, r: int, flipsign: bool = True) -> np.ndarray:
         """

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -1,3 +1,4 @@
+"""Tucker Tensor Implementation"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
@@ -35,7 +36,9 @@ class ttensor:
         # Empty constructor
         # TODO explore replacing with typing protocol
         self.core: Union[tensor, sptensor] = tensor()
+        #pylint: disable=invalid-name
         self.u = []
+        # TODO consider factor_matrices to match ktensor
 
     @classmethod
     def from_data(cls, core, factors):
@@ -479,6 +482,7 @@ class ttensor:
 
         return ttensor.from_data(self.core, new_u)
 
+    #pylint: disable=too-many-branches
     def reconstruct(self, samples=None, modes=None):
         """
         Reconstruct or partially reconstruct tensor from ttensor.
@@ -540,6 +544,7 @@ class ttensor:
 
         return ttensor.from_data(self.core, new_u).full()
 
+    # pylint: disable=too-many-branches,too-many-locals
     def nvecs(self, n, r, flipsign=True):
         """
         Compute the leading mode-n vectors for a ttensor.

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -36,7 +36,7 @@ class ttensor:
         # Empty constructor
         # TODO explore replacing with typing protocol
         self.core: Union[tensor, sptensor] = tensor()
-        #pylint: disable=invalid-name
+        # pylint: disable=invalid-name
         self.u = []
         # TODO consider factor_matrices to match ktensor
 
@@ -273,7 +273,7 @@ class ttensor:
                 W.append(this_factor.transpose().dot(other_factor))
             J = other.core.ttm(W)
             return self.core.innerprod(J)
-        elif isinstance(other, (tensor, sptensor)):
+        if isinstance(other, (tensor, sptensor)):
             if self.shape != other.shape:
                 raise ValueError(
                     "ttensors must have same shape to perform an innerproduct, but "
@@ -285,14 +285,12 @@ class ttensor:
                 return Z.innerprod(other)
             Z = other.ttm(self.u, transpose=True)
             return Z.innerprod(self.core)
-        elif isinstance(other, ktensor):
+        if isinstance(other, ktensor):
             # Call ktensor implementation
-            # TODO needs ttensor ttv
             return other.innerprod(self)
-        else:
-            raise ValueError(
-                f"Inner product between ttensor and {type(other)} is not supported"
-            )
+        raise ValueError(
+            f"Inner product between ttensor and {type(other)} is not supported"
+        )
 
     def __mul__(self, other):
         """
@@ -375,8 +373,7 @@ class ttensor:
         # Create final result
         if remdims.size == 0:
             return newcore
-        else:
-            return ttensor.from_data(newcore, [self.u[dim] for dim in remdims])
+        return ttensor.from_data(newcore, [self.u[dim] for dim in remdims])
 
     def mttkrp(self, U, n):
         """
@@ -418,8 +415,7 @@ class ttensor:
             Y = self.core.ttm(V)
             tmp = Y.innerprod(self.core)
             return np.sqrt(tmp)
-        else:
-            return self.full().norm()
+        return self.full().norm()
 
     def permute(self, order):
         """
@@ -471,21 +467,21 @@ class ttensor:
         size_idx = int(not transpose)
 
         # Check that each multiplicand is the right size.
-        for i in range(len(dims)):
-            if matrix[vidx[i]].shape[size_idx] != self.shape[dims[i]]:
+        for i, dim in enumerate(dims):
+            if matrix[vidx[i]].shape[size_idx] != self.shape[dim]:
                 raise ValueError(f"Multiplicand {i} is wrong size")
 
         # Do the actual multiplications in the specified modes.
         new_u = self.u.copy()
-        for i in range(len(dims)):
+        for i, dim in enumerate(dims):
             if transpose:
-                new_u[dims[i]] = matrix[vidx[i]].transpose().dot(new_u[dims[i]])
+                new_u[dim] = matrix[vidx[i]].transpose().dot(new_u[dim])
             else:
-                new_u[dims[i]] = matrix[vidx[i]].dot(new_u[dims[i]])
+                new_u[dim] = matrix[vidx[i]].dot(new_u[dim])
 
         return ttensor.from_data(self.core, new_u)
 
-    #pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches
     def reconstruct(self, samples=None, modes=None):
         """
         Reconstruct or partially reconstruct tensor from ttensor.
@@ -537,7 +533,7 @@ class ttensor:
                 # Skip empty samples
                 new_u.append(self.u[k])
                 continue
-            elif (
+            if (
                 len(full_samples[k].shape) == 2
                 and full_samples[k].shape[-1] == shape[k]
             ):

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -8,11 +8,11 @@ from typing import Union
 
 import numpy as np
 import scipy
-import scipy.sparse as sparse
+from scipy import sparse
 
 from pyttb import ktensor
 from pyttb import pyttb_utils as ttb_utils
-from pyttb import sptenmat, sptensor, tenmat, tensor
+from pyttb import sptensor, tenmat, tensor
 from pyttb.sptensor import tt_to_sparse_matrix
 
 ALT_CORE_ERROR = "TTensor doesn't support non-tensor cores yet. Only tensor/sptensor."
@@ -104,11 +104,13 @@ class ttensor:
         for factor_idx, factor in enumerate(self.u):
             if not isinstance(factor, (np.ndarray, sparse.coo_matrix)):
                 raise ValueError(
-                    f"Factor matrices must be numpy arrays but factor {factor_idx} was {type(factor)}"
+                    f"Factor matrices must be numpy arrays but factor {factor_idx} "
+                    f" was {type(factor)}"
                 )
             if len(factor.shape) != 2:
                 raise ValueError(
-                    f"Factor matrix {factor_idx} has shape {factor.shape} and is not a matrix!"
+                    f"Factor matrix {factor_idx} has shape {factor.shape} and is not "
+                    f"a matrix!"
                 )
 
         # Verify size consistency
@@ -121,7 +123,8 @@ class ttensor:
         for factor_idx, factor in enumerate(self.u):
             if factor.shape[-1] != self.core.shape[factor_idx]:
                 raise ValueError(
-                    f"Factor matrix {factor_idx} does not have {self.core.shape[factor_idx]} columns"
+                    f"Factor matrix {factor_idx} does not have "
+                    f"{self.core.shape[factor_idx]} columns"
                 )
 
     @property
@@ -165,7 +168,7 @@ class ttensor:
         """
         recomposed_tensor = self.core.ttm(self.u)
 
-        # There is a small chance tensor could be sparse so ensure we cast that to dense.
+        # There is a small chance tensor could be sparse so cast that to dense.
         if not isinstance(recomposed_tensor, tensor):
             recomposed_tensor = tensor.from_tensor_type(recomposed_tensor)
         return recomposed_tensor
@@ -252,8 +255,9 @@ class ttensor:
         if isinstance(other, ttensor):
             if self.shape != other.shape:
                 raise ValueError(
-                    "ttensors must have same shape to perform an innerproduct, but this ttensor "
-                    f"has shape {self.shape} and the other has {other.shape}"
+                    "ttensors must have same shape to perform an innerproduct, "
+                    f" but this ttensor has shape {self.shape} and the other has "
+                    f"{other.shape}"
                 )
             if np.prod(self.core.shape) > np.prod(other.core.shape):
                 # Reverse arguments so the ttensor with the smaller core comes first.
@@ -266,8 +270,9 @@ class ttensor:
         elif isinstance(other, (tensor, sptensor)):
             if self.shape != other.shape:
                 raise ValueError(
-                    "ttensors must have same shape to perform an innerproduct, but this ttensor "
-                    f"has shape {self.shape} and the other has {other.shape}"
+                    "ttensors must have same shape to perform an innerproduct, but "
+                    f" this ttensor has shape {self.shape} and the other has "
+                    f"{other.shape}"
                 )
             if np.prod(self.shape) < np.prod(self.core.shape):
                 Z = self.full()
@@ -336,7 +341,8 @@ class ttensor:
         if isinstance(exclude_dims, (float, int)):
             exclude_dims = np.array([exclude_dims])
 
-        # Check that vector is a list of vectors, if not place single vector as element in list
+        # Check that vector is a list of vectors,
+        # if not place single vector as element in list
         if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
             return self.ttv(np.array([vector]), dims, exclude_dims)
 
@@ -587,7 +593,8 @@ class ttensor:
             v = v[:, :r]
         else:
             logging.debug(
-                "Greater than or equal to tensor.shape[n] - 1 eigenvectors requires cast to dense to solve"
+                "Greater than or equal to tensor.shape[n] - 1 eigenvectors requires "
+                "cast to dense to solve"
             )
             if sparse.issparse(Y):
                 Y = Y.toarray()

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -95,6 +95,9 @@ class ttensor:
         # Copy Constructor
         if isinstance(source, ttensor):
             return cls.from_data(source.core, source.u)
+        raise ValueError(
+            f"Can only cast ttensor to ttensor but received {type(source)}"
+        )
 
     def _validate_ttensor(self):
         """

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -3,17 +3,18 @@
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
 
+from __future__ import annotations
+
 import logging
 import textwrap
-from typing import Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import scipy
 from scipy import sparse
 
-from pyttb import ktensor
+import pyttb as ttb
 from pyttb import pyttb_utils as ttb_utils
-from pyttb import sptensor, tenmat, tensor
 from pyttb.sptensor import tt_to_sparse_matrix
 
 ALT_CORE_ERROR = "TTensor doesn't support non-tensor cores yet. Only tensor/sptensor."
@@ -25,34 +26,36 @@ class ttensor:
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Create an empty decomposed tucker tensor
 
         Returns
         -------
-        :class:`pyttb.ttensor`
+        Empty ttensor.
         """
         # Empty constructor
         # TODO explore replacing with typing protocol
-        self.core: Union[tensor, sptensor] = tensor()
+        self.core: Union[ttb.tensor, ttb.sptensor] = ttb.tensor()
         # pylint: disable=invalid-name
-        self.u = []
+        self.u: List[np.ndarray] = []
         # TODO consider factor_matrices to match ktensor
 
     @classmethod
-    def from_data(cls, core, factors):
+    def from_data(
+        cls, core: Union[ttb.tensor, ttb.sptensor], factors: List[np.ndarray]
+    ) -> ttensor:
         """
         Construct an ttensor from fully defined core tensor and factor matrices.
 
         Parameters
         ----------
-        core: :class: `ttb.tensor`
-        factors: :class:`list(numpy.ndarray)`
+        core: Core of tucker tensor.
+        factors: Factor matrices.
 
         Returns
         -------
-        :class:`pyttb.ttensor`
+        Constructed tucket tensor.
 
         Examples
         --------
@@ -70,7 +73,7 @@ class ttensor:
         >>> K0 = ttb.ttensor.from_data(core, factors)
         """
         ttensorInstance = ttensor()
-        if isinstance(core, (tensor, sptensor)):
+        if isinstance(core, (ttb.tensor, ttb.sptensor)):
             ttensorInstance.core = core.from_tensor_type(core)
             ttensorInstance.u = factors.copy()
         else:
@@ -80,7 +83,7 @@ class ttensor:
         return ttensorInstance
 
     @classmethod
-    def from_tensor_type(cls, source):
+    def from_tensor_type(cls, source: ttensor) -> ttensor:
         """
         Converts other tensor types into a ttensor
 
@@ -100,12 +103,7 @@ class ttensor:
         )
 
     def _validate_ttensor(self):
-        """
-        Verifies the validity of constructed ttensor
-
-        Returns
-        -------
-        """
+        """Verifies the validity of constructed ttensor"""
         # Confirm all factors are matrices
         for factor_idx, factor in enumerate(self.u):
             if not isinstance(factor, (np.ndarray, sparse.coo_matrix)):
@@ -134,14 +132,8 @@ class ttensor:
                 )
 
     @property
-    def shape(self):
-        """
-        Shape of the tensor this deconstruction represents.
-
-        Returns
-        -------
-        tuple(int)
-        """
+    def shape(self) -> Tuple[int, ...]:
+        """Shape of the tensor this deconstruction represents."""
         return tuple(factor.shape[0] for factor in self.u)
 
     def __repr__(self):  # pragma: no cover
@@ -164,55 +156,47 @@ class ttensor:
 
     __str__ = __repr__
 
-    def full(self):
-        """
-        Convert a ttensor to a (dense) tensor.
-
-        Returns
-        -------
-        :class:`pyttb.tensor`
-        """
+    def full(self) -> ttb.tensor:
+        """Convert a ttensor to a (dense) tensor."""
         recomposed_tensor = self.core.ttm(self.u)
 
         # There is a small chance tensor could be sparse so cast that to dense.
-        if not isinstance(recomposed_tensor, tensor):
-            recomposed_tensor = tensor.from_tensor_type(recomposed_tensor)
+        if not isinstance(recomposed_tensor, ttb.tensor):
+            recomposed_tensor = ttb.tensor.from_tensor_type(recomposed_tensor)
         return recomposed_tensor
 
-    def double(self):
+    def double(self) -> np.ndarray:
         """
         Convert ttensor to an array of doubles
 
         Returns
         -------
-        :class:`numpy.ndarray`
-            copy of tensor data
+        Copy of tensor data.
         """
         return self.full().double()
 
     @property
-    def ndims(self):
+    def ndims(self) -> int:
         """
         Number of dimensions of a ttensor.
 
         Returns
         -------
-        int
-            Number of dimensions of ttensor
+        Number of dimensions of ttensor
         """
         return len(self.u)
 
-    def isequal(self, other):
+    def isequal(self, other: ttensor) -> bool:
         """
         Component equality for ttensors
 
         Parameters
         ----------
-        other: :class:`pyttb.ttensor`
+        other: TTensor to compare against.
 
         Returns
         -------
-        bool: True if ttensors decompositions are identical, false otherwise
+        True if ttensors decompositions are identical, false otherwise
         """
         if not isinstance(other, ttensor):
             return False
@@ -245,18 +229,17 @@ class ttensor:
 
         return ttensor.from_data(-self.core, self.u)
 
-    def innerprod(self, other):
+    def innerprod(self, other: Union[ttb.tensor, ttb.sptensor, ttb.ktensor]) -> float:
         """
         Efficient inner product with a ttensor
 
         Parameters
         ----------
-        other: :class:`pyttb.tensor`, :class:`pyttb.sptensor`, :class:`pyttb.ktensor`,
-        :class:`pyttb.ttensor`
+        other: Tensor to take an innerproduct with.
 
         Returns
         -------
-        float
+        Result of the innerproduct.
         """
         if isinstance(other, ttensor):
             if self.shape != other.shape:
@@ -273,7 +256,7 @@ class ttensor:
                 W.append(this_factor.transpose().dot(other_factor))
             J = other.core.ttm(W)
             return self.core.innerprod(J)
-        if isinstance(other, (tensor, sptensor)):
+        if isinstance(other, (ttb.tensor, ttb.sptensor)):
             if self.shape != other.shape:
                 raise ValueError(
                     "ttensors must have same shape to perform an innerproduct, but "
@@ -285,7 +268,7 @@ class ttensor:
                 return Z.innerprod(other)
             Z = other.ttm(self.u, transpose=True)
             return Z.innerprod(self.core)
-        if isinstance(other, ktensor):
+        if isinstance(other, ttb.ktensor):
             # Call ktensor implementation
             return other.innerprod(self)
         raise ValueError(
@@ -327,7 +310,12 @@ class ttensor:
             return self.__mul__(other)
         raise ValueError("This object cannot be multiplied by ttensor")
 
-    def ttv(self, vector, dims=None, exclude_dims=None):
+    def ttv(
+        self,
+        vector: Union[List[np.ndarray], np.ndarray],
+        dims: Optional[Union[int, np.ndarray]] = None,
+        exclude_dims: Optional[Union[int, np.ndarray]] = None,
+    ) -> Union[float, ttensor]:
         """
         TTensor times vector
 
@@ -347,8 +335,12 @@ class ttensor:
 
         # Check that vector is a list of vectors,
         # if not place single vector as element in list
-        if len(vector) > 0 and isinstance(vector[0], (int, float, np.int_, np.float_)):
-            return self.ttv(np.array([vector]), dims, exclude_dims)
+        if (
+            len(vector) > 0
+            and isinstance(vector, np.ndarray)
+            and isinstance(vector[0], (int, float, np.int_, np.float_))
+        ):
+            return self.ttv([vector], dims, exclude_dims)
 
         # Get sorted dims and index for multiplicands
         dims, vidx = ttb_utils.tt_dimscheck(self.ndims, len(vector), dims, exclude_dims)
@@ -362,7 +354,7 @@ class ttensor:
         remdims = np.setdiff1d(np.arange(0, self.ndims), dims)
 
         # Create W to multiply with core, only populated remaining dims
-        W = [None] * self.ndims
+        W = [np.empty(())] * self.ndims
         for i in range(dims.size):
             dim_idx = dims[i]
             W[dim_idx] = self.u[dim_idx].transpose().dot(vector[vidx[i]])
@@ -372,10 +364,11 @@ class ttensor:
 
         # Create final result
         if remdims.size == 0:
-            return newcore
+            assert not isinstance(newcore, (ttb.tensor, ttb.sptensor))
+            return float(newcore)
         return ttensor.from_data(newcore, [self.u[dim] for dim in remdims])
 
-    def mttkrp(self, U, n):
+    def mttkrp(self, U: Union[ttb.ktensor, List[np.ndarray]], n: int) -> np.ndarray:
         """
         Matricized tensor times Khatri-Rao product for ttensors.
 
@@ -390,7 +383,7 @@ class ttensor:
         """
         # NOTE: MATLAB version calculates an unused R here
 
-        W = [None] * self.ndims
+        W = [np.empty(())] * self.ndims
         for i in range(0, self.ndims):
             if i == n:
                 continue
@@ -401,12 +394,12 @@ class ttensor:
         # Find each column of answer by multiplying by weights
         return self.u[n].dot(Y)
 
-    def norm(self):
+    def norm(self) -> float:
         """
         Compute the norm of a ttensor.
         Returns
         -------
-        norm: float, Frobenius norm of Tensor
+        Frobenius norm of Tensor.
         """
         if np.prod(self.shape) > np.prod(self.core.shape):
             V = []
@@ -417,17 +410,22 @@ class ttensor:
             return np.sqrt(tmp)
         return self.full().norm()
 
-    def permute(self, order):
+    def permute(self, order: np.ndarray) -> ttensor:
         """
-        Permute dimensions for a ttensor
+        Permute :class:`pyttb.ttensor` dimensions.
+
+        Rearranges the dimensions of a :class:`pyttb.ttensor` so that they are
+        in the order specified by `order`. The corresponding ttensor has the
+        same components as `self` but the order of the subscripts needed to
+        access any particular element is rearranged as specified by `order`.
 
         Parameters
         ----------
-        order: :class:`Numpy.ndarray`
+        order: Permutation of [0,...,self.ndims].
 
         Returns
         -------
-        :class:`pyttb.ttensor`
+        Permuted :class:`pyttb.ttensor`.
         """
         if not np.array_equal(np.arange(0, self.ndims), np.sort(order)):
             raise ValueError("Invalid permutation")
@@ -435,23 +433,28 @@ class ttensor:
         new_u = [self.u[idx] for idx in order]
         return ttensor.from_data(new_core, new_u)
 
-    def ttm(self, matrix, dims=None, exclude_dims=None, transpose=False):
+    def ttm(
+        self,
+        matrix: Union[np.ndarray, List[np.ndarray]],
+        dims: Optional[Union[float, np.ndarray]] = None,
+        exclude_dims: Optional[Union[int, np.ndarray]] = None,
+        transpose: bool = False,
+    ) -> ttensor:
         """
         Tensor times matrix for ttensor
 
         Parameters
         ----------
-        matrix: :class:`Numpy.ndarray`, list[:class:`Numpy.ndarray`]
-        dims: :class:`Numpy.ndarray`, int
-        transpose: bool
+        matrix: Matrix or matrices to multiple by
+        dims: Dimensions to multiply against
+        exclude_dims: Use all dimensions but these
+        transpose: Transpose matrices during multiplication
         """
         if dims is None and exclude_dims is None:
             dims = np.arange(self.ndims)
         elif isinstance(dims, list):
             dims = np.array(dims)
-        elif np.isscalar(dims):
-            if dims < 0:
-                raise ValueError("Negative dims is currently unsupported, see #62")
+        elif isinstance(dims, (float, int, np.generic)):
             dims = np.array([dims])
 
         if isinstance(exclude_dims, (float, int)):
@@ -482,7 +485,11 @@ class ttensor:
         return ttensor.from_data(self.core, new_u)
 
     # pylint: disable=too-many-branches
-    def reconstruct(self, samples=None, modes=None):
+    def reconstruct(
+        self,
+        samples: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
+        modes: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
+    ) -> ttb.tensor:
         """
         Reconstruct or partially reconstruct tensor from ttensor.
 
@@ -500,6 +507,13 @@ class ttensor:
         if full_tensor_sampling:
             return self.full()
 
+        if modes is not None and samples is None:
+            raise ValueError(
+                "Samples can be provided without modes, but samples must be provided "
+                "with modes."
+            )
+        assert samples is not None
+
         if modes is None:
             modes = np.arange(self.ndims)
         elif isinstance(modes, list):
@@ -512,10 +526,10 @@ class ttensor:
         elif not isinstance(samples, list):
             samples = [samples]
 
-        unequal_lengths = len(samples) != len(modes)
+        unequal_lengths = len(samples) > 0 and len(samples) != len(modes)
         if unequal_lengths:
             raise ValueError(
-                "If samples and modes provides lengths must be equal, but "
+                "If samples and modes provided lengths must be equal, but "
                 f"samples had length {len(samples)} and modes {len(modes)}"
             )
 
@@ -544,7 +558,7 @@ class ttensor:
         return ttensor.from_data(self.core, new_u).full()
 
     # pylint: disable=too-many-branches,too-many-locals
-    def nvecs(self, n, r, flipsign=True):
+    def nvecs(self, n: int, r: int, flipsign: bool = True) -> np.ndarray:
         """
         Compute the leading mode-n vectors for a ttensor.
 
@@ -556,7 +570,7 @@ class ttensor:
 
         Returns
         -------
-        :class:`numpy.ndarray`
+        Computed eigenvectors.
         """
         # Compute inner product of all n-1 factors
         V = []
@@ -567,17 +581,17 @@ class ttensor:
                 V.append(factor.transpose().dot(factor))
         H = self.core.ttm(V)
 
-        if isinstance(H, sptensor):
+        if isinstance(H, ttb.sptensor):
             HnT = tt_to_sparse_matrix(H, n, True)
         else:
-            HnT = tenmat.from_tensor_type(H.full(), cdims=np.array([n])).double()
+            HnT = ttb.tenmat.from_tensor_type(H.full(), cdims=np.array([n])).double()
 
         G = self.core
 
-        if isinstance(G, sptensor):
+        if isinstance(G, ttb.sptensor):
             GnT = tt_to_sparse_matrix(G, n, True)
         else:
-            GnT = tenmat.from_tensor_type(G.full(), cdims=np.array([n])).double()
+            GnT = ttb.tenmat.from_tensor_type(G.full(), cdims=np.array([n])).double()
 
         # Compute Xn * Xn'
         # Big hack because if RHS is sparse wrong dot product is used

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -33,6 +33,7 @@ def test_linting():
         ttb.pyttb_utils.__file__,
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.khatrirao.__name__}.py"),
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.ktensor.__name__}.py"),
+        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.ttensor.__name__}.py"),
     ]
     # TODO pylint fails to import pyttb in tests
     # add mypy check

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -34,6 +34,7 @@ def test_linting():
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.khatrirao.__name__}.py"),
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.ktensor.__name__}.py"),
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.ttensor.__name__}.py"),
+        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tenmat.__name__}.py"),
     ]
     # TODO pylint fails to import pyttb in tests
     # add mypy check

--- a/tests/test_tenmat.py
+++ b/tests/test_tenmat.py
@@ -350,6 +350,10 @@ def test_tenmat_initialization_from_tensor_type(
             a = ttb.tenmat.from_tensor_type(tensorInstance, d[0], d[1], tshape)
         assert exc in str(excinfo)
 
+    # Incorrect source type
+    with pytest.raises(ValueError):
+        ttb.tenmat.from_tensor_type("not a tensor")
+
 
 @pytest.mark.indevelopment
 def test_tenmat_ctranspose(sample_tenmat_4way):

--- a/tests/test_ttensor.py
+++ b/tests/test_ttensor.py
@@ -91,7 +91,7 @@ def test_ttensor_initialization_from_tensor_type(sample_ttensor):
 
     # Negative test
     with pytest.raises(ValueError):
-        ttb.ttensor.from_tensor_type('Not a ttensor')
+        ttb.ttensor.from_tensor_type("Not a ttensor")
 
 
 @pytest.mark.indevelopment

--- a/tests/test_ttensor.py
+++ b/tests/test_ttensor.py
@@ -89,6 +89,10 @@ def test_ttensor_initialization_from_tensor_type(sample_ttensor):
     assert ttensorCopy.u == ttensorInstance.u
     assert ttensorCopy.shape == ttensorInstance.shape
 
+    # Negative test
+    with pytest.raises(ValueError):
+        ttb.ttensor.from_tensor_type('Not a ttensor')
+
 
 @pytest.mark.indevelopment
 def test_ttensor_full(sample_ttensor):

--- a/tests/test_ttensor.py
+++ b/tests/test_ttensor.py
@@ -369,6 +369,9 @@ def test_ttensor_reconstruct(random_ttensor):
     with pytest.raises(ValueError):
         _ = ttensorInstance.reconstruct(1, [0, 1])
 
+    with pytest.raises(ValueError):
+        ttensorInstance.reconstruct(modes=np.array([1]))
+
 
 @pytest.mark.indevelopment
 def test_ttensor_nvecs(random_ttensor):


### PR DESCRIPTION
This covers linting and typing for TTENSOR, TENMAT, and PYTTB_UTILS.

For users of the data structures as a toolbox this should be sufficient typing coverage to be interesting/useful. So additionally I added [py.typed](https://peps.python.org/pep-0561/) to the package so next release it will be incorporated in the wheel. With the ktensor changes next release probably needs to be 1.7 anyway.

I updated the ticket to cover the [algorithms](https://github.com/sandialabs/pyttb/issues/63) next. There are definitely quality of life improvements around centralizing some common logic and types to make consistency easier. But IMO the primary value is getting initial coverage everywhere so the lay of the land is a bit clearer.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--190.org.readthedocs.build/en/190/

<!-- readthedocs-preview pyttb end -->