### PR TITLE
Finish Typing/Linting Pyttb Initial Support

### DIFF
--- a/pyttb/__init__.py
+++ b/pyttb/__init__.py
@@ -1,3 +1,4 @@
+"""Entrypoint for Python Tensor Toolbox"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
@@ -29,6 +30,7 @@ from pyttb.tucker_als import tucker_als
 
 
 def ignore_warnings(ignore=True):
+    """Helper to disable warnings"""
     if ignore:
         warnings.simplefilter("ignore")
     else:

--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -27,38 +27,46 @@ def cp_als(
 
     Parameters
     ----------
-    input_tensor: Tensor to decompose
-    rank: Rank of the decomposition
-    stoptol: Tolerance used for termination - when the change in the fitness function
+    input_tensor:
+        Tensor to decompose
+    rank:
+        Rank of the decomposition
+    stoptol:
+        Tolerance used for termination - when the change in the fitness function
         in successive iterations drops below this value, the iterations terminate
-    dimorder: Order to loop through dimensions (default: [range(tensor.ndims)])
-    maxiters: Maximum number of iterations
-    init: str or :class:`pyttb.ktensor`
+    dimorder:
+        Order to loop through dimensions (default: [range(tensor.ndims)])
+    maxiters:
+        Maximum number of iterations
+    init:
         Initial guess (default: "random")
-
-             * "random": initialize using a :class:`pyttb.ktensor` with values chosen
-                from a Normal distribution with mean 0 and standard deviation 1
-             * "nvecs": initialize factor matrices of a :class:`pyttb.ktensor` using
-                the eigenvectors of the outer product of the matricized input tensor
-             * :class:`pyttb.ktensor`: initialize using a specific
-                :class:`pyttb.ktensor` as input - must be the same shape as the input
-                tensor and have the same rank as the input rank
-
-    printitn: Number of iterations to perform before printing iteration status - 0 for
+         * "random": initialize using a :class:`pyttb.ktensor` with values chosen
+            from a Normal distribution with mean 0 and standard deviation 1
+         * "nvecs": initialize factor matrices of a :class:`pyttb.ktensor` using
+            the eigenvectors of the outer product of the matricized input tensor
+         * :class:`pyttb.ktensor`: initialize using a specific
+            :class:`pyttb.ktensor` as input - must be the same shape as the input
+            tensor and have the same rank as the input rank
+    printitn:
+        Number of iterations to perform before printing iteration status - 0 for
         no status printing
-    fixsigns: Align the signs of the columns of the factorization to align with the
+    fixsigns:
+        Align the signs of the columns of the factorization to align with the
         input tensor data
 
     Returns
     -------
-    M: Resulting ktensor from CP-ALS factorization
-    Minit: Initial guess
-    output: Information about the computation. Dictionary keys:
-        * `params` : tuple of (stoptol, maxiters, printitn, dimorder)
-        * `iters`: number of iterations performed
-        * `normresidual`: norm of the difference between the input tensor
+    M:
+        Resulting ktensor from CP-ALS factorization
+    Minit:
+        Initial guess
+    output:
+        Information about the computation. Dictionary keys:
+         * `params` : tuple of (stoptol, maxiters, printitn, dimorder)
+         * `iters`: number of iterations performed
+         * `normresidual`: norm of the difference between the input tensor
             and ktensor factorization
-        * `fit`: value of the fitness function (fraction of tensor data
+         * `fit`: value of the fitness function (fraction of tensor data
             explained by the model)
 
     Example

--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -2,6 +2,9 @@
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 
@@ -10,31 +13,26 @@ import pyttb as ttb
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 def cp_als(
-    input_tensor,
-    rank,
-    stoptol=1e-4,
-    maxiters=1000,
-    dimorder=None,
-    init="random",
-    printitn=1,
-    fixsigns=True,
-):
+    input_tensor: Union[ttb.tensor, ttb.sptensor],
+    rank: int,
+    stoptol: float = 1e-4,
+    maxiters: int = 1000,
+    dimorder: Optional[List[int]] = None,
+    init: Union[Literal["random"], Literal["nvecs"], ttb.ktensor] = "random",
+    printitn: int = 1,
+    fixsigns: bool = True,
+) -> Tuple[ttb.ktensor, ttb.ktensor, Dict]:
     """
     Compute CP decomposition with alternating least squares
 
     Parameters
     ----------
     input_tensor: Tensor to decompose
-    rank: int
-        Rank of the decomposition
-    stoptol: float
-        Tolerance used for termination - when the change in the fitness function
+    rank: Rank of the decomposition
+    stoptol: Tolerance used for termination - when the change in the fitness function
         in successive iterations drops below this value, the iterations terminate
-        (default: 1e-4)
-    dimorder: list
-        Order to loop through dimensions (default: [range(tensor.ndims)])
-    maxiters: int
-        Maximum number of iterations (default: 1000)
+    dimorder: Order to loop through dimensions (default: [range(tensor.ndims)])
+    maxiters: Maximum number of iterations
     init: str or :class:`pyttb.ktensor`
         Initial guess (default: "random")
 
@@ -46,28 +44,22 @@ def cp_als(
                 :class:`pyttb.ktensor` as input - must be the same shape as the input
                 tensor and have the same rank as the input rank
 
-    printitn: int
-        Number of iterations to perform before printing iteration status - 0 for no
-            status printing (default: 1)
-    fixsigns: bool
-        Align the signs of the columns of the factorization to align with the input
-            tensor data (default: True)
+    printitn: Number of iterations to perform before printing iteration status - 0 for
+        no status printing
+    fixsigns: Align the signs of the columns of the factorization to align with the
+        input tensor data
 
     Returns
     -------
-    M: :class:`pyttb.ktensor`
-        Resulting ktensor from CP-ALS factorization
-    Minit: :class:`pyttb.ktensor`
-        Initial guess
-    output: dict
-        Information about the computation. Dictionary keys:
-
-            * `params` : tuple of (stoptol, maxiters, printitn, dimorder)
-            * `iters`: number of iterations performed
-            * `normresidual`: norm of the difference between the input tensor
-                and ktensor factorization
-            * `fit`: value of the fitness function (fraction of tensor data
-                explained by the model)
+    M: Resulting ktensor from CP-ALS factorization
+    Minit: Initial guess
+    output: Information about the computation. Dictionary keys:
+        * `params` : tuple of (stoptol, maxiters, printitn, dimorder)
+        * `iters`: number of iterations performed
+        * `normresidual`: norm of the difference between the input tensor
+            and ktensor factorization
+        * `fit`: value of the fitness function (fraction of tensor data
+            explained by the model)
 
     Example
     -------
@@ -128,7 +120,7 @@ def cp_als(
     normX = input_tensor.norm()
 
     # Set up dimorder if not specified
-    if not dimorder:
+    if dimorder is None:
         dimorder = list(range(N))
     else:
         if not isinstance(dimorder, list):
@@ -268,11 +260,12 @@ def cp_als(
             fit = 1 - (normresidual / normX)  # fraction explained by model
         print(f" Final f = {fit:e}")
 
-    output = {}
-    output["params"] = (stoptol, maxiters, printitn, dimorder)
-    output["iters"] = iteration
-    output["normresidual"] = normresidual
-    output["fit"] = fit
+    output = {
+        "params": (stoptol, maxiters, printitn, dimorder),
+        "iters": iteration,
+        "normresidual": normresidual,
+        "fit": fit,
+    }
 
     return M, init, output
 

--- a/pyttb/cp_apr.py
+++ b/pyttb/cp_apr.py
@@ -772,30 +772,31 @@ def tt_cp_apr_pqnr(
 
     Parameters
     ----------
-    input_tensor: Union[:class:`pyttb.tensor`,:class:`pyttb.sptensor`]
+    input_tensor:
+        Tensor to decompose
     rank: int
         Rank of the decomposition
-    init: str or :class:`pyttb.ktensor`
+    init:
         Initial guess
-    stoptol: float
+    stoptol:
         Tolerance on overall KKT violation
-    stoptime: float
+    stoptime:
         Maximum number of seconds to run
-    maxiters: int
+    maxiters:
         Maximum number of iterations
-    maxinneriters: int
+    maxinneriters:
         Maximum inner iterations per outer iteration
-    epsDivZero: float
+    epsDivZero:
         Safeguard against divide by zero
-    printitn: int
+    printitn:
         Print every n outer iterations, 0 for none
-    printinneritn: int
+    printinneritn:
         Print every n inner iterations
-    epsActive: float
+    epsActive:
         PDNR & PQNR ALGORITHM PARAMETER: Bertsekas tolerance for active set
-    lbfgsMem: int
+    lbfgsMem:
         Number of vector pairs to store for L-BFGS
-    precompinds: bool
+    precompinds:
         Precompute sparse tensor indices
 
     Returns
@@ -1176,13 +1177,19 @@ def tt_calcpi_prowsubprob(
 
     Parameters
     ----------
-    Data :class:`pyttb.sptensor` or :class:`pyttb.tensor`
-    isSparse: bool
-    Model :class:`pyttb.ktensor`
-    rank: int
-    factorIndex: int
-    ndims: int
-    sparse_indices: list
+    Data:
+        Tensor to compute subproblem for.
+    isSparse:
+        Flag to determine if sparse subproblem.
+    Model:
+        Current decomposition.
+    rank:
+        Rank of solution.
+    factorIndex:
+        Which factor to solve
+    ndims:
+        Number of dimensions
+    sparse_indices:
         Indices of row subproblem nonzero elements
 
     Returns
@@ -1229,12 +1236,15 @@ def calc_partials(
 
     Parameters
     ----------
-    isSparse: bool
-    Pi: :class:`numpy.ndarray`
-    epsilon: float
-        Prevent division by zero
-    data_row: :class:`numpy.ndarray`
-    model_row: :class:`numpy.ndarray`
+    isSparse:
+        Flag if sparse subproblem.
+    Pi:
+    epsilon:
+        Prevent division by zero.
+    data_row:
+        Row of data for subproblem.
+    model_row:
+        Row of model for subproblem.
 
     Returns
     -------
@@ -1271,18 +1281,18 @@ def get_search_dir_pdnr(
 
     Parameters
     ----------
-    Pi: :class:`numpy.ndarray`
-    ups_row: :class:`numpy.ndarray`
+    Pi:
+    ups_row:
         intermediate quantity (upsilon) used for second derivatives
-    rank: int
+    rank:
         number of variables for the row subproblem
-    gradModel:  :class:`numpy.ndarray`
+    gradModel:
         gradient vector for the row subproblem
-    model_row: :class:`numpy.ndarray`
+    model_row:
         vector of variables for the row subproblem
-    mu: float
+    mu:
         damping parameter
-    epsActSet: float
+    epsActSet:
         Bertsekas tolerance for active set determination
 
     Returns
@@ -1370,29 +1380,29 @@ def tt_linesearch_prowsubprob(
 
     Parameters
     ----------
-    direction:  :class:`numpy.ndarray`
+    direction:
         search direction
-    grad:  :class:`numpy.ndarray`
+    grad:
         gradient vector a model_old
-    model_old:  :class:`numpy.ndarray`
+    model_old:
         current variable values
-    step_len: float
+    step_len:
         initial step length, which is the maximum possible step length
-    step_red: float
+    step_red:
         step reduction factor (suggest 1/2)
-    max_steps: int
+    max_steps:
         maximum number of steps to try (suggest 10)
-    suff_decr: float
+    suff_decr:
         sufficent decrease for convergence (suggest 1.0e-4)
-    isSparse: bool
+    isSparse:
         sparsity flag for computing the objective
-    data_row:  :class:`numpy.ndarray`
+    data_row:
         row subproblem data, for computing the objective
-    Pi:  :class:`numpy.ndarray`
+    Pi:
         Pi matrix, for computing the objective
-    phi_row:  :class:`numpy.ndarray`
+    phi_row:
         1-grad, more accurate if failing over to multiplicative update
-    display_warning: bool
+    display_warning:
         Flag to display warning messages or not
 
     Returns
@@ -1487,10 +1497,10 @@ def get_hessian(
 
     Parameters
     ----------
-    upsilon: :class:`numpy.ndarray`
+    upsilon:
         intermediate quantity (upsilon) used for second derivatives
-    Pi: :class:`numpy.ndarray`
-    free_indices: list
+    Pi:
+    free_indices:
 
     Returns
     -------
@@ -1521,13 +1531,13 @@ def tt_loglikelihood_row(
 
     Parameters
     ----------
-    isSparse: bool
+    isSparse:
         Sparsity flag
-    data_row: :class:`numpy.ndarray`
+    data_row:
         vector of data values
-    model_row: :class:`numpy.ndarray`
+    model_row:
         vector of model values
-    Pi: :class:`numpy.ndarray`
+    Pi:
 
     Notes
     -----
@@ -1580,21 +1590,21 @@ def get_search_dir_pqnr(
 
     Parameters
     ----------
-    model_row: :class:`numpy.ndarray`
+    model_row:
         current variable values
-    gradModel: :class:`numpy.ndarray`
+    gradModel:
         gradient at model_row
-    epsActSet: float
+    epsActSet:
         Bertsekas tolerance for active set determination
-    delta_model: :class:`numpy.ndarray`
+    delta_model:
         L-BFGS array of variable deltas
-    delta_grad: :class:`numpy.ndarray`
+    delta_grad:
         L-BFGS array of gradient deltas
     rho:
-    lbfgs_pos: int
+    lbfgs_pos:
         pointer into L-BFGS arrays
     iters:
-    disp_warn: bool
+    disp_warn:
 
     Returns
     -------
@@ -1677,16 +1687,16 @@ def calc_grad(
 
     Parameters
     ----------
-    isSparse: bool
-    Pi: :class:`numpy.ndarray`
-    eps_div_zero: float
-    data_row: :class:`numpy.ndarray`
-    model_row: :class:`numpy.ndarray`
+    isSparse:
+    Pi:
+    eps_div_zero:
+    data_row:
+    model_row:
 
     Returns
     -------
-    phi_row: :class:`numpy.ndarray`
-    grad_row: :class:`numpy.ndarray`
+    phi_row:
+    grad_row:
 
     """
     # TODO: note this is duplicated exactly from calc_partials, should
@@ -1717,15 +1727,15 @@ def calculate_pi(
 
     Parameters
     ----------
-    Data: :class:`pyttb.sptensor` or :class:`pyttb.tensor`
-    Model: :class:`pyttb.ktensor`
-    rank: int
-    factorIndex: int
-    ndims: int
+    Data:
+    Model:
+    rank:
+    factorIndex:
+    ndims:
 
     Returns
     -------
-    Pi: :class:`numpy.ndarray`
+    Pi:
     """
     if isinstance(Data, ttb.sptensor):
         Pi = np.ones((Data.nnz, rank))
@@ -1755,12 +1765,12 @@ def calculate_phi(
 
     Parameters
     ----------
-    Data: :class:`pyttb.sptensor` or :class:`pyttb.tensor`
-    Model: :class:`pyttb.ktensor`
-    rank: int
-    factorIndex: int
-    Pi: :class:`numpy.ndarray`
-    epsilon: float
+    Data:
+    Model:
+    rank:
+    factorIndex:
+    Pi:
+    epsilon:
 
     Returns
     -------
@@ -1796,12 +1806,12 @@ def tt_loglikelihood(
 
     Parameters
     ----------
-    Data: :class:`pyttb.sptensor` or :class:`pyttb.tensor`
-    Model: :class:`pyttb.ktensor`
+    Data:
+    Model:
 
     Returns
     -------
-    loglikelihood: float
+    loglikelihood:
         - (sum_i m_i - x_i * log_i) with i as a multiindex across all tensor dimensions
 
     Notes
@@ -1844,11 +1854,11 @@ def vectorize_for_mu(matrix: np.ndarray) -> np.ndarray:
 
     Parameters
     ----------
-    matrix: :class:`numpy.ndarray`
+    matrix:
 
     Returns
     -------
-    matrix: :class:`numpy.ndarray`
-        len(matrix.shape)==1
+    matrix:
+        Unraveled matrix len(matrix.shape)==1
     """
     return matrix.ravel()

--- a/pyttb/export_data.py
+++ b/pyttb/export_data.py
@@ -1,17 +1,22 @@
+"""Utilities for saving tensor data"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
+from __future__ import annotations
 
-import os
+from typing import Optional, TextIO, Tuple, Union
 
 import numpy as np
 
 import pyttb as ttb
 
-from .pyttb_utils import *
 
-
-def export_data(data, filename, fmt_data=None, fmt_weights=None):
+def export_data(
+    data: Union[ttb.tensor, ttb.ktensor, ttb.sptensor, np.ndarray],
+    filename: str,
+    fmt_data: Optional[str] = None,
+    fmt_weights: Optional[str] = None,
+):
     """
     Export tensor-related data to a file.
     """
@@ -19,78 +24,67 @@ def export_data(data, filename, fmt_data=None, fmt_weights=None):
         assert False, f"Invalid data type for export: {type(data)}"
 
     # open file
-    fp = open(filename, "w")
+    # pylint: disable=unspecified-encoding
+    with open(filename, "w") as fp:
+        if isinstance(data, ttb.tensor):
+            print("tensor", file=fp)
+            export_size(fp, data.shape)
+            # numpy always writes the array with 'C' ordering, regardless
+            # of the ordering of the array.  So we must transpose it first
+            # to preserve the convention of 'F' ordering of the file.
+            export_array(fp, data.data.transpose(), fmt_data)
 
-    if isinstance(data, ttb.tensor):
-        print("tensor", file=fp)
-        export_size(fp, data.shape)
-        # numpy always writes the array with 'C' ordering, regardless
-        # of the ordering of the array.  So we must transpose it first
-        # to preserve the convention of 'F' ordering of the file.
-        export_array(fp, data.data.transpose(), fmt_data)
+        elif isinstance(data, ttb.sptensor):
+            print("sptensor", file=fp)
+            export_sparse_size(fp, data)
+            export_sparse_array(fp, data, fmt_data)
 
-    elif isinstance(data, ttb.sptensor):
-        print("sptensor", file=fp)
-        export_sparse_size(fp, data)
-        export_sparse_array(fp, data, fmt_data)
+        elif isinstance(data, ttb.ktensor):
+            print("ktensor", file=fp)
+            export_size(fp, data.shape)
+            export_rank(fp, data)
+            export_weights(fp, data, fmt_weights)
+            for n in range(data.ndims):
+                print("matrix", file=fp)
+                export_size(fp, data.factor_matrices[n].shape)
+                export_factor(fp, data.factor_matrices[n], fmt_data)
 
-    elif isinstance(data, ttb.ktensor):
-        print("ktensor", file=fp)
-        export_size(fp, data.shape)
-        export_rank(fp, data)
-        export_weights(fp, data, fmt_weights)
-        for n in range(data.ndims):
+        elif isinstance(data, np.ndarray):
             print("matrix", file=fp)
-            export_size(fp, data.factor_matrices[n].shape)
-            export_factor(fp, data.factor_matrices[n], fmt_data)
-        """
-        fprintf(fid, 'ktensor\n');
-        export_size(fid, size(A));
-        export_rank(fid, A);
-        export_lambda(fid, A.lambda, fmt_lambda);   
-        for n = 1:length(size(A))
-            fprintf(fid, 'matrix\n');
-            export_size(fid, size(A.U{n}));
-            export_factor(fid, A.U{n}, fmt_data);
-        end
-        """
-
-    elif isinstance(data, np.ndarray):
-        print("matrix", file=fp)
-        export_size(fp, data.shape)
-        export_array(fp, data, fmt_data)
+            export_size(fp, data.shape)
+            export_array(fp, data, fmt_data)
 
 
-def export_size(fp, shape):
-    # Export the size of something to a file
+def export_size(fp: TextIO, shape: Tuple[int, ...]):
+    """Export the size of something to a file"""
     print(f"{len(shape)}", file=fp)  # # of dimensions on one line
     shape_str = " ".join([str(d) for d in shape])
     print(f"{shape_str}", file=fp)  # size of each dimensions on the next line
 
 
-def export_rank(fp, data):
-    # Export the rank of a ktensor to a file
+def export_rank(fp: TextIO, data: ttb.ktensor):
+    """Export the rank of a ktensor to a file"""
     print(f"{len(data.weights)}", file=fp)  # ktensor rank on one line
 
 
-def export_weights(fp, data, fmt_weights):
-    # Export dense data that supports numel and linear indexing
+def export_weights(fp: TextIO, data: ttb.ktensor, fmt_weights: Optional[str]):
+    """Export KTensor weights"""
     if not fmt_weights:
         fmt_weights = "%.16e"
     data.weights.tofile(fp, sep=" ", format=fmt_weights)
     print(file=fp)
 
 
-def export_array(fp, data, fmt_data):
-    # Export dense data that supports numel and linear indexing
+def export_array(fp: TextIO, data: np.ndarray, fmt_data: Optional[str]):
+    """Export dense data"""
     if not fmt_data:
         fmt_data = "%.16e"
     data.tofile(fp, sep="\n", format=fmt_data)
     print(file=fp)
 
 
-def export_factor(fp, data, fmt_data):
-    # Export dense data that supports numel and linear indexing
+def export_factor(fp: TextIO, data: np.ndarray, fmt_data: Optional[str]):
+    """Export KTensor factor"""
     if not fmt_data:
         fmt_data = "%.16e"
     for i in range(data.shape[0]):
@@ -99,16 +93,16 @@ def export_factor(fp, data, fmt_data):
         print(file=fp)
 
 
-def export_sparse_size(fp, A):
-    # Export the size of something to a file
+def export_sparse_size(fp: TextIO, A: ttb.sptensor):
+    """Export the size of something to a file"""
     print(f"{len(A.shape)}", file=fp)  # # of dimensions on one line
     shape_str = " ".join([str(d) for d in A.shape])
     print(f"{shape_str}", file=fp)  # size of each dimensions on the next line
     print(f"{A.nnz}", file=fp)  # number of nonzeros
 
 
-def export_sparse_array(fp, A, fmt_data):
-    # Export sparse array data in coordinate format
+def export_sparse_array(fp: TextIO, A: ttb.sptensor, fmt_data: Optional[str]):
+    """Export sparse array data in coordinate format"""
     if not fmt_data:
         fmt_data = "%.16e"
     # TODO: looping through all values may take a long time, can this be more efficient?

--- a/pyttb/hosvd.py
+++ b/pyttb/hosvd.py
@@ -3,6 +3,8 @@
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
 
+from __future__ import annotations
+
 import warnings
 from typing import List, Optional
 
@@ -12,14 +14,15 @@ import scipy
 import pyttb as ttb
 
 
+# pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 def hosvd(
-    input_tensor,
+    input_tensor: ttb.tensor,
     tol: float,
     verbosity: float = 1,
     dimorder: Optional[List[int]] = None,
     sequential: bool = True,
     ranks: Optional[List[int]] = None,
-):
+) -> ttb.ttensor:
     """Compute sequentially-truncated higher-order SVD (Tucker).
 
     Computes a Tucker decomposition with relative error
@@ -63,12 +66,13 @@ def hosvd(
     else:
         if not isinstance(dimorder, list):
             raise ValueError("Dimorder must be a list")
-        elif tuple(range(d)) != tuple(sorted(dimorder)):
+        if tuple(range(d)) != tuple(sorted(dimorder)):
             raise ValueError(
                 "Dimorder must be a list or permutation of range(tensor.ndims)"
             )
 
-    # TODO should unify printing throughout. Probably easier to use python logging levels
+    # TODO should unify printing throughout. Probably easier to use python logging
+    #  levels
     if verbosity > 0:
         print("Computing HOSVD...\n")
 
@@ -104,9 +108,9 @@ def hosvd(
             ranks[k] = np.where(eigsum > eigsumthresh)[0][-1]
 
             if verbosity > 5:
-                print(f"Reverse cummulative sum of evals of Gram matrix:")
-                for i in range(len(eigsum)):
-                    print_msg = f"{i: d}: {eigsum[i]: 6.4f}"
+                print("Reverse cummulative sum of evals of Gram matrix:")
+                for i, a_sum in enumerate(eigsum):
+                    print_msg = f"{i: d}: {a_sum: 6.4f}"
                     if i == ranks[k]:
                         print_msg += " <-- Cutoff"
                     print(print_msg)

--- a/pyttb/hosvd.py
+++ b/pyttb/hosvd.py
@@ -31,12 +31,18 @@ def hosvd(
 
     Parameters
     ----------
-    input_tensor: Tensor to factor
-    tol: Relative error to stop at
-    verbosity: Print level
-    dimorder: Order to loop through dimensions
-    sequential: Use sequentially-truncated version
-    ranks: Specify ranks to consider rather than computing
+    input_tensor:
+        Tensor to factor
+    tol:
+        Relative error to stop at
+    verbosity:
+        Print level
+    dimorder:
+        Order to loop through dimensions
+    sequential:
+        Use sequentially-truncated version
+    ranks:
+        Specify ranks to consider rather than computing
 
     Example
     -------

--- a/pyttb/import_data.py
+++ b/pyttb/import_data.py
@@ -1,74 +1,84 @@
+"""Utilities for importing tensor data"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
+from __future__ import annotations
 
 import os
+from typing import TextIO, Tuple, Union
 
 import numpy as np
 
 import pyttb as ttb
 
-from .pyttb_utils import *
 
+# pylint: disable=too-many-locals
+def import_data(
+    filename: str, index_base: int = 1
+) -> Union[ttb.sptensor, ttb.ktensor, ttb.tensor, np.ndarray]:
+    """
+    Import tensor data
 
-def import_data(filename, index_base=1):
+    Parameters
+    ----------
+    filename:
+        File to import.
+    index_base:
+        Index basing allows interoperability (Primarily between python and MATLAB).
+    """
     # Check if file exists
     if not os.path.isfile(filename):
         assert False, f"File path {filename} does not exist."
 
     # import
-    fp = open(filename, "r")
+    # pylint: disable=unspecified-encoding
+    with open(filename, "r") as fp:
+        # tensor type should be on the first line
+        # valid: tensor, sptensor, matrix, ktensor
+        data_type = import_type(fp)
 
-    # tensor type should be on the first line
-    # valid: tensor, sptensor, matrix, ktensor
-    data_type = import_type(fp)
+        if data_type not in ["tensor", "sptensor", "matrix", "ktensor"]:
+            assert False, f"Invalid data type found: {data_type}"
 
-    if data_type not in ["tensor", "sptensor", "matrix", "ktensor"]:
-        fp.close()
-        assert False, f"Invalid data type found: {data_type}"
+        if data_type == "tensor":
+            shape = import_shape(fp)
+            data = import_array(fp, np.prod(shape))
+            return ttb.tensor.from_data(data, shape)
 
-    if data_type == "tensor":
-        shape = import_shape(fp)
-        data = import_array(fp, np.prod(shape))
-        fp.close()
-        return ttb.tensor.from_data(data, shape)
+        if data_type == "sptensor":
+            shape = import_shape(fp)
+            nz = import_nnz(fp)
+            subs, vals = import_sparse_array(fp, len(shape), nz, index_base)
+            return ttb.sptensor.from_data(subs, vals, shape)
 
-    elif data_type == "sptensor":
-        shape = import_shape(fp)
-        nz = import_nnz(fp)
-        subs, vals = import_sparse_array(fp, len(shape), nz, index_base)
-        fp.close()
-        return ttb.sptensor.from_data(subs, vals, shape)
+        if data_type == "matrix":
+            shape = import_shape(fp)
+            mat = import_array(fp, np.prod(shape))
+            mat = np.reshape(mat, np.array(shape))
+            return mat
 
-    elif data_type == "matrix":
-        shape = import_shape(fp)
-        mat = import_array(fp, np.prod(shape))
-        mat = np.reshape(mat, np.array(shape))
-        fp.close()
-        return mat
-
-    elif data_type == "ktensor":
-        shape = import_shape(fp)
-        r = import_rank(fp)
-        weights = import_array(fp, r)
-        factor_matrices = []
-        for n in range(len(shape)):
-            fac_type = fp.readline().strip()
-            fac_shape = import_shape(fp)
-            fac = import_array(fp, np.prod(fac_shape))
-            fac = np.reshape(fac, np.array(fac_shape))
-            factor_matrices.append(fac)
-        fp.close()
-        return ttb.ktensor(factor_matrices, weights, copy=False)
+        if data_type == "ktensor":
+            shape = import_shape(fp)
+            r = import_rank(fp)
+            weights = import_array(fp, r)
+            factor_matrices = []
+            for _ in range(len(shape)):
+                fp.readline().strip()  # Skip factor type
+                fac_shape = import_shape(fp)
+                fac = import_array(fp, np.prod(fac_shape))
+                fac = np.reshape(fac, np.array(fac_shape))
+                factor_matrices.append(fac)
+            return ttb.ktensor(factor_matrices, weights, copy=False)
+    raise ValueError("Failed to load tensor data")  # pragma: no cover
 
 
-def import_type(fp):
-    # Import IO data type
+def import_type(fp: TextIO) -> str:
+    """Extract IO data type"""
     return fp.readline().strip().split(" ")[0]
 
 
-def import_shape(fp):
-    # Import the shape of something from a file
+def import_shape(fp: TextIO) -> Tuple[int, ...]:
+    """Extract the shape of something from a file"""
     n = int(fp.readline().strip().split(" ")[0])
     shape = [int(d) for d in fp.readline().strip().split(" ")]
     if len(shape) != n:
@@ -76,18 +86,20 @@ def import_shape(fp):
     return tuple(shape)
 
 
-def import_nnz(fp):
-    # Import the size of something from a file
+def import_nnz(fp: TextIO) -> int:
+    """Extract the number of non-zeros of something from a file"""
     return int(fp.readline().strip().split(" ")[0])
 
 
-def import_rank(fp):
-    # Import the rank of something from a file
+def import_rank(fp: TextIO) -> int:
+    """Extract the rank of something from a file"""
     return int(fp.readline().strip().split(" ")[0])
 
 
-def import_sparse_array(fp, n, nz, index_base=1):
-    # Import sparse data subs and vals from coordinate format data
+def import_sparse_array(
+    fp: TextIO, n: int, nz: int, index_base: int = 1
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Extract sparse data subs and vals from coordinate format data"""
     subs = np.zeros((nz, n), dtype="int64")
     vals = np.zeros((nz, 1))
     for k in range(nz):
@@ -97,5 +109,6 @@ def import_sparse_array(fp, n, nz, index_base=1):
     return subs, vals
 
 
-def import_array(fp, n):
+def import_array(fp: TextIO, n: Union[int, np.integer]) -> np.ndarray:
+    """Extract numpy array from file"""
     return np.fromfile(fp, count=n, sep=" ")

--- a/pyttb/khatrirao.py
+++ b/pyttb/khatrirao.py
@@ -17,8 +17,10 @@ def khatrirao(*matrices: np.ndarray, reverse: bool = False) -> np.ndarray:
 
     Parameters
     ----------
-    matrices: Collection of matrices to take the product of
-    reverse: bool Set to true to calculate product in reverse
+    matrices:
+        Collection of matrices to take the product of
+    reverse:
+        Set to true to calculate product in reverse
 
     Examples
     --------

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -75,9 +75,12 @@ class ktensor:
 
         Parameters
         ----------
-        factor_matrices: Factors for ktensor.
-        weights: Tensor weights, defaults to all 1's.
-        copy: Whether or not to copy the input data or just reference it.
+        factor_matrices:
+            Factors for ktensor.
+        weights:
+            Tensor weights, defaults to all 1's.
+        copy:
+            Whether or not to copy the input data or just reference it.
 
         Examples
         --------
@@ -198,8 +201,10 @@ class ktensor:
             dimension sizes) and return a :class:`numpy.ndarray` of that shape.
             Example functions include `numpy.random.random_sample`,
             `numpy,zeros`, `numpy.ones`.
-        shape: Shape of the resulting tensor.
-        num_components: Number of components/weights for resulting tensor.
+        shape:
+            Shape of the resulting tensor.
+        num_components:
+            Number of components/weights for resulting tensor.
 
         Returns
         -------
@@ -284,22 +289,21 @@ class ktensor:
         cls, data: np.ndarray, shape: Tuple[int, ...], contains_weights: bool
     ):
         """
-        Construct a :class:`pyttb.ktensor` from a vector (given as a
-        :class:`numpy.ndarray`) and shape (given as a
-        :class:`numpy.ndarray`). The rank of the :class:`pyttb.ktensor`
-        is inferred from the shape and length of the vector.
+        Construct a :class:`pyttb.ktensor` from a vector and shape. The rank of the
+        :class:`pyttb.ktensor` is inferred from the shape and length of the vector.
 
         Parameters
         ----------
-        data: :class:`numpy.ndarray`, required
-            Vector containing either elements of the factor matrices (when
-            `contains_weights`==False) or elements of the weights and factor
-            matrices (when `contains_weights`==True). When both the elements of
+        data:
+            Vector containing either elements of the factor matrices or elements of the
+            weights and factor matrices. When both the elements of
             the weights and the factor_matrices are present, the weights come
             first and the columns of the factor matrices come next.
-        shape: Shape of the resulting ktensor.
-        contains_weights: Flag to specify if `data` contains weights. If False,
-            all weights are set to 1.
+        shape:
+            Shape of the resulting ktensor.
+        contains_weights:
+            Flag to specify if `data` contains weights.
+            If False, all weights are set to 1.
 
         Returns
         -------
@@ -413,8 +417,10 @@ class ktensor:
 
         Parameters
         ----------
-        weight_factor: Index of the factor matrix the weights will be absorbed into.
-        permutation: The new order of the components of the :class:`pyttb.ktensor`
+        weight_factor:
+            Index of the factor matrix the weights will be absorbed into.
+        permutation:
+            The new order of the components of the :class:`pyttb.ktensor`
             into which to permute. The permutation must be of length equal to
             the number of components of the :class:`pyttb.ktensor`, `self.ncomponents`
             and must be a permutation of [0,...,`self.ncomponents`-1].
@@ -614,7 +620,8 @@ class ktensor:
 
         Parameters
         ----------
-        k: Dimension for subscripted indexing
+        k:
+            Dimension for subscripted indexing
 
         Returns
         -------
@@ -641,7 +648,7 @@ class ktensor:
 
         Parameters
         ----------
-        idx: int, :class:`tuple`, :class:`list`, :class:`numpy.ndarray`, optional
+        idx:
             Index set of components to extract. It should be the case that
             `idx` is a subset of [0,...,`self.ncomponents`]. If this
             parameter is None or is empty, a copy of the
@@ -725,7 +732,8 @@ class ktensor:
 
         Parameters
         ----------
-        other: If not None, returns a version of the :class:`pyttb.ktensor`
+        other:
+            If not None, returns a version of the :class:`pyttb.ktensor`
             where some of the signs of the columns of the factor matrices have
             been flipped to better align with `other`. In not None, both
             :class:`pyttb.ktensor` objects are first normalized (using
@@ -909,7 +917,8 @@ class ktensor:
 
         Parameters
         ----------
-        other: Tensor with which to compute the inner product.
+        other:
+            Tensor with which to compute the inner product.
 
         Returns
         -------
@@ -942,13 +951,14 @@ class ktensor:
             f"Unsupported type for inner product with ktensor. Received {type(other)}"
         )
 
-    def isequal(self, other) -> bool:
+    def isequal(self, other: ttb.ktensor) -> bool:
         """
         Equal comparator for :class:`pyttb.ktensor` objects.
 
         Parameters
         ----------
-        other: :class:`pyttb.ktensor` with which to compare.
+        other:
+            :class:`pyttb.ktensor` with which to compare.
 
         Examples
         --------
@@ -987,7 +997,8 @@ class ktensor:
 
         Parameters
         ----------
-        return_diffs: If True, returns the matrix of the norm of the differences
+        return_diffs:
+            If True, returns the matrix of the norm of the differences
             between the factor matrices.
 
         Returns
@@ -1043,7 +1054,8 @@ class ktensor:
 
         Parameters
         ----------
-        W: Mask tensor to apply to ktensor.
+        W:
+            Mask tensor to apply to ktensor.
 
         Returns
         -------
@@ -1096,8 +1108,10 @@ class ktensor:
 
         Parameters
         ----------
-        U: Factor matrices.
-        n: Multiply by all modes except n.
+        U:
+            Factor matrices.
+        n:
+            Multiply by all modes except n.
 
         Returns
         -------
@@ -1190,13 +1204,17 @@ class ktensor:
 
         Parameters
         ----------
-        weight_factor: Absorb the weights into one or more factors. If "all", absorb
+        weight_factor:
+            Absorb the weights into one or more factors. If "all", absorb
             weight equally across all factors. If `int`, absorb weight into a
             single dimension (value must be in range(self.ndims)).
-        sort: Sort the columns in descending order of the weights.
-        normtype: Order of the norm (see :func:`numpy.linalg.norm` for possible
+        sort:
+            Sort the columns in descending order of the weights.
+        normtype:
+            Order of the norm (see :func:`numpy.linalg.norm` for possible
             values).
-        mode: Index of factor matrix to normalize. A value of `None` means
+        mode:
+            Index of factor matrix to normalize. A value of `None` means
             normalize all factor matrices.
 
         Returns
@@ -1290,9 +1308,12 @@ class ktensor:
 
         Parameters
         ----------
-        n: Mode for tensor matricization.
-        r: Number of eigenvectors to compute and use.
-        flipsign: If True, make each column's largest element positive.
+        n:
+            Mode for tensor matricization.
+        r:
+            Number of eigenvectors to compute and use.
+        flipsign:
+            If True, make each column's largest element positive.
 
         Returns
         -------
@@ -1353,7 +1374,8 @@ class ktensor:
 
         Parameters
         ----------
-        order: Permutation of [0,...,self.ndimensions].
+        order:
+            Permutation of [0,...,self.ndimensions].
 
         Returns
         -------
@@ -1402,7 +1424,8 @@ class ktensor:
 
         Parameters
         ----------
-        mode: Must be value in [0,...self.ndims].
+        mode:
+            Must be value in [0,...self.ndims].
 
         Returns
         -------
@@ -1488,11 +1511,15 @@ class ktensor:
 
         Parameters
         ----------
-        other: :class:`pyttb.ktensor` with which to match.
-        weight_penalty: Flag indicating whether or not to consider the weights in the
+        other:
+            :class:`pyttb.ktensor` with which to match.
+        weight_penalty:
+            Flag indicating whether or not to consider the weights in the
             calculations.
-        threshold: Threshold specified in the formula above for determining a match.
-        greedy: Flag indicating whether or not to consider all possible matchings
+        threshold:
+            Threshold specified in the formula above for determining a match.
+        greedy:
+            Flag indicating whether or not to consider all possible matchings
             (exponentially expensive) or just do a greedy matching.
 
         Returns
@@ -1691,7 +1718,8 @@ class ktensor:
 
         Parameters
         ----------
-        mode: Index of factor matrix to absorb all of the weights.
+        mode:
+            Index of factor matrix to absorb all of the weights.
 
         Returns
         -------
@@ -1761,7 +1789,8 @@ class ktensor:
 
         Parameters
         ----------
-        include_weights: Flag to specify whether or not to include weights in output.
+        include_weights:
+            Flag to specify whether or not to include weights in output.
 
         Returns
         -------
@@ -1865,9 +1894,12 @@ class ktensor:
 
         Parameters
         ----------
-        vector: :class:`numpy.ndarray` or list[:class:`numpy.ndarray`], required
-        dims: int, :class:`numpy.ndarray`, optional
+        vector:
+            Vector to multiply by.
+        dims:
+            Dimension(s) along which to multiply.
         exclude_dims:
+            Multiply by all but excluded dimension(s).
 
         Returns
         -------
@@ -1974,12 +2006,13 @@ class ktensor:
 
         Parameters
         ----------
-        modes: int or :class:`list` of int, required
+        modes:
             List of dimensions to update; values must be in ascending order. If
             the first element of the list is -1, then update the weights. All
             other integer values values must be sorted and in
             [0,...,self.ndims].
-        data: Data values to use in the update.
+        data:
+            Data values to use in the update.
 
         Returns
         -------

--- a/pyttb/pyttb_utils.py
+++ b/pyttb/pyttb_utils.py
@@ -22,9 +22,12 @@ def tt_to_dense_matrix(
 
     Parameters
     ----------
-    tensorInstance: Tensor to matricize
-    mode: Mode around which to unwrap tensor
-    transpose: Whether or not to tranpose unwrapped tensor
+    tensorInstance:
+        Tensor to matricize
+    mode:
+        Mode around which to unwrap tensor
+    transpose:
+        Whether or not to tranpose unwrapped tensor
 
     Returns
     -------
@@ -58,9 +61,12 @@ def tt_from_dense_matrix(
 
     Parameters
     ----------
-    matrix: Matrix to (re-)create tensor from.
-    mode: Mode around which tensor was unwrapped
-    idx: In {0,1}, idx of mode in matrix, s.b. 0 for tranpose=True
+    matrix:
+        Matrix to (re-)create tensor from.
+    mode:
+        Mode around which tensor was unwrapped
+    idx:
+        In {0,1}, idx of mode in matrix, s.b. 0 for tranpose=True
 
     Returns
     -------
@@ -84,12 +90,15 @@ def tt_union_rows(MatrixA: np.ndarray, MatrixB: np.ndarray) -> np.ndarray:
 
     Parameters
     ----------
-    MatrixA: First matrix.
-    MatrixB: Second matrix.
+    MatrixA:
+        First matrix.
+    MatrixB:
+        Second matrix.
 
     Returns
     -------
-    location: List of intersection indices
+    location:
+        List of intersection indices
 
     Examples
     --------
@@ -224,8 +233,10 @@ def tt_tenfun(function_handle, *inputs):  # pylint:disable=too-many-branches
 
     Parameters
     ----------
-    function_handle: callable
-    inputs: tensor type, or np.array
+    function_handle:
+        callable
+    inputs:
+        tensor type, or np.array
 
     Returns
     -------
@@ -321,8 +332,10 @@ def tt_setdiff_rows(MatrixA: np.ndarray, MatrixB: np.ndarray) -> np.ndarray:
 
     Parameters
     ----------
-    MatrixA: First matrix.
-    MatrixB: Second matrix.
+    MatrixA:
+        First matrix.
+    MatrixB:
+        Second matrix.
 
     Returns
     -------
@@ -349,12 +362,15 @@ def tt_intersect_rows(MatrixA: np.ndarray, MatrixB: np.ndarray) -> np.ndarray:
 
     Parameters
     ----------
-    MatrixA: First matrix.
-    MatrixB: Second matrix.
+    MatrixA:
+        First matrix.
+    MatrixB:
+        Second matrix.
 
     Returns
     -------
-    location: List of intersection indices.
+    location:
+        List of intersection indices.
 
     Examples
     --------
@@ -386,9 +402,12 @@ def tt_irenumber(t: ttb.sptensor, shape: Tuple[int, ...], number_range) -> np.nd
 
     Parameters
     ----------
-    t: Sptensor we are trying to assign from
-    shape: Shape of destination tensor
-    number_range: Key from __setitem__ for destination tensor
+    t:
+        Sptensor we are trying to assign from
+    shape:
+        Shape of destination tensor
+    number_range:
+        Key from __setitem__ for destination tensor
 
     Returns
     -------
@@ -429,14 +448,17 @@ def tt_renumber(
 
     Parameters
     ----------
-    subs: :class:`numpy.ndarray`
-    shape: Shape of source tensor.
+    subs:
+    shape:
+        Shape of source tensor.
     range:
 
     Returns
     -------
-    newsubs: Updated subscripts.
-    newshape: Resulting shape.
+    newsubs:
+        Updated subscripts.
+    newshape:
+        Resulting shape.
     """
     newshape = np.array(shape)
     newsubs = subs
@@ -465,9 +487,9 @@ def tt_renumberdim(idx: np.ndarray, shape: int, number_range) -> Tuple[int, int]
 
     Parameters
     ----------
-    idx: :class:`numpy.ndarray`
-    shape: int
-    number_range: :class:`numpy.ndarray`
+    idx:
+    shape:
+    number_range:
 
     Returns
     -------
@@ -504,15 +526,15 @@ def tt_ismember_rows(search: np.ndarray, source: np.ndarray) -> np.ndarray:
 
     Parameters
     ----------
-    search: :class:`numpy.ndarray`
-    source: :class:`numpy.ndarray`
+    search:
+    source:
 
     Returns
     -------
-    results: :class:`numpy.ndarray`
-    search.size==results.size,
-    if search[0,:] == source[3,:], then results[0] = 3
-    if exists i such that search[i,:] != source[j,:] for any j, then results[i] = -1
+    results:
+        search.size==results.size,
+        if search[0,:] == source[3,:], then results[0] = 3
+        if exists i such that search[i,:] != source[j,:] for any j, then results[i] = -1
 
     Examples
     --------
@@ -539,8 +561,9 @@ def tt_ind2sub(shape: Tuple[int, ...], idx: np.ndarray) -> np.ndarray:
 
     Parameters
     ----------
-    shape: tuple
-    idx: :class:`numpy.ndarray`
+    shape:
+    idx:
+
     Returns
     -------
     :class:`numpy.ndarray`
@@ -557,8 +580,10 @@ def tt_subsubsref(obj, s):  # pylint: disable=unused-argument
 
     Parameters
     ----------
-    obj: Tensor Data Structure
-    s: Reference into tensor
+    obj:
+        Tensor Data Structure
+    s:
+        Reference into tensor
 
     Returns
     -------
@@ -582,10 +607,12 @@ def tt_intvec2str(v: np.ndarray) -> str:
 
     Parameters
     ----------
-    v: :class:`numpy.ndarray` integer vector
+    v:
+        Integer vector
+
     Returns
     -------
-    str: formatted string to print
+    Formatted string to print
     """
     return np.array2string(v)
 
@@ -596,10 +623,10 @@ def tt_sub2ind(shape: Tuple[int, ...], subs: np.ndarray) -> np.ndarray:
 
     Parameters
     ----------
-    shape: tuple
-    Shape of tensor
-    subs: :class:`numpy.ndarray`
-    Subscripts for tensor
+    shape:
+        Shape of tensor
+    subs:
+        Subscripts for tensor
 
     Returns
     -------
@@ -626,10 +653,10 @@ def tt_sizecheck(shape: Tuple[int, ...], nargout: bool = True) -> bool:
 
     Parameters
     ----------
-    shape: tuple
-    Shape of tensor
-    nargout: bool
-    Controls if response returned or just acts as assert
+    shape:
+        Shape of tensor
+    nargout:
+        Controls if response returned or just acts as assert
 
     Returns
     -------
@@ -668,10 +695,10 @@ def tt_subscheck(subs: np.ndarray, nargout: bool = True) -> bool:
 
     Parameters
     ----------
-    subs: :class:`numpy.ndarray`
-    Subs of tensor
-    nargout: bool
-    Controls if response returned or just acts as assert
+    subs:
+        Subs of tensor
+    nargout:
+        Controls if response returned or just acts as assert
 
     Returns
     -------
@@ -709,10 +736,10 @@ def tt_valscheck(vals: np.ndarray, nargout: bool = True) -> bool:
 
     Parameters
     ----------
-    vals: :class:`numpy.ndarray`
-    Values of tensor
-    nargout: bool
-    Controls if response returned or just acts as assert
+    vals:
+        Values of tensor
+    nargout:
+        Controls if response returned or just acts as assert
 
     Returns
     -------
@@ -737,8 +764,8 @@ def isrow(v: np.ndarray) -> bool:
 
     Parameters
     ----------
-    v: :class:`numpy.ndarray`
-    vector input
+    v:
+        Vector input
 
     Returns
     -------
@@ -755,7 +782,7 @@ def isvector(a: np.ndarray) -> bool:
 
     Parameters
     ----------
-    a: :class:`numpy.ndarray`
+    a:
 
     Returns
     -------
@@ -774,7 +801,7 @@ def islogical(a: np.ndarray) -> bool:
 
     Parameters
     ----------
-    a: :class:`numpy.ndarray`
+    a:
 
     Returns
     -------

--- a/pyttb/sptenmat.py
+++ b/pyttb/sptenmat.py
@@ -1,11 +1,11 @@
+"""Sparse Matricized Tensor Representation"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
 
-import pyttb as ttb
 
-
-class sptenmat(object):
+# pylint: disable=too-few-public-methods
+class sptenmat:
     """
     SPTENMAT Store sparse tensor as a sparse matrix.
 

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -48,13 +48,17 @@ def tt_to_sparse_matrix(
 
     Parameters
     ----------
-    sptensorInstance: sparse tensor to unwrap
-    mode: Mode around which to unwrap tensor
-    transpose: Whether or not to tranpose unwrapped tensor
+    sptensorInstance:
+        Sparse tensor to unwrap
+    mode:
+        Mode around which to unwrap tensor
+    transpose:
+        Whether or not to transpose unwrapped tensor
 
     Returns
     -------
-    spmatrix: unwrapped tensor
+    spmatrix:
+        Unwrapped tensor
     """
     old = np.setdiff1d(np.arange(sptensorInstance.ndims), mode).astype(int)
     spmatrix = sptensorInstance.reshape(
@@ -74,10 +78,10 @@ def tt_from_sparse_matrix(
 
     Parameters
     ----------
-    spmatrix: :class:`Scipy.sparse.coo_matrix`
-    mode: int
+    spmatrix:
+    mode:
         Mode around which tensor was unwrapped
-    idx: int
+    idx:
         in {0,1}, idx of mode in spmatrix, s.b. 0 for tranpose=True
 
     Returns
@@ -134,9 +138,12 @@ class sptensor:
 
         Parameters
         ----------
-        subs: location of non-zero entries
-        vals: values for non-zero entries
-        shape: shape of sparse tensor
+        subs:
+            Location of non-zero entries
+        vals:
+            Values for non-zero entries
+        shape:
+            Shape of sparse tensor
 
         Examples
         --------
@@ -168,7 +175,8 @@ class sptensor:
 
         Parameters
         ----------
-        source: Source tensor to create sptensor from
+        source:
+            Source tensor to create sptensor from
 
         Returns
         -------
@@ -216,10 +224,13 @@ class sptensor:
 
         Parameters
         ----------
-        function_handle: function that accepts 2 arguments and generates
+        function_handle:
+            Function that accepts 2 arguments and generates
             :class:`numpy.ndarray` of length nonzeros
-        shape: tuple
-        nonzeros: int or float
+        shape:
+            Shape of generated tensor
+        nonzeros:
+            Number of nonzeros in generated tensor
 
         Returns
         -------
@@ -270,10 +281,14 @@ class sptensor:
 
         Parameters
         ----------
-        subs: location of non-zero entries
-        vals: values for non-zero entries
-        shape: shape of sparse tensor
-        function_handle: Aggregation function, or name of supported
+        subs:
+            Location of non-zero entries
+        vals:
+            Values for non-zero entries
+        shape:
+            Shape of sparse tensor
+        function_handle:
+            Aggregation function, or name of supported
             aggregation function from numpy_groupies
 
         Returns
@@ -372,8 +387,10 @@ class sptensor:
 
         Parameters
         ----------
-        dims: Dimensions to collapse
-        fun: Method used to collapse dimensions
+        dims:
+            Dimensions to collapse
+        fun:
+            Method used to collapse dimensions
 
         Returns
         -------
@@ -427,8 +444,10 @@ class sptensor:
 
         Parameters
         ----------
-        i: First dimension
-        j: Second dimension
+        i:
+            First dimension
+        j:
+            Second dimension
 
         Returns
         -------
@@ -492,7 +511,8 @@ class sptensor:
 
         Parameters
         ----------
-        function_handle: Function that updates all values.
+        function_handle:
+            Function that updates all values.
 
         Returns
         -------
@@ -519,7 +539,8 @@ class sptensor:
 
         Parameters
         ----------
-        k: int Dimension for subscript indexing
+        k:
+            Dimension for subscript indexing
         """
         if k is not None:
             return self.shape[k] - 1
@@ -531,7 +552,8 @@ class sptensor:
 
         Parameters
         ----------
-        searchsubs: subscripts to find in sptensor
+        searchsubs:
+            subscripts to find in sptensor
 
         See Also
         --------
@@ -607,7 +629,8 @@ class sptensor:
 
         Parameters
         ----------
-        other: Other tensor to take innerproduct with
+        other:
+            Other tensor to take innerproduct with
         """
         # If all entries are zero innerproduct must be 0
         if self.nnz == 0:
@@ -647,7 +670,8 @@ class sptensor:
 
         Parameters
         ----------
-        other: Other tensor to compare against
+        other:
+            Other tensor to compare against
         """
         if self.shape != other.shape:
             return False
@@ -663,7 +687,8 @@ class sptensor:
 
         Parameters
         ----------
-        B: Other value to compare with
+        B:
+            Other value to compare with
 
         Returns
         ----------
@@ -767,7 +792,8 @@ class sptensor:
 
         Parameters
         ----------
-        other: Other value to xor against
+        other:
+            Other value to xor against
 
         Returns
         -------
@@ -796,7 +822,8 @@ class sptensor:
 
         Parameters
         ----------
-        W: Mask tensor
+        W:
+            Mask tensor
 
         Returns
         -------
@@ -826,8 +853,10 @@ class sptensor:
 
         Parameters
         ----------
-        U: Matrices to create the Khatri-Rao product
-        n: Mode to matricize sptensor in
+        U:
+            Matrices to create the Khatri-Rao product
+        n:
+            Mode to matricize sptensor in
 
         Returns
         -------
@@ -915,9 +944,12 @@ class sptensor:
 
         Parameters
         ----------
-        n: Mode to unfold
-        r: Number of eigenvectors to compute
-        flipsign: Make each eigenvector's largest element positive
+        n:
+            Mode to unfold
+        r:
+            Number of eigenvectors to compute
+        flipsign:
+            Make each eigenvector's largest element positive
         """
         old = np.setdiff1d(np.arange(self.ndims), n).astype(int)
         # tnt calculation is a workaround for missing sptenmat
@@ -964,7 +996,8 @@ class sptensor:
 
         Parameters
         ----------
-        order: Updated order of dimensions
+        order:
+            Updated order of dimensions
         """
         # Error check
         if self.ndims != order.size or np.any(
@@ -991,8 +1024,8 @@ class sptensor:
 
         Parameters
         ----------
-        new_shape: tuple
-        old_modes: :class:`Numpy.ndarray`
+        new_shape:
+        old_modes:
 
         Returns
         -------
@@ -1036,8 +1069,8 @@ class sptensor:
 
         Parameters
         ----------
-        factor: :class:`numpy.ndarray`
-        dims: int or :class:`numpy.ndarray`
+        factor:
+        dims:
 
         Returns
         -------
@@ -1115,7 +1148,7 @@ class sptensor:
 
         Parameters
         ----------
-        region: :class:`numpy.ndarray` or tuple denoting indexing
+        region:
             Subset of total sptensor shape in which to find non-zero values
 
         Returns
@@ -1189,9 +1222,12 @@ class sptensor:
 
         Parameters
         ----------
-        vector: Vector(s) to multiply against
-        dims: Dimensions to multiply with vector(s)
-        exclude_dims: Use all dimensions but these
+        vector:
+            Vector(s) to multiply against
+        dims:
+            Dimensions to multiply with vector(s)
+        exclude_dims:
+            Use all dimensions but these
         """
 
         if dims is None and exclude_dims is None:
@@ -1284,7 +1320,7 @@ class sptensor:
 
         Parameters
         ----------
-        item: tuple(int),tuple(slice),:class:`numpy.ndarray`
+        item:
 
         Returns
         -------
@@ -1451,8 +1487,8 @@ class sptensor:
 
         Parameters
         ----------
-        key: tuple(int),tuple(slice),:class:`numpy.ndarray`
-        value: int,float, :class:`numpy.ndarray`, :class:`pyttb.sptensor`
+        key:
+        value:
 
         """
         # TODO IndexError for value outside of indices
@@ -1779,7 +1815,8 @@ class sptensor:
 
         Parameters
         ----------
-        other: compare equality of sptensor to other
+        other:
+            Compare equality of sptensor to other
 
         Returns
         -------
@@ -1857,7 +1894,8 @@ class sptensor:
 
         Parameters
         ----------
-        other: compare equality of sptensor to other
+        other:
+            Compare equality of sptensor to other
 
         Returns
         -------
@@ -2543,16 +2581,20 @@ class sptensor:
         dims: Optional[Union[float, np.ndarray]] = None,
         exclude_dims: Optional[Union[float, np.ndarray]] = None,
         transpose: bool = False,
-    ):
+    ) -> Union[ttb.tensor, sptensor]:
         """
         Sparse tensor times matrix.
 
         Parameters
         ----------
-        matrices: A matrix or list of matrices
-        dims: Dimensions to multiply against
-        exclude_dims: Use all dimensions but these
-        transpose: Transpose matrices to be multiplied
+        matrices:
+            A matrix or list of matrices
+        dims:
+            Dimensions to multiply against
+        exclude_dims:
+            Use all dimensions but these
+        transpose:
+            Transpose matrices to be multiplied
 
         Returns
         -------
@@ -2640,7 +2682,8 @@ class sptensor:
 
         Parameters
         ----------
-        return_inverse: Return mapping from new tensor to old tensor subscripts.
+        return_inverse:
+            Return mapping from new tensor to old tensor subscripts.
 
         Examples
         --------
@@ -2679,9 +2722,12 @@ def sptenrand(
 
     Parameters
     ----------
-    shape: Shape of resulting tensor
-    density: Density of resulting sparse tensor
-    nonzeros: Number of nonzero entries in resulting sparse tensor
+    shape:
+        Shape of resulting tensor
+    density:
+        Density of resulting sparse tensor
+    nonzeros:
+        Number of nonzero entries in resulting sparse tensor
 
     Returns
     -------
@@ -2727,8 +2773,10 @@ def sptendiag(
 
     Parameters
     ----------
-    elements: Elements to set along the diagonal
-    shape: Shape of resulting tensor
+    elements:
+        Elements to set along the diagonal
+    shape:
+        Shape of resulting tensor
 
     Returns
     -------

--- a/pyttb/sptensor3.py
+++ b/pyttb/sptensor3.py
@@ -1,10 +1,10 @@
+"""Sparse Tensor 3 Class Placeholder"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
 
-import pyttb as ttb
 
-
+# pylint: disable=too-few-public-methods
 class sptensor3:
     """
     SPTENSOR3 a sparse tensor variant.

--- a/pyttb/sumtensor.py
+++ b/pyttb/sumtensor.py
@@ -1,10 +1,10 @@
+"""Sum Tensor Class Placeholder"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
 
-import pyttb as ttb
 
-
+# pylint: disable=too-few-public-methods
 class sumtensor:
     """
     SUMTENSOR Class for implicit sum of other tensors.

--- a/pyttb/symktensor.py
+++ b/pyttb/symktensor.py
@@ -1,14 +1,10 @@
+"""Symmetric Kruskal Tensor Class Placeholder"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
 
-import numpy as np
 
-import pyttb as ttb
-
-from .pyttb_utils import *
-
-
+# pylint: disable=too-few-public-methods
 class symktensor:
     """
     SYMKTENSOR Class for symmetric Kruskal tensors (decomposed).

--- a/pyttb/symtensor.py
+++ b/pyttb/symtensor.py
@@ -1,10 +1,10 @@
+"""Symmetric Tensor Class Placeholder"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
 
-import pyttb as ttb
 
-
+# pylint: disable=too-few-public-methods
 class symtensor:
     """
     SYMTENSOR Class for storing only unique entries of symmetric tensor.

--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -41,7 +41,8 @@ class tenmat:
 
         Parameters
         ----------
-        data: Tensor source data
+        data:
+            Tensor source data
         rdims:
         cdims:
         tshape:
@@ -121,7 +122,8 @@ class tenmat:
 
         Parameters
         ----------
-        source: Tensor type to create dense tensor from
+        source:
+            Tensor type to create dense tensor from
         rdims:
         cdims:
         cdims_cyclic:
@@ -247,8 +249,8 @@ class tenmat:
 
         Parameters
         ----------
-        k: int
-            dimension for subscripted indexing
+        k:
+            Dimension for subscripted indexing
 
         Returns
         -------

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -48,8 +48,10 @@ class tensor:
 
         Parameters
         ----------
-        data: Tensor source data
-        shape: Shape of resulting tensor if not the same as data shape
+        data:
+            Tensor source data
+        shape:
+            Shape of resulting tensor if not the same as data shape
 
         Returns
         -------
@@ -103,7 +105,8 @@ class tensor:
 
         Parameters
         ----------
-        source: Tensor type to create dense tensor from
+        source:
+            Tensor type to create dense tensor from
 
         Returns
         -------
@@ -156,8 +159,10 @@ class tensor:
 
         Parameters
         ----------
-        function_handle: Function to generate data to construct tensor
-        shape: Shape of resulting tensor
+        function_handle:
+            Function to generate data to construct tensor
+        shape:
+            Shape of resulting tensor
 
         Returns
         -------
@@ -189,8 +194,10 @@ class tensor:
 
         Parameters
         ----------
-        dims: Dimensions to collapse
-        fun: Method used to collapse dimensions
+        dims:
+            Dimensions to collapse
+        fun:
+            Method used to collapse dimensions
 
         Returns
         -------
@@ -240,8 +247,10 @@ class tensor:
 
         Parameters
         ----------
-        i: First dimension
-        j: Second dimension
+        i:
+            First dimension
+        j:
+            Second dimension
 
         Returns
         -------
@@ -332,7 +341,8 @@ class tensor:
 
         Parameters
         ----------
-        k: dimension for subscripted indexing
+        k:
+            Dimension for subscripted indexing
 
         Examples
         --------
@@ -390,7 +400,8 @@ class tensor:
 
         Parameters
         ----------
-        other: Tensor type to take an innerproduct with
+        other:
+            Tensor type to take an innerproduct with
 
         Examples
         --------
@@ -415,7 +426,8 @@ class tensor:
 
         Parameters
         ----------
-        other: Tensor to compare against
+        other:
+            Tensor to compare against
 
         Examples
         --------
@@ -443,10 +455,12 @@ class tensor:
 
         Parameters
         ----------
-        grps: Modes to check for symmetry
-        version: Flag
+        grps:
+            Modes to check for symmetry
+        version:
             Any non-None value will call the non-default old version
-        return_details: Flag to return symmetry details in addition to bool
+        return_details:
+            Flag to return symmetry details in addition to bool
 
         Returns
         -------
@@ -543,7 +557,8 @@ class tensor:
 
         Parameters
         ----------
-        B: Value to and against self
+        B:
+            Value to and against self
 
         Examples
         --------
@@ -579,7 +594,8 @@ class tensor:
 
         Parameters
         ----------
-        other: Value to perform or against
+        other:
+            Value to perform or against
 
         Examples
         --------
@@ -599,7 +615,8 @@ class tensor:
 
         Parameters
         ----------
-        other: Value to perform xor against
+        other:
+            Value to perform xor against
 
         Examples
         --------
@@ -619,7 +636,8 @@ class tensor:
 
         Parameters
         ----------
-        W: Mask tensor
+        W:
+            Mask tensor
 
         Returns
         -------
@@ -649,8 +667,10 @@ class tensor:
 
         Parameters
         ----------
-        U: Matrices to create the Khatri-Rao product
-        n: Mode to matricize tensor in
+        U:
+            Matrices to create the Khatri-Rao product
+        n:
+            Mode to matricize tensor in
 
         Returns
         -------
@@ -773,9 +793,12 @@ class tensor:
 
         Parameters
         ----------
-        n: Mode to unfold
-        r: Number of eigenvectors to compute
-        flipsign: Make each eigenvector's largest element positive
+        n:
+            Mode to unfold
+        r:
+            Number of eigenvectors to compute
+        flipsign:
+            Make each eigenvector's largest element positive
 
         Examples
         --------
@@ -816,7 +839,8 @@ class tensor:
 
         Parameters
         ----------
-        order: New order of tensor dimensions
+        order:
+            New order of tensor dimensions
 
         Returns
         -------
@@ -849,7 +873,8 @@ class tensor:
 
         Parameters
         ----------
-        shape: New shape
+        shape:
+            New shape
 
         Examples
         --------
@@ -905,8 +930,11 @@ class tensor:
 
         Parameters
         ----------
-        grps: Modes to check for symmetry
-        version: Any non-None value will call the non-default old version
+        grps:
+            Modes to check for symmetry
+        version:
+            Any non-None value will call the non-default old version
+
         Returns
         -------
         """
@@ -1035,10 +1063,14 @@ class tensor:
 
         Parameters
         ----------
-        matrix: Matrix or matrices to multiple by
-        dims: Dimensions to multiply against
-        exclude_dims: Use all dimensions but these
-        transpose: Transpose matrices during multiplication
+        matrix:
+            Matrix or matrices to multiple by
+        dims:
+            Dimensions to multiply against
+        exclude_dims:
+            Use all dimensions but these
+        transpose:
+            Transpose matrices during multiplication
         """
         if dims is None and exclude_dims is None:
             dims = np.arange(self.ndims)
@@ -1103,9 +1135,12 @@ class tensor:
 
         Parameters
         ----------
-        other: Tensor to multiply by
-        selfdims: Dimensions to contract this tensor by for multiplication
-        otherdims: Dimensions to contract other tensor by for multiplication
+        other:
+            Tensor to multiply by
+        selfdims:
+            Dimensions to contract this tensor by for multiplication
+        otherdims:
+            Dimensions to contract other tensor by for multiplication
         """
 
         if not isinstance(other, tensor):
@@ -1151,9 +1186,12 @@ class tensor:
 
         Parameters
         ----------
-        vector: Vector(s) to multiply against
-        dims: Dimensions to multiply with vector(s)
-        exclude_dims: Use all dimensions but these
+        vector:
+            Vector(s) to multiply against
+        dims:
+            Dimensions to multiply with vector(s)
+        exclude_dims:
+            Use all dimensions but these
         """
 
         if dims is None and exclude_dims is None:
@@ -1210,8 +1248,10 @@ class tensor:
 
         Parameters
         ----------
-        vector: Vector(s) to multiply against
-        skip_dim: Multiply tensor by vector in all dims except [0, skip_dim]
+        vector:
+            Vector(s) to multiply against
+        skip_dim:
+            Multiply tensor by vector in all dims except [0, skip_dim]
         """
         # Only two simple cases are supported
         if skip_dim is None:
@@ -1868,7 +1908,8 @@ def tenones(shape: Tuple[int, ...]) -> tensor:
 
     Parameters
     ----------
-    shape: Shape of resulting tensor
+    shape:
+        Shape of resulting tensor
 
     Returns
     -------
@@ -1887,7 +1928,8 @@ def tenzeros(shape: Tuple[int, ...]) -> tensor:
 
     Parameters
     ----------
-    shape: Shape of resulting tensor
+    shape:
+        Shape of resulting tensor
 
     Returns
     -------
@@ -1906,7 +1948,8 @@ def tenrand(shape: Tuple[int, ...]) -> tensor:
 
     Parameters
     ----------
-    shape: Shape of resulting tensor
+    shape:
+        Shape of resulting tensor
 
     Returns
     -------
@@ -1932,8 +1975,10 @@ def tendiag(elements: np.ndarray, shape: Optional[Tuple[int, ...]] = None) -> te
 
     Parameters
     ----------
-    elements: Elements to set along the diagonal
-    shape: Shape of resulting tensor
+    elements:
+        Elements to set along the diagonal
+    shape:
+        Shape of resulting tensor
 
     Returns
     -------

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -50,8 +50,10 @@ class ttensor:
 
         Parameters
         ----------
-        core: Core of tucker tensor.
-        factors: Factor matrices.
+        core:
+            Core of tucker tensor.
+        factors:
+            Factor matrices.
 
         Returns
         -------
@@ -89,7 +91,8 @@ class ttensor:
 
         Parameters
         ----------
-        source: :class:`pyttb.ttensor`
+        source:
+            Source tensor to create a new ttensor from.
 
         Returns
         -------
@@ -192,7 +195,8 @@ class ttensor:
 
         Parameters
         ----------
-        other: TTensor to compare against.
+        other:
+            TTensor to compare against.
 
         Returns
         -------
@@ -235,7 +239,8 @@ class ttensor:
 
         Parameters
         ----------
-        other: Tensor to take an innerproduct with.
+        other:
+            Tensor to take an innerproduct with.
 
         Returns
         -------
@@ -264,7 +269,7 @@ class ttensor:
                     f"{other.shape}"
                 )
             if np.prod(self.shape) < np.prod(self.core.shape):
-                Z = self.full()
+                Z: Union[ttb.tensor, ttb.sptensor] = self.full()
                 return Z.innerprod(other)
             Z = other.ttm(self.u, transpose=True)
             return Z.innerprod(self.core)
@@ -321,8 +326,12 @@ class ttensor:
 
         Parameters
         ----------
-        vector: :class:`Numpy.ndarray`, list[:class:`Numpy.ndarray`]
-        dims: :class:`Numpy.ndarray`, int
+        vector:
+            Vector to multiply by.
+        dims:
+            Dimensions to multiply in.
+        exclude_dims:
+            Alternative multiply by all dimensions but these.
         """
         if dims is None and exclude_dims is None:
             dims = np.array([])
@@ -374,8 +383,10 @@ class ttensor:
 
         Parameters
         ----------
-        U: array of matrices or ktensor
-        n: multiplies by all modes except n
+        U:
+            Array of matrices or ktensor
+        n:
+            Multiplies by all modes except n
 
         Returns
         -------
@@ -421,7 +432,8 @@ class ttensor:
 
         Parameters
         ----------
-        order: Permutation of [0,...,self.ndims].
+        order:
+            Permutation of [0,...,self.ndims].
 
         Returns
         -------
@@ -445,10 +457,14 @@ class ttensor:
 
         Parameters
         ----------
-        matrix: Matrix or matrices to multiple by
-        dims: Dimensions to multiply against
-        exclude_dims: Use all dimensions but these
-        transpose: Transpose matrices during multiplication
+        matrix:
+            Matrix or matrices to multiple by
+        dims:
+            Dimensions to multiply against
+        exclude_dims:
+            Use all dimensions but these
+        transpose:
+            Transpose matrices during multiplication
         """
         if dims is None and exclude_dims is None:
             dims = np.arange(self.ndims)
@@ -495,8 +511,8 @@ class ttensor:
 
         Parameters
         ----------
-        samples: :class:`Numpy.ndarray`, list[:class:`Numpy.ndarray`]
-        modes: :class:`Numpy.ndarray`, list[:class:`Numpy.ndarray`]
+        samples:
+        modes:
 
         Returns
         -------
@@ -564,9 +580,12 @@ class ttensor:
 
         Parameters
         ----------
-        n: mode for tensor matricization
-        r: number of eigenvalues
-        flipsign: Make each column's largest element positive if true
+        n:
+            Mode for tensor matricization
+        r:
+            Number of eigenvalues
+        flipsign:
+            Make each column's largest element positive if true
 
         Returns
         -------

--- a/pyttb/tucker_als.py
+++ b/pyttb/tucker_als.py
@@ -28,30 +28,39 @@ def tucker_als(
 
     Parameters
     ----------
-    input_tensor: :class:`pyttb.tensor`
-    rank: Rank of the decomposition(s)
-    stoptol: Tolerance used for termination - when the change in the fitness function
+    input_tensor:
+        Tensor to decompose.
+    rank:
+        Rank of the decomposition(s)
+    stoptol:
+        Tolerance used for termination - when the change in the fitness function
         in successive iterations drops below this value, the iterations terminate
-    dimorder: Order to loop through dimensions (default: [range(tensor.ndims)])
-    maxiters: Maximum number of iterations
-    init: Initial guess (default: "random")
-
-        * "random": initialize using a :class:`pyttb.ttensor` with values chosen from
+    dimorder:
+        Order to loop through dimensions (default: [range(tensor.ndims)])
+    maxiters:
+        Maximum number of iterations
+    init:
+        Initial guess (default: "random")
+         * "random": initialize using a :class:`pyttb.ttensor` with values chosen from
             a Normal distribution with mean 0 and standard deviation 1
-        * "nvecs": initialize factor matrices of a :class:`pyttb.ttensor` using the
+         * "nvecs": initialize factor matrices of a :class:`pyttb.ttensor` using the
             eigenvectors of the outer product of the matricized input tensor
-        * :class:`pyttb.ttensor`: initialize using a specific :class:`pyttb.ttensor`
+         * :class:`pyttb.ttensor`: initialize using a specific :class:`pyttb.ttensor`
             as input - must be the same shape as the input tensor and have the same
             rank as the input rank
 
-    printitn: Number of iterations to perform before printing iteration status:
+    printitn:
+        Number of iterations to perform before printing iteration status:
         0 for no status printing
 
     Returns
     -------
-    M: Resulting ttensor from Tucker-ALS factorization
-    Minit: Initial guess
-    output: Information about the computation. Dictionary keys:
+    M:
+        Resulting ttensor from Tucker-ALS factorization
+    Minit:
+        Initial guess
+    output:
+        Information about the computation. Dictionary keys:
 
         * `params` : tuple of (stoptol, maxiters, printitn, dimorder)
         * `iters`: number of iterations performed

--- a/tests/test_cp_apr.py
+++ b/tests/test_cp_apr.py
@@ -525,3 +525,6 @@ def test_cp_apr_negative_tests():
 
     with pytest.raises(AssertionError):
         ttb.cp_apr(dense_tensor, rank=1, algorithm="UNSUPPORTED_ALG")
+
+    with pytest.raises(ValueError):
+        ttb.cp_apr(dense_tensor, rank=1, init="Bad initial guess")

--- a/tests/test_cp_apr.py
+++ b/tests/test_cp_apr.py
@@ -12,7 +12,7 @@ import pyttb as ttb
 def test_vectorizeForMu():
     matrix = np.array([[1, 2], [3, 4]])
     vector = np.array([1, 2, 3, 4])
-    assert np.array_equal(ttb.vectorizeForMu(matrix), vector)
+    assert np.array_equal(ttb.vectorize_for_mu(matrix), vector)
 
 
 @pytest.mark.indevelopment
@@ -81,7 +81,7 @@ def test_calculatePi():
     answer = np.array([[0, 6], [7, 8]])
     assert np.all(
         np.isclose(
-            ttb.calculatePi(
+            ttb.calculate_pi(
                 tensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims
             ),
             answer,
@@ -89,7 +89,7 @@ def test_calculatePi():
     )
     assert np.all(
         np.isclose(
-            ttb.calculatePi(
+            ttb.calculate_pi(
                 sptensorInstance, ktensorInstance, 2, 0, sptensorInstance.ndims
             ),
             answer,
@@ -110,10 +110,10 @@ def test_calculatePi():
 
     print(tensorInstance.shape)
     print(sptensorInstance.shape)
-    print(ttb.calculatePi(tensorInstance, ktensorInstance, n, 0, tensorInstance.ndims).shape)
-    print(ttb.calculatePi(sptensorInstance, ktensorInstance, n, 0, sptensorInstance.ndims).shape)
-    print(np.all(np.isclose(ttb.calculatePi(tensorInstance, ktensorInstance, n, 0, tensorInstance.ndims),
-               ttb.calculatePi(sptensorInstance, ktensorInstance, n, 0, sptensorInstance.ndims))))
+    print(ttb.calculate_pi(tensorInstance, ktensorInstance, n, 0, tensorInstance.ndims).shape)
+    print(ttb.calculate_pi(sptensorInstance, ktensorInstance, n, 0, sptensorInstance.ndims).shape)
+    print(np.all(np.isclose(ttb.calculate_pi(tensorInstance, ktensorInstance, n, 0, tensorInstance.ndims),
+               ttb.calculate_pi(sptensorInstance, ktensorInstance, n, 0, sptensorInstance.ndims))))
     assert True
     """
 
@@ -129,12 +129,12 @@ def test_calculatePhi():
     tensorInstance = ktensorInstance.full()
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
     answer = np.array([[0, 0], [11.226415094339623, 24.830188679245282]])
-    Pi = ttb.calculatePi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     assert np.isclose(
-        ttb.calculatePhi(sptensorInstance, ktensorInstance, 2, 0, Pi, 1e-12), answer
+        ttb.calculate_phi(sptensorInstance, ktensorInstance, 2, 0, Pi, 1e-12), answer
     ).all()
     assert np.isclose(
-        ttb.calculatePhi(tensorInstance, ktensorInstance, 2, 0, Pi, 1e-12), answer
+        ttb.calculate_phi(tensorInstance, ktensorInstance, 2, 0, Pi, 1e-12), answer
     ).all()
 
 
@@ -292,7 +292,7 @@ def test_calc_partials():
     # print(tensorInstance[:, 0])
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
     answer = np.array([[0, 6], [7, 8]])
-    Pi = ttb.calculatePi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     # TODO: These are just verifying same functionality as matlab
     phi, ups = ttb.calc_partials(
         False, Pi, 1e-12, tensorInstance[0, :].data, ktensorInstance[0][0, :]
@@ -356,13 +356,13 @@ def test_getHessian():
     free_indices = [0, 1]
     rank = 2
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
-    Pi = ttb.calculatePi(
+    Pi = ttb.calculate_pi(
         sptensorInstance, ktensorInstance, rank, 0, tensorInstance.ndims
     )
     phi, ups = ttb.calc_partials(
         False, Pi, 1e-12, tensorInstance[1, :].data, ktensorInstance[0][0, :]
     )
-    Hessian = ttb.getHessian(ups, Pi, free_indices)
+    Hessian = ttb.get_hessian(ups, Pi, free_indices)
     assert np.allclose(Hessian, Hessian.transpose())
 
     # Element indexed simple test
@@ -373,7 +373,7 @@ def test_getHessian():
     Pi = np.random.normal(size=(length, rank))
     phi, ups = ttb.calc_partials(False, Pi, 1e-12, x_row, m_row)
     free_indices = [0, 1]
-    Hessian = ttb.getHessian(ups, Pi, free_indices)
+    Hessian = ttb.get_hessian(ups, Pi, free_indices)
 
     #
     num_free = len(free_indices)
@@ -402,9 +402,9 @@ def test_getSearchDirPdnr():
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
     data_row = tensorInstance[1, :].data
     model_row = ktensorInstance[0][0, :]
-    Pi = ttb.calculatePi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     phi, ups = ttb.calc_partials(False, Pi, 1e-12, data_row, model_row)
-    search, pred = ttb.getSearchDirPdnr(Pi, ups, 2, phi, model_row, 0.1, 1e-6)
+    search, pred = ttb.get_search_dir_pdnr(Pi, ups, 2, phi, model_row, 0.1, 1e-6)
     # TODO validate this projection formulation
     projGradStep = (model_row - ups.transpose()) * (
         model_row - (ups.transpose() > 0).astype(float)
@@ -420,7 +420,7 @@ def test_getSearchDirPdnr():
             assert search[r] == ups[r]
         else:
             free_indices.append(r)
-    Hessian_free = ttb.getHessian(ups, Pi, free_indices)
+    Hessian_free = ttb.get_hessian(ups, Pi, free_indices)
     direction = np.linalg.solve(
         Hessian_free + (0.1 * np.eye(len(free_indices))), -ups[free_indices]
     )[:, None]
@@ -439,7 +439,7 @@ def test_tt_loglikelihood_row():
     tensorInstance = ktensorInstance.full()
     # print(tensorInstance[:, 0])
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
-    Pi = ttb.calculatePi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     loglikelihood = ttb.tt_loglikelihood_row(
         False, tensorInstance[1, :].data, tensorInstance[1, :].data, Pi
     )
@@ -457,11 +457,11 @@ def test_tt_linesearch_prowsubprob():
     tensorInstance = ktensorInstance.full()
     # print(tensorInstance[:, 0])
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
-    Pi = ttb.calculatePi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     phi, ups = ttb.calc_partials(
         False, Pi, 1e-12, tensorInstance[1, :].data, ktensorInstance[0][0, :]
     )
-    search, pred = ttb.getSearchDirPdnr(
+    search, pred = ttb.get_search_dir_pdnr(
         Pi, ups, 2, phi, tensorInstance[1, :].data, 0.1, 1e-6
     )
     with pytest.warns(Warning) as record:
@@ -496,11 +496,11 @@ def test_getSearchDirPqnr():
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
     data_row = tensorInstance[1, :].data
     model_row = ktensorInstance[0][0, :]
-    Pi = ttb.calculatePi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     phi, ups = ttb.calc_partials(False, Pi, 1e-12, data_row, model_row)
     delta_model = np.random.normal(size=(2, model_row.shape[0]))
     delta_grad = np.random.normal(size=(2, phi.shape[0]))
-    search, pred = ttb.getSearchDirPqnr(
+    search, pred = ttb.get_search_dir_pqnr(
         model_row, phi, 1e-6, delta_model, delta_grad, phi, 1, 5, False
     )
     # This only verifies that for the right shaped input nothing crashes. Doesn't verify correctness

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -26,25 +26,10 @@ def test_formatting():
 @pytest.mark.packaging
 def test_linting():
     """Confirm linting of the project is enforce"""
-
-    enforced_files = [
-        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tensor.__name__}.py"),
-        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.sptensor.__name__}.py"),
-        ttb.pyttb_utils.__file__,
-        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.khatrirao.__name__}.py"),
-        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.ktensor.__name__}.py"),
-        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.ttensor.__name__}.py"),
-        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tenmat.__name__}.py"),
-        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.cp_als.__name__}.py"),
-        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.hosvd.__name__}.py"),
-        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tucker_als.__name__}.py"),
-    ]
-    # TODO pylint fails to import pyttb in tests
-    # add mypy check
     root_dir = os.path.dirname(os.path.dirname(__file__))
     toml_file = os.path.join(root_dir, "pyproject.toml")
     subprocess.run(
-        f"pylint {' '.join(enforced_files)} --rcfile {toml_file} -j0",
+        f"pylint {os.path.join(root_dir, 'pyttb')} --rcfile {toml_file} -j0",
         check=True,
         shell=True,
     )

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -37,6 +37,7 @@ def test_linting():
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tenmat.__name__}.py"),
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.cp_als.__name__}.py"),
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.hosvd.__name__}.py"),
+        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tucker_als.__name__}.py"),
     ]
     # TODO pylint fails to import pyttb in tests
     # add mypy check

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -35,6 +35,7 @@ def test_linting():
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.ktensor.__name__}.py"),
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.ttensor.__name__}.py"),
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tenmat.__name__}.py"),
+        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.cp_als.__name__}.py"),
     ]
     # TODO pylint fails to import pyttb in tests
     # add mypy check

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -36,6 +36,7 @@ def test_linting():
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.ttensor.__name__}.py"),
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.tenmat.__name__}.py"),
         os.path.join(os.path.dirname(ttb.__file__), f"{ttb.cp_als.__name__}.py"),
+        os.path.join(os.path.dirname(ttb.__file__), f"{ttb.hosvd.__name__}.py"),
     ]
     # TODO pylint fails to import pyttb in tests
     # add mypy check


### PR DESCRIPTION
Resolves: https://github.com/sandialabs/pyttb/issues/63

* Adds typing and linting to the remaining components of pyttb.
* Fixes a formatting error in our docstrings I introduced. Now all our parameters shouldn't have a hard coded type and display properly. Our type hints provide types to documentation.
* Always follow up improvements possible for our typing. General direction of allowing the most general input and the most specific output. But at least we have pinned what we currently support. Adding some helper type definitions to unify the look/feel of our interfaces is probably a good next step but probably not critical path for 2.0.
* Lots of mostly non-functional changes. Might be easier to review by commit where I explained what typing/linting changes I addressed.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--194.org.readthedocs.build/en/194/

<!-- readthedocs-preview pyttb end -->