### PR TITLE
MYST_NB: Raise exception if notebook fails in doc build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,8 @@ myst_enable_extensions = [
     "dollarmath",
 ]
 
+nb_execution_raise_on_error = True
+
 napoleon_use_param = False
 napoleon_use_rtype = False
 


### PR DESCRIPTION
I think it was a one line config to make rtd preview operate as expected.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--191.org.readthedocs.build/en/191/

<!-- readthedocs-preview pyttb end -->