### PR TITLE
End & array_equal & shape

### DIFF
--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -197,7 +197,7 @@ def cp_als(
             # Compute the matrix of coefficients for linear system
             Y = np.prod(UtU, axis=2, where=[i != n for i in range(N)])
             # don't try to solve linear system with Y = 0
-            if (Y == np.zeros(Y.shape)).all():
+            if (Y == 0).all():
                 Unew = np.zeros(Unew.shape)
             else:
                 Unew = np.linalg.solve(Y.T, Unew.T).T
@@ -213,7 +213,7 @@ def cp_als(
                 weights = np.maximum(np.max(np.abs(Unew), 0), 1)  # max-norm
 
             # if weights are 0, do not divide
-            if not (weights == np.zeros(weights.shape)).all():
+            if not (weights == 0).all():
                 Unew = Unew / weights
 
             U[n] = Unew

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -614,31 +614,6 @@ class ktensor:
         """
         return self.full().double()
 
-    def end(self, k: Optional[int] = None) -> int:
-        """
-        Last index of indexing expression for :class:`pyttb.ktensor`.
-
-        Parameters
-        ----------
-        k:
-            Dimension for subscripted indexing
-
-        Returns
-        -------
-        Final index
-
-        Examples
-        --------
-        >>> K = ttb.ktensor.from_function(np.ones, (2, 3, 4), 2)
-        >>> print(K.end(2))
-        3
-        """
-
-        if k is not None:  # Subscripted indexing
-            return self.shape[k] - 1
-        # For linear indexing
-        return int(np.prod(self.shape) - 1)
-
     def extract(
         self, idx: Optional[Union[int, tuple, list, np.ndarray]] = None
     ) -> ktensor:

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -951,7 +951,7 @@ class ktensor:
         if (self.weights != other.weights).any():
             return False
         for k in range(self.ndims):
-            if not (self.factor_matrices[k] == other.factor_matrices[k]).all():
+            if not np.array_equal(self.factor_matrices[k], other.factor_matrices[k]):
                 return False
         return True
 
@@ -1007,7 +1007,7 @@ class ktensor:
             for j in range(i + 1, self.ndims):
                 if self.factor_matrices[i].shape != self.factor_matrices[j].shape:
                     diffs[i, j] = np.inf
-                elif (self.factor_matrices[i] == self.factor_matrices[j]).all():
+                elif np.array_equal(self.factor_matrices[i], self.factor_matrices[j]):
                     diffs[i, j] = 0
                 else:
                     diffs[i, j] = np.linalg.norm(
@@ -1746,7 +1746,7 @@ class ktensor:
             assert False, "Input parameter'mode' must be in the range of self.ndims"
 
         # all weights are equal to 1
-        if (self.weights == np.ones(self.weights.shape)).all():
+        if np.array_equal(self.weights, np.ones(self.weights.shape)):
             return self.factor_matrices.copy()
 
         lsgn = np.sign(self.weights)

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -868,7 +868,7 @@ class ktensor:
         [[5. 6.]
          [7. 8.]]
         >>> print(K.full()) # doctest: +NORMALIZE_WHITESPACE
-        tensor of shape 2 x 2
+        tensor of shape (2, 2)
         data[:, :] =
         [[29. 39.]
          [63. 85.]]

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -533,19 +533,6 @@ class sptensor:
             return ttb.sptensor.from_data(np.array([]), np.array([]), self.shape)
         return ttb.sptensor.from_data(self.subs[idx, :], vals[idx], self.shape)
 
-    def end(self, k: Optional[int] = None) -> int:
-        """
-        Last index of indexing expression for sparse tensor
-
-        Parameters
-        ----------
-        k:
-            Dimension for subscript indexing
-        """
-        if k is not None:
-            return self.shape[k] - 1
-        return int(np.prod(self.shape) - 1)
-
     def extract(self, searchsubs: np.ndarray) -> np.ndarray:
         """
         Extract value for a sptensor.

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -2540,8 +2540,7 @@ class sptensor:
             s += (" x ").join([str(int(d)) for d in self.shape])
             return s
 
-        s = "Sparse tensor of shape "
-        s += (" x ").join([str(int(d)) for d in self.shape])
+        s = f"Sparse tensor of shape {self.shape}"
         s += f" with {nz} nonzeros \n"
 
         # Stop insane printouts

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -429,7 +429,7 @@ class sptensor:
                     size=newsize[0],
                     func=fun,
                 )
-            return np.zeros((newsize[0], 1))
+            return np.zeros((newsize[0],))
 
         # Create Result
         if self.subs.size > 0:
@@ -1089,7 +1089,7 @@ class sptensor:
                 assert False, "Size mismatch in scale"
             return ttb.sptensor.from_data(
                 self.subs,
-                self.vals * factor[self.subs[:, dims].transpose()[0]],
+                self.vals * factor[self.subs[:, dims].transpose()[0]][:, None],
                 self.shape,
             )
         assert False, "Invalid scaling factor"

--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -243,22 +243,6 @@ class tenmat:
         """
         return self.data.astype(np.float_).copy()
 
-    def end(self, k: int) -> int:
-        """
-        Last index of indexing expression for tenmat
-
-        Parameters
-        ----------
-        k:
-            Dimension for subscripted indexing
-
-        Returns
-        -------
-        Index
-        """
-
-        return self.data.shape[k] - 1
-
     @property
     def ndims(self) -> int:
         """Return the number of dimensions of a tenmat"""

--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -482,10 +482,7 @@ class tenmat:
         """
         s = ""
         s += "matrix corresponding to a tensor of shape "
-        if self.data.size == 0:
-            s += str(self.shape)
-        else:
-            s += (" x ").join([str(int(d)) for d in self.tshape])
+        s += str(self.tshape)
         s += "\n"
 
         s += "rindices = "

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1439,12 +1439,12 @@ class tensor:
         1.0
         >>> # produces a tensor of order 1 and size 1
         >>> X[1,1,1,:] # doctest: +NORMALIZE_WHITESPACE
-        tensor of shape 1
+        tensor of shape (1,)
         data[:] =
         [1.]
         >>> # produces a tensor of size 2 x 2 x 1
         >>> X[0:2,[2, 3],1,:] # doctest: +NORMALIZE_WHITESPACE
-        tensor of shape 2 x 2 x 1
+        tensor of shape (2, 2, 1)
         data[0, :, :] =
         [[1.]
          [1.]]
@@ -1839,8 +1839,7 @@ class tensor:
             return s
 
         s = ""
-        s += "tensor of shape "
-        s += (" x ").join([str(int(d)) for d in self.shape])
+        s += f"tensor of shape {self.shape}"
         s += "\n"
 
         if self.ndims == 1:

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -335,29 +335,6 @@ class tensor:
         """
         return ttb.tensor.from_data(np.exp(self.data))
 
-    def end(self, k: Optional[int] = None) -> int:
-        """
-        Last index of indexing expression for tensor
-
-        Parameters
-        ----------
-        k:
-            Dimension for subscripted indexing
-
-        Examples
-        --------
-        >>> X = ttb.tensor.from_data(np.ones((2,2)))
-        >>> X.end()  # linear indexing
-        3
-        >>> X.end(0)
-        1
-        """
-
-        if k is not None:  # Subscripted indexing
-            return self.shape[k] - 1
-        # For linear indexing
-        return np.prod(self.shape) - 1
-
     def find(self) -> Tuple[np.ndarray, np.ndarray]:
         """
         FIND Find subscripts of nonzero elements in a tensor.

--- a/tests/test_import_export_data.py
+++ b/tests/test_import_export_data.py
@@ -126,7 +126,7 @@ def test_import_data_array(sample_array):
     data_filename = os.path.join(os.path.dirname(__file__), "data", "matrix.tns")
     X = ttb.import_data(data_filename)
 
-    assert (M == X).all()
+    assert np.array_equal(M, X)
 
 
 @pytest.mark.indevelopment
@@ -230,14 +230,14 @@ def test_export_data_array(sample_array):
     ttb.export_data(M, data_filename)
 
     X = ttb.import_data(data_filename)
-    assert (M == X).all()
+    assert np.array_equal(M, X)
     os.unlink(data_filename)
 
     data_filename = os.path.join(os.path.dirname(__file__), "data", "matrix_int.out")
     ttb.export_data(M, data_filename, fmt_data="%d")
 
     X = ttb.import_data(data_filename)
-    assert (M == X).all()
+    assert np.array_equal(M, X)
     os.unlink(data_filename)
 
 

--- a/tests/test_khatrirao.py
+++ b/tests/test_khatrirao.py
@@ -24,9 +24,9 @@ def test_khatrirao():
             [64, 125, 216],
         ]
     )
-    assert (ttb.khatrirao(*[A, A, A]) == answer).all()
-    assert (ttb.khatrirao(*[A, A, A], reverse=True) == answer).all()
-    assert (ttb.khatrirao(A, A, A) == answer).all()
+    assert np.array_equal(ttb.khatrirao(*[A, A, A]), answer)
+    assert np.array_equal(ttb.khatrirao(*[A, A, A], reverse=True), answer)
+    assert np.array_equal(ttb.khatrirao(A, A, A), answer)
 
     # Test case where inputs are column vectors
     a_1 = np.array([[1], [1], [1], [1]])
@@ -40,8 +40,8 @@ def test_khatrirao():
             a_2[3, 0] * np.ones((16, 1)),
         )
     )
-    assert (ttb.khatrirao(*[a_2, a_1, a_1]) == result).all()
-    assert (ttb.khatrirao(a_2, a_1, a_1) == result).all()
+    assert np.array_equal(ttb.khatrirao(*[a_2, a_1, a_1]), result)
+    assert np.array_equal(ttb.khatrirao(a_2, a_1, a_1), result)
 
     with pytest.raises(AssertionError) as excinfo:
         ttb.khatrirao(a_2, a_1, np.ones((2, 2, 2)))

--- a/tests/test_ktensor.py
+++ b/tests/test_ktensor.py
@@ -274,14 +274,6 @@ def test_ktensor_double(sample_ktensor_2way, sample_ktensor_3way):
     assert (K3.double() == A).all()
 
 
-def test_ktensor_end(sample_ktensor_3way):
-    (data, K) = sample_ktensor_3way
-    assert K.end() == 23
-    assert K.end(k=0) == 1
-    assert K.end(k=1) == 2
-    assert K.end(k=2) == 3
-
-
 def test_ktensor_extract(sample_ktensor_3way):
     (data, K) = sample_ktensor_3way
     weights = data["weights"][[1]]

--- a/tests/test_ktensor.py
+++ b/tests/test_ktensor.py
@@ -65,26 +65,26 @@ def test_ktensor_init(sample_ktensor_2way):
 
     # Input: none (empty ktensor)
     K = ttb.ktensor()
-    assert (K.weights == empty).all()
+    assert np.array_equal(K.weights, empty)
     assert K.factor_matrices == []
 
     # Input: factor_matrices, weights
     (data, K) = sample_ktensor_2way
     K = ttb.ktensor(data["factor_matrices"], data["weights"])
-    assert (K.weights == data["weights"]).all()
-    assert (K.factor_matrices[0] == data["factor_matrices"][0]).all()
-    assert (K.factor_matrices[1] == data["factor_matrices"][1]).all()
+    assert np.array_equal(K.weights, data["weights"])
+    assert np.array_equal(K.factor_matrices[0], data["factor_matrices"][0])
+    assert np.array_equal(K.factor_matrices[1], data["factor_matrices"][1])
 
     # Input: factor_matrices provided, weights = None
     K = ttb.ktensor(data["factor_matrices"])
-    assert (
-        K.weights
-        == np.ones(
+    assert np.array_equal(
+        K.weights,
+        np.ones(
             2,
-        )
-    ).all()
-    assert (K.factor_matrices[0] == data["factor_matrices"][0]).all()
-    assert (K.factor_matrices[1] == data["factor_matrices"][1]).all()
+        ),
+    )
+    assert np.array_equal(K.factor_matrices[0], data["factor_matrices"][0])
+    assert np.array_equal(K.factor_matrices[1], data["factor_matrices"][1])
 
     # Input: copy=True
     K = ttb.ktensor(data["factor_matrices"], data["weights"])
@@ -132,14 +132,14 @@ def test_ktensor_init(sample_ktensor_2way):
 
 def test_ktensor_from_function():
     K0 = ttb.ktensor.from_function(np.ones, (2, 3, 4), 2)
-    assert (K0.weights == np.array([1.0, 1.0])).all()
-    assert (K0.factor_matrices[0] == np.ones((2, 2))).all()
-    assert (K0.factor_matrices[1] == np.ones((3, 2))).all()
-    assert (K0.factor_matrices[2] == np.ones((4, 2))).all()
+    assert np.array_equal(K0.weights, np.array([1.0, 1.0]))
+    assert np.array_equal(K0.factor_matrices[0], np.ones((2, 2)))
+    assert np.array_equal(K0.factor_matrices[1], np.ones((3, 2)))
+    assert np.array_equal(K0.factor_matrices[2], np.ones((4, 2)))
 
     np.random.seed(1)
     K1 = ttb.ktensor.from_function(np.random.random_sample, (2, 3, 4), 2)
-    assert (K1.weights == np.array([1.0, 1.0])).all()
+    assert np.array_equal(K1.weights, np.array([1.0, 1.0]))
     fm0 = np.array([[4.17022005e-01, 7.20324493e-01], [1.14374817e-04, 3.02332573e-01]])
     fm1 = np.array(
         [[0.14675589, 0.09233859], [0.18626021, 0.34556073], [0.39676747, 0.53881673]]
@@ -162,25 +162,25 @@ def test_ktensor_from_vector(sample_ktensor_3way):
 
     # without explicit weights in x
     K0 = ttb.ktensor.from_vector(data["vector"], data["shape"], False)
-    assert (K0.weights == np.ones((3, 1))).all()
-    assert (K0.factor_matrices[0] == data["factor_matrices"][0]).all()
-    assert (K0.factor_matrices[1] == data["factor_matrices"][1]).all()
-    assert (K0.factor_matrices[2] == data["factor_matrices"][2]).all()
+    assert np.array_equal(K0.weights, np.ones((2,)))
+    assert np.array_equal(K0.factor_matrices[0], data["factor_matrices"][0])
+    assert np.array_equal(K0.factor_matrices[1], data["factor_matrices"][1])
+    assert np.array_equal(K0.factor_matrices[2], data["factor_matrices"][2])
 
     # with explicit weights in x
     K1 = ttb.ktensor.from_vector(data["vector_with_weights"], data["shape"], True)
-    assert (K1.weights == data["weights"]).all()
-    assert (K1.factor_matrices[0] == data["factor_matrices"][0]).all()
-    assert (K1.factor_matrices[1] == data["factor_matrices"][1]).all()
-    assert (K1.factor_matrices[2] == data["factor_matrices"][2]).all()
+    assert np.array_equal(K1.weights, data["weights"])
+    assert np.array_equal(K1.factor_matrices[0], data["factor_matrices"][0])
+    assert np.array_equal(K1.factor_matrices[1], data["factor_matrices"][1])
+    assert np.array_equal(K1.factor_matrices[2], data["factor_matrices"][2])
 
     # data as a row vector will work, but will be transposed
     transposed_data = data["vector"].copy().reshape((1, len(data["vector"])))
     K2 = ttb.ktensor.from_vector(transposed_data, data["shape"], False)
-    assert (K2.weights == np.ones((3, 1))).all()
-    assert (K2.factor_matrices[0] == data["factor_matrices"][0]).all()
-    assert (K2.factor_matrices[1] == data["factor_matrices"][1]).all()
-    assert (K2.factor_matrices[2] == data["factor_matrices"][2]).all()
+    assert np.array_equal(K2.weights, np.ones((2,)))
+    assert np.array_equal(K2.factor_matrices[0], data["factor_matrices"][0])
+    assert np.array_equal(K2.factor_matrices[1], data["factor_matrices"][1])
+    assert np.array_equal(K2.factor_matrices[2], data["factor_matrices"][2])
 
     # error if the shape does not match the the number of data elements
     with pytest.raises(AssertionError) as excinfo:
@@ -196,9 +196,9 @@ def test_ktensor_arrange(sample_ktensor_2way):
     K0 = K.copy()
     p = [1, 0]
     K0.arrange(permutation=p)
-    assert (K0.weights == data["weights"][p]).all()
-    assert (K0.factor_matrices[0] == data["factor_matrices"][0][:, p]).all()
-    assert (K0.factor_matrices[1] == data["factor_matrices"][1][:, p]).all()
+    assert np.array_equal(K0.weights, data["weights"][p])
+    assert np.array_equal(K0.factor_matrices[0], data["factor_matrices"][0][:, p])
+    assert np.array_equal(K0.factor_matrices[1], data["factor_matrices"][1][:, p])
 
     # normalize and arrange by sorting weights (default)
     K1 = K.copy()
@@ -230,9 +230,9 @@ def test_ktensor_arrange(sample_ktensor_2way):
 def test_ktensor_copy(sample_ktensor_2way):
     (data, K0) = sample_ktensor_2way
     K1 = K0.copy()
-    assert (K0.weights == K1.weights).all()
-    assert (K0.factor_matrices[0] == K1.factor_matrices[0]).all()
-    assert (K0.factor_matrices[1] == K1.factor_matrices[1]).all()
+    assert np.array_equal(K0.weights, K1.weights)
+    assert np.array_equal(K0.factor_matrices[0], K1.factor_matrices[0])
+    assert np.array_equal(K0.factor_matrices[1], K1.factor_matrices[1])
 
     # make sure it is a deep copy
     K1.weights[0] = 0
@@ -241,7 +241,7 @@ def test_ktensor_copy(sample_ktensor_2way):
 
 def test_ktensor_double(sample_ktensor_2way, sample_ktensor_3way):
     (data2, K2) = sample_ktensor_2way
-    assert (K2.double() == np.array([[29.0, 39.0], [63.0, 85.0]])).all()
+    assert np.array_equal(K2.double(), np.array([[29.0, 39.0], [63.0, 85.0]]))
     (data3, K3) = sample_ktensor_3way
     A = np.array(
         [
@@ -271,7 +271,7 @@ def test_ktensor_double(sample_ktensor_2way, sample_ktensor_3way):
             1832.0,
         ]
     ).reshape((2, 3, 4))
-    assert (K3.double() == A).all()
+    assert np.array_equal(K3.double(), A)
 
 
 def test_ktensor_extract(sample_ktensor_3way):
@@ -434,25 +434,25 @@ def test_ktensor_issymetric(sample_ktensor_2way, sample_ktensor_symmetric):
     (data, K) = sample_ktensor_2way
     assert ~(K.issymmetric())
     issym, diffs = K.issymmetric(return_diffs=True)
-    assert (diffs == np.array([[0.0, 8.0], [0.0, 0]])).all()
+    assert np.array_equal(diffs, np.array([[0.0, 8.0], [0.0, 0]]))
 
     # should be symmetric
     (datas, K1) = sample_ktensor_symmetric
     assert K1.issymmetric()
     issym1, diffs1 = K1.issymmetric(return_diffs=True)
-    assert (diffs1 == np.array([[0.0, 0.0], [0.0, 0]])).all()
+    assert np.array_equal(diffs1, np.array([[0.0, 0.0], [0.0, 0]]))
 
     # Wrong shape
     K2 = ttb.ktensor.from_function(np.ones, (2, 3), 2)
     assert ~(K2.issymmetric())
     issym2, diffs2 = K2.issymmetric(return_diffs=True)
-    assert (diffs2 == np.array([[0.0, np.inf], [0.0, 0]])).all()
+    assert np.array_equal(diffs2, np.array([[0.0, np.inf], [0.0, 0]]))
 
 
 def test_ktensor_mask(sample_ktensor_2way):
     (data, K) = sample_ktensor_2way
     W = ttb.tensor.from_data(np.array([[0, 1], [1, 0]]))
-    assert (K.mask(W) == np.array([[63], [39]])).all()
+    assert np.array_equal(K.mask(W), np.array([[63], [39]]))
 
     # Mask too large
     with pytest.raises(AssertionError) as excinfo:
@@ -466,7 +466,7 @@ def test_ktensor_mttkrp(sample_ktensor_3way):
     output0 = np.array(
         [[12492.0, 12492.0, 12492.0, 12492.0], [17856.0, 17856.0, 17856.0, 17856.0]]
     )
-    assert (K.mttkrp(K1.factor_matrices, 0) == output0).all()
+    assert np.array_equal(K.mttkrp(K1.factor_matrices, 0), output0)
     output1 = np.array(
         [
             [8892.0, 8892.0, 8892.0, 8892],
@@ -474,7 +474,7 @@ def test_ktensor_mttkrp(sample_ktensor_3way):
             [11340.0, 11340.0, 11340.0, 11340],
         ]
     )
-    assert (K.mttkrp(K1.factor_matrices, 1) == output1).all()
+    assert np.array_equal(K.mttkrp(K1.factor_matrices, 1), output1)
     output2 = np.array(
         [
             [6858.0, 6858.0, 6858.0, 6858],
@@ -483,7 +483,7 @@ def test_ktensor_mttkrp(sample_ktensor_3way):
             [8316.0, 8316.0, 8316.0, 8316],
         ]
     )
-    assert (K.mttkrp(K1.factor_matrices, 2) == output2).all()
+    assert np.array_equal(K.mttkrp(K1.factor_matrices, 2), output2)
 
     # Wrong number of factor matrices
     fm_wrong_size = [
@@ -772,9 +772,9 @@ def test_ktensor_permute(sample_ktensor_3way):
 def test_ktensor_redistribute(sample_ktensor_2way):
     (data, K) = sample_ktensor_2way
     K.redistribute(0)
-    assert (np.array([[1, 4], [3, 8]]) == K[0]).all()
-    assert (np.array([[5, 6], [7, 8]]) == K[1]).all()
-    assert (np.array([1, 1]) == K.weights).all()
+    assert np.array_equal(np.array([[1, 4], [3, 8]]), K[0])
+    assert np.array_equal(np.array([[5, 6], [7, 8]]), K[1])
+    assert np.array_equal(np.array([1, 1]), K.weights)
 
 
 def test_ktensor_score():
@@ -790,14 +790,14 @@ def test_ktensor_score():
     assert score == 0.875
     assert np.allclose(Aperm.weights, np.array([15.49193338, 23.23790008, 7.74596669]))
     assert flag == 1
-    assert (best_perm == np.array([0, 2, 1])).all()
+    assert np.array_equal(best_perm, np.array([0, 2, 1]))
 
     # compare just factor matrices (i.e., do not use weights)
     score, Aperm, flag, best_perm = A.score(B, weight_penalty=False)
     assert score == 1.0
     assert np.allclose(Aperm.weights, np.array([15.49193338, 7.74596669, 23.23790008]))
     assert flag == 1
-    assert (best_perm == np.array([0, 1, 2])).all()
+    assert np.array_equal(best_perm, np.array([0, 1, 2]))
 
     # zero lambda values lead to equal components
     A0 = ttb.ktensor(
@@ -962,8 +962,8 @@ def test_ktensor_tolist(sample_ktensor_3way):
 
 def test_ktensor_tovec(sample_ktensor_3way):
     (data, K0) = sample_ktensor_3way
-    assert (data["vector_with_weights"] == K0.tovec()).all()
-    assert (data["vector"] == K0.tovec(include_weights=False)).all()
+    assert np.array_equal(data["vector_with_weights"], K0.tovec())
+    assert np.array_equal(data["vector"], K0.tovec(include_weights=False))
 
 
 def test_ktensor_ttv(sample_ktensor_3way):
@@ -1008,31 +1008,47 @@ def test_ktensor_update(sample_ktensor_3way):
     vec1 = np.random.randn(K.shape[1] * K.ncomponents)
     vec2 = np.random.randn(K.shape[2] * K.ncomponents)
     K1.update(0, vec0)
-    assert (K1.factor_matrices[0] == vec0.reshape((K1.shape[0], K1.ncomponents))).all()
+    assert np.array_equal(
+        K1.factor_matrices[0], vec0.reshape((K1.shape[0], K1.ncomponents))
+    )
     K1.update(1, vec1)
-    assert (K1.factor_matrices[1] == vec1.reshape((K1.shape[1], K1.ncomponents))).all()
+    assert np.array_equal(
+        K1.factor_matrices[1], vec1.reshape((K1.shape[1], K1.ncomponents))
+    )
     K1.update(2, vec2)
-    assert (K1.factor_matrices[2] == vec2.reshape((K1.shape[2], K1.ncomponents))).all()
+    assert np.array_equal(
+        K1.factor_matrices[2], vec2.reshape((K1.shape[2], K1.ncomponents))
+    )
 
     # all factor matrix updates
     K2 = K.copy()
     vec_all = np.concatenate((vec0, vec1, vec2))
     K2.update([0, 1, 2], vec_all)
-    assert (K2.factor_matrices[0] == vec0.reshape((K2.shape[0], K2.ncomponents))).all()
-    assert (K2.factor_matrices[1] == vec1.reshape((K2.shape[1], K2.ncomponents))).all()
-    assert (K2.factor_matrices[2] == vec2.reshape((K2.shape[2], K2.ncomponents))).all()
+    assert np.array_equal(
+        K2.factor_matrices[0], vec0.reshape((K2.shape[0], K2.ncomponents))
+    )
+    assert np.array_equal(
+        K2.factor_matrices[1], vec1.reshape((K2.shape[1], K2.ncomponents))
+    )
+    assert np.array_equal(
+        K2.factor_matrices[2], vec2.reshape((K2.shape[2], K2.ncomponents))
+    )
 
     # multiple but not all factor matrix updates
     K3 = K.copy()
     vec_some = np.concatenate((vec0, vec2))
     K3.update([0, 2], vec_some)
-    assert (K3.factor_matrices[0] == vec0.reshape((K3.shape[0], K3.ncomponents))).all()
-    assert (K3.factor_matrices[2] == vec2.reshape((K3.shape[2], K3.ncomponents))).all()
+    assert np.array_equal(
+        K3.factor_matrices[0], vec0.reshape((K3.shape[0], K3.ncomponents))
+    )
+    assert np.array_equal(
+        K3.factor_matrices[2], vec2.reshape((K3.shape[2], K3.ncomponents))
+    )
 
     # weights update
     weights = np.array([100, 200])
     K1.update(-1, weights)
-    assert (K1.weights == weights).all()
+    assert np.array_equal(K1.weights, weights)
 
     # not enough weights
     with pytest.raises(AssertionError) as excinfo:
@@ -1066,14 +1082,16 @@ def test_ktensor__add__(sample_ktensor_2way, sample_ktensor_3way):
     (data1, K1) = sample_ktensor_3way
     # adding ktensor to itself
     K2 = K0 + K0
-    assert (np.concatenate((data0["weights"], data0["weights"])) == K2.weights).all()
+    assert np.array_equal(
+        np.concatenate((data0["weights"], data0["weights"])), K2.weights
+    )
     for k in range(K2.ndims):
-        assert (
+        assert np.array_equal(
             np.concatenate(
                 (data0["factor_matrices"][k], data0["factor_matrices"][k]), axis=1
-            )
-            == K2.factor_matrices[k]
-        ).all()
+            ),
+            K2.factor_matrices[k],
+        )
 
     # shapes do not match, should raise error
     with pytest.raises(AssertionError) as excinfo:
@@ -1099,10 +1117,10 @@ def test_ktensor__getitem__(sample_ktensor_2way):
     assert K[0, 1] == 39
     assert K[1, 0] == 63
     assert K[1, 1] == 85
-    assert (data["factor_matrices"][0] == K[0]).all()
-    assert (data["factor_matrices"][1] == K[1]).all()
+    assert np.array_equal(data["factor_matrices"][0], K[0])
+    assert np.array_equal(data["factor_matrices"][1], K[1])
     # to return a 2D ndarray, the columns must be defined by a slice
-    assert (data["factor_matrices"][0][:, [0]] == K[0][:, [0]]).all()
+    assert np.array_equal(data["factor_matrices"][0][:, [0]], K[0][:, [0]])
     with pytest.raises(AssertionError) as excinfo:
         K[0, 0, 0]
     assert "ktensor.__getitem__ requires tuples with 2 elements" in str(excinfo)
@@ -1119,9 +1137,9 @@ def test_ktensor__neg__(sample_ktensor_2way):
     # adding ktensor to itself
     K1 = -K0
     K2 = -K1
-    assert (-data0["weights"] == K1.weights).all()
+    assert np.array_equal(-data0["weights"], K1.weights)
     for k in range(K1.ndims):
-        assert (data0["factor_matrices"][k] == K1.factor_matrices[k]).all()
+        assert np.array_equal(data0["factor_matrices"][k], K1.factor_matrices[k])
     assert K2.isequal(K0)
 
 
@@ -1129,9 +1147,9 @@ def test_ktensor__pos__(sample_ktensor_2way):
     (data0, K0) = sample_ktensor_2way
     # adding ktensor to itself
     K1 = +K0
-    assert (data0["weights"] == K1.weights).all()
+    assert np.array_equal(data0["weights"], K1.weights)
     for k in range(K1.ndims):
-        assert (data0["factor_matrices"][k] == K1.factor_matrices[k]).all()
+        assert np.array_equal(data0["factor_matrices"][k], K1.factor_matrices[k])
     assert K1.isequal(K0)
 
 
@@ -1151,14 +1169,16 @@ def test_ktensor__sub__(sample_ktensor_2way, sample_ktensor_3way):
     (data1, K1) = sample_ktensor_3way
     # adding ktensor to itself
     K2 = K0 - K0
-    assert (np.concatenate((data0["weights"], -data0["weights"])) == K2.weights).all()
+    assert np.array_equal(
+        np.concatenate((data0["weights"], -data0["weights"])), K2.weights
+    )
     for k in range(K2.ndims):
-        assert (
+        assert np.array_equal(
             np.concatenate(
                 (data0["factor_matrices"][k], data0["factor_matrices"][k]), axis=1
-            )
-            == K2.factor_matrices[k]
-        ).all()
+            ),
+            K2.factor_matrices[k],
+        )
     # shapes do not match, should raise error
     with pytest.raises(AssertionError) as excinfo:
         K3 = K0 - K1
@@ -1179,13 +1199,13 @@ def test_ktensor__sub__(sample_ktensor_2way, sample_ktensor_3way):
 def test_ktensor__mul__(sample_ktensor_2way, sample_ktensor_3way):
     (data0, K0) = sample_ktensor_2way
     K1 = 2 * K0
-    assert (2 * data0["weights"] == K1.weights).all()
+    assert np.array_equal(2 * data0["weights"], K1.weights)
     for k in range(K1.ndims):
-        assert (data0["factor_matrices"][k] == K1.factor_matrices[k]).all()
+        assert np.array_equal(data0["factor_matrices"][k], K1.factor_matrices[k])
     K2 = K0 * 2
-    assert (2 * data0["weights"] == K2.weights).all()
+    assert np.array_equal(2 * data0["weights"], K2.weights)
     for k in range(K1.ndims):
-        assert (data0["factor_matrices"][k] == K2.factor_matrices[k]).all()
+        assert np.array_equal(data0["factor_matrices"][k], K2.factor_matrices[k])
     with pytest.raises(AssertionError) as excinfo:
         K3 = K0 * K0
     assert (
@@ -1198,7 +1218,7 @@ def test_ktensor__mul__(sample_ktensor_2way, sample_ktensor_3way):
     Tshape = (2, 2)
     T = ttb.tensor.from_data(Tdata, Tshape)
     K0T = K0 * T
-    assert (K0T.double() == np.array([[29.0, 78.0], [189.0, 340.0]])).all()
+    assert np.array_equal(K0T.double(), np.array([[29.0, 78.0], [189.0, 340.0]]))
 
     # test with sptensor
     Ssubs = np.array([[0, 0], [0, 1], [1, 1]])
@@ -1206,7 +1226,7 @@ def test_ktensor__mul__(sample_ktensor_2way, sample_ktensor_3way):
     Sshape = (2, 2)
     S = ttb.sptensor.from_data(Ssubs, Svals, Sshape)
     K0S = S * K0
-    assert (K0S.double() == np.array([[14.5, 39.0], [0.0, 127.5]])).all()
+    assert np.array_equal(K0S.double(), np.array([[14.5, 39.0], [0.0, 127.5]]))
 
 
 def test_ktensor__str__(sample_ktensor_2way):

--- a/tests/test_pyttb_utils.py
+++ b/tests/test_pyttb_utils.py
@@ -55,25 +55,25 @@ def test_sptensor_from_dense_matrix():
 def test_tt_union_rows():
     a = np.array([[4, 6], [1, 9], [2, 6], [2, 6], [99, 0]])
     b = np.array([[1, 7], [1, 8], [2, 6]])
-    assert (
-        ttb.tt_union_rows(a, b)
-        == np.array([[1, 7], [1, 8], [4, 6], [1, 9], [2, 6], [99, 0]])
-    ).all()
+    assert np.array_equal(
+        ttb.tt_union_rows(a, b),
+        np.array([[1, 7], [1, 8], [4, 6], [1, 9], [2, 6], [99, 0]]),
+    )
     _, idx = np.unique(a, axis=0, return_index=True)
-    assert (ttb.tt_union_rows(a, np.array([])) == a[np.sort(idx)]).all()
-    assert (ttb.tt_union_rows(np.array([]), a) == a[np.sort(idx)]).all()
+    assert np.array_equal(ttb.tt_union_rows(a, np.array([])), a[np.sort(idx)])
+    assert np.array_equal(ttb.tt_union_rows(np.array([]), a), a[np.sort(idx)])
 
 
 @pytest.mark.indevelopment
 def test_tt_dimscheck():
     #  Empty
     rdims, ridx = ttb.tt_dimscheck(6, dims=np.array([]))
-    assert (rdims == np.array([0, 1, 2, 3, 4, 5])).all()
+    assert np.array_equal(rdims, np.array([0, 1, 2, 3, 4, 5]))
     assert ridx is None
 
     # Exclude Dims
     rdims, ridx = ttb.tt_dimscheck(6, exclude_dims=np.array([1]))
-    assert (rdims == np.array([0, 2, 3, 4, 5])).all()
+    assert np.array_equal(rdims, np.array([0, 2, 3, 4, 5]))
     assert ridx is None
 
     # Invalid minus
@@ -83,18 +83,18 @@ def test_tt_dimscheck():
 
     # Positive
     rdims, ridx = ttb.tt_dimscheck(6, dims=np.array([5]))
-    assert (rdims == np.array([5])).all()
+    assert np.array_equal(rdims, np.array([5]))
     assert ridx is None
 
     # M==P
     rdims, ridx = ttb.tt_dimscheck(6, 5, exclude_dims=np.array([0]))
-    assert (rdims == np.array([1, 2, 3, 4, 5])).all()
-    assert (ridx == np.arange(0, 5)).all()
+    assert np.array_equal(rdims, np.array([1, 2, 3, 4, 5]))
+    assert np.array_equal(ridx, np.arange(0, 5))
 
     # M==N
     rdims, ridx = ttb.tt_dimscheck(6, 6, exclude_dims=np.array([0]))
-    assert (rdims == np.array([1, 2, 3, 4, 5])).all()
-    assert (ridx == rdims).all()
+    assert np.array_equal(rdims, np.array([1, 2, 3, 4, 5]))
+    assert np.array_equal(ridx, rdims)
 
     # M>N
     with pytest.raises(AssertionError) as excinfo:
@@ -127,23 +127,23 @@ def test_tt_tenfun():
     def add(x, y):
         return x + y
 
-    assert (ttb.tt_tenfun(add, t1, t2).data == 2 * data).all()
+    assert np.array_equal(ttb.tt_tenfun(add, t1, t2).data, 2 * data)
 
     # Single argument case
     def add1(x):
         return x + 1
 
-    assert (ttb.tt_tenfun(add1, t1).data == (data + 1)).all()
+    assert np.array_equal(ttb.tt_tenfun(add1, t1).data, (data + 1))
 
     # Multi argument case
     def tensor_max(x):
         return np.max(x, axis=0)
 
-    assert (ttb.tt_tenfun(tensor_max, t1, t1, t1).data == data).all()
+    assert np.array_equal(ttb.tt_tenfun(tensor_max, t1, t1, t1).data, data)
     # TODO: sptensor arguments, depends on fixing the indexing ordering
 
     # No np array case
-    assert (ttb.tt_tenfun(tensor_max, data, data, data).data == data).all()
+    assert np.array_equal(ttb.tt_tenfun(tensor_max, data, data, data).data, data)
 
     # No argument case
     with pytest.raises(AssertionError) as excinfo:
@@ -177,16 +177,16 @@ def test_tt_setdiff_rows():
     b = np.array(
         [[1, 7], [1, 8], [2, 6], [2, 1], [2, 4], [4, 6], [4, 7], [5, 9], [5, 2], [5, 1]]
     )
-    assert (ttb.tt_setdiff_rows(a, b) == np.array([1, 4])).all()
+    assert np.array_equal(ttb.tt_setdiff_rows(a, b), np.array([1, 4]))
 
     a = np.array([[4, 6], [1, 9]])
     b = np.array([[1, 7], [1, 8]])
-    assert (ttb.tt_setdiff_rows(a, b) == np.array([0, 1])).all()
+    assert np.array_equal(ttb.tt_setdiff_rows(a, b), np.array([0, 1]))
 
     a = np.array([[4, 6], [1, 9]])
     b = np.array([])
-    assert (ttb.tt_setdiff_rows(a, b) == np.arange(a.shape[0])).all()
-    assert (ttb.tt_setdiff_rows(b, a) == b).all()
+    assert np.array_equal(ttb.tt_setdiff_rows(a, b), np.arange(a.shape[0]))
+    assert np.array_equal(ttb.tt_setdiff_rows(b, a), b)
 
 
 @pytest.mark.indevelopment
@@ -195,12 +195,12 @@ def test_tt_intersect_rows():
     b = np.array(
         [[1, 7], [1, 8], [2, 6], [2, 1], [2, 4], [4, 6], [4, 7], [5, 9], [5, 2], [5, 1]]
     )
-    assert (ttb.tt_intersect_rows(a, b) == np.array([2, 0])).all()
+    assert np.array_equal(ttb.tt_intersect_rows(a, b), np.array([2, 0]))
 
     a = np.array([[4, 6], [1, 9]])
     b = np.array([])
-    assert (ttb.tt_intersect_rows(a, b) == b).all()
-    assert (ttb.tt_intersect_rows(a, b) == ttb.tt_intersect_rows(b, a)).all()
+    assert np.array_equal(ttb.tt_intersect_rows(a, b), b)
+    assert np.array_equal(ttb.tt_intersect_rows(a, b), ttb.tt_intersect_rows(b, a))
 
 
 @pytest.mark.indevelopment
@@ -209,10 +209,10 @@ def test_tt_ismember_rows():
     b = np.array(
         [[1, 7], [1, 8], [2, 6], [2, 1], [2, 4], [4, 6], [4, 7], [5, 9], [5, 2], [5, 1]]
     )
-    assert (ttb.tt_ismember_rows(a, b) == np.array([5, -1, 2])).all()
-    assert (
-        ttb.tt_ismember_rows(b, a) == np.array([-1, -1, 2, -1, -1, 0, -1, -1, -1, -1])
-    ).all()
+    assert np.array_equal(ttb.tt_ismember_rows(a, b), np.array([5, -1, 2]))
+    assert np.array_equal(
+        ttb.tt_ismember_rows(b, a), np.array([-1, -1, 2, -1, -1, 0, -1, -1, -1, -1])
+    )
 
 
 @pytest.mark.indevelopment
@@ -235,23 +235,23 @@ def test_tt_irenumber():
     )
 
     # Pad equal to number of modes
-    assert (
-        ttb.tt_irenumber(sptensorInstance, shape, (const, const, const))
-        == extended_result
-    ).all()
+    assert np.array_equal(
+        ttb.tt_irenumber(sptensorInstance, shape, (const, const, const)),
+        extended_result,
+    )
 
     # Full slice should equal original
-    assert (ttb.tt_irenumber(sptensorInstance, shape, slice_tuple) == subs).all()
+    assert np.array_equal(ttb.tt_irenumber(sptensorInstance, shape, slice_tuple), subs)
 
     # Verify that list and equivalent slice act the same
-    assert (
-        ttb.tt_irenumber(sptensorInstance, shape, (const, const, slice(0, 1, 1)))
-        == np.array([[const, const, const, const, 0], [const, const, const, const, 1]])
-    ).all()
-    assert (
-        ttb.tt_irenumber(sptensorInstance, shape, (const, const, [0, 1]))
-        == np.array([[const, const, const, const, 0], [const, const, const, const, 1]])
-    ).all()
+    assert np.array_equal(
+        ttb.tt_irenumber(sptensorInstance, shape, (const, const, slice(0, 1, 1))),
+        np.array([[const, const, const, const, 0], [const, const, const, const, 1]]),
+    )
+    assert np.array_equal(
+        ttb.tt_irenumber(sptensorInstance, shape, (const, const, [0, 1])),
+        np.array([[const, const, const, const, 0], [const, const, const, const, 1]]),
+    )
 
 
 @pytest.mark.indevelopment
@@ -267,7 +267,7 @@ def test_tt_renumberdims():
     number_range = np.array([1, 3, 4])
     idx = [1, 3, 4]
     newidx, newshape = ttb.tt_renumberdim(idx, shape, number_range)
-    assert (newidx == np.array([0, 1, 2])).all()
+    assert np.array_equal(newidx, np.array([0, 1, 2]))
     assert newshape == 3
 
     # Slice input
@@ -275,7 +275,7 @@ def test_tt_renumberdims():
     number_range = slice(1, 3, None)
     idx = [1, 2]
     newidx, newshape = ttb.tt_renumberdim(idx, shape, number_range)
-    assert (newidx == np.array([0, 1])).all()
+    assert np.array_equal(newidx, np.array([0, 1]))
     assert newshape == 2
 
 
@@ -286,7 +286,7 @@ def test_tt_renumber():
     number_range = (1, 1, 1)
     subs = np.array([[3, 3, 3]])
     newsubs, newshape = ttb.tt_renumber(subs, shape, number_range)
-    assert (newsubs == np.array([[0, 0, 0]])).all()
+    assert np.array_equal(newsubs, np.array([[0, 0, 0]]))
     assert newshape == (0, 0, 0)
 
     # Array in each dimension
@@ -294,7 +294,7 @@ def test_tt_renumber():
     number_range = ([1, 3, 4], [1, 3, 4], [1, 3, 4])
     subs = np.array([[1, 1, 1], [3, 3, 3]])
     newsubs, newshape = ttb.tt_renumber(subs, shape, number_range)
-    assert (newsubs == np.array([[0, 0, 0], [1, 1, 1]])).all()
+    assert np.array_equal(newsubs, np.array([[0, 0, 0], [1, 1, 1]]))
     assert newshape == (3, 3, 3)
 
     # Slice in each dimension
@@ -302,7 +302,7 @@ def test_tt_renumber():
     number_range = (slice(1, 3, None), slice(1, 3, None), slice(1, 3, None))
     subs = np.array([[2, 2, 2]])
     newsubs, newshape = ttb.tt_renumber(subs, shape, number_range)
-    assert (newsubs == np.array([[1, 1, 1]])).all()
+    assert np.array_equal(newsubs, np.array([[1, 1, 1]]))
     assert newshape == (2, 2, 2)
 
     # Slice in each dimension, empty subs
@@ -327,10 +327,10 @@ def test_tt_sub2ind_valid():
     subs = np.array([[0, 0, 0], [1, 1, 1], [3, 3, 3]])
     idx = np.array([0, 21, 63])
     siz = np.array([4, 4, 4])
-    assert (ttb.tt_sub2ind(siz, subs) == idx).all()
+    assert np.array_equal(ttb.tt_sub2ind(siz, subs), idx)
 
     empty = np.array([])
-    assert (ttb.tt_sub2ind(siz, empty) == empty).all()
+    assert np.array_equal(ttb.tt_sub2ind(siz, empty), empty)
 
 
 @pytest.mark.indevelopment

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -27,14 +27,14 @@ def test_sptensor_initialization_empty():
 
     # No args
     sptensorInstance = ttb.sptensor()
-    assert (sptensorInstance.subs == empty).all()
-    assert (sptensorInstance.vals == empty).all()
+    assert np.array_equal(sptensorInstance.subs, empty)
+    assert np.array_equal(sptensorInstance.vals, empty)
     assert sptensorInstance.shape == ()
 
     # With shape
     sptensorInstance = ttb.sptensor((2, 2))
-    assert (sptensorInstance.subs == empty).all()
-    assert (sptensorInstance.vals == empty).all()
+    assert np.array_equal(sptensorInstance.subs, empty)
+    assert np.array_equal(sptensorInstance.vals, empty)
     assert sptensorInstance.shape == (2, 2)
 
     with pytest.raises(ValueError):
@@ -43,8 +43,8 @@ def test_sptensor_initialization_empty():
 
 def test_sptensor_initialization_from_data(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
-    assert (sptensorInstance.subs == data["subs"]).all()
-    assert (sptensorInstance.vals == data["vals"]).all()
+    assert np.array_equal(sptensorInstance.subs, data["subs"])
+    assert np.array_equal(sptensorInstance.vals, data["vals"])
     assert sptensorInstance.shape == data["shape"]
 
 
@@ -52,8 +52,8 @@ def test_sptensor_initialization_from_tensor_type(sample_sptensor):
     # Copy constructor
     (data, sptensorInstance) = sample_sptensor
     sptensorCopy = ttb.sptensor.from_tensor_type(sptensorInstance)
-    assert (sptensorCopy.subs == data["subs"]).all()
-    assert (sptensorCopy.vals == data["vals"]).all()
+    assert np.array_equal(sptensorCopy.subs, data["subs"])
+    assert np.array_equal(sptensorCopy.vals, data["vals"])
     assert sptensorCopy.shape == data["shape"]
 
     # Convert Tensor
@@ -63,13 +63,13 @@ def test_sptensor_initialization_from_tensor_type(sample_sptensor):
     logging.debug(f"inputData = {inputData}")
     logging.debug(f"tensorInstance = {tensorInstance}")
     logging.debug(f"sptensorFromTensor = {sptensorFromTensor}")
-    assert (
-        sptensorFromTensor.subs
-        == ttb.tt_ind2sub(inputData.shape, np.arange(0, inputData.size))
-    ).all()
-    assert (
-        sptensorFromTensor.vals == inputData.reshape((inputData.size, 1), order="F")
-    ).all()
+    assert np.array_equal(
+        sptensorFromTensor.subs,
+        ttb.tt_ind2sub(inputData.shape, np.arange(0, inputData.size)),
+    )
+    assert np.array_equal(
+        sptensorFromTensor.vals, inputData.reshape((inputData.size, 1), order="F")
+    )
     assert sptensorFromTensor.shape == inputData.shape
 
     # From coo sparse matrix
@@ -92,14 +92,14 @@ def test_sptensor_initialization_from_function():
     shape = (4, 4, 4)
     nz = 6
     sptensorInstance = ttb.sptensor.from_function(function_handle, shape, nz)
-    assert (sptensorInstance.vals == function_handle()).all()
+    assert np.array_equal(sptensorInstance.vals, function_handle())
     assert sptensorInstance.shape == shape
     assert len(sptensorInstance.subs) == nz
 
     # NZ as a propotion in [0,1)
     nz = 0.09375
     sptensorInstance = ttb.sptensor.from_function(function_handle, shape, nz)
-    assert (sptensorInstance.vals == function_handle()).all()
+    assert np.array_equal(sptensorInstance.vals, function_handle())
     assert sptensorInstance.shape == shape
     assert len(sptensorInstance.subs) == int(nz * np.prod(shape))
 
@@ -127,13 +127,17 @@ def test_sptensor_initialization_from_aggregator(sample_sptensor):
     vals = np.array([[0.5], [1.5], [2.5], [3.5], [4.5], [5.5]])
     shape = (4, 4, 4)
     a = ttb.sptensor.from_aggregator(subs, vals, shape)
-    assert (a.subs == np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])).all()
-    assert (a.vals == np.array([[10.5], [1.5], [2.5], [3.5]])).all()
+    assert np.array_equal(
+        a.subs, np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])
+    )
+    assert np.array_equal(a.vals, np.array([[10.5], [1.5], [2.5], [3.5]]))
     assert a.shape == shape
 
     a = ttb.sptensor.from_aggregator(subs, vals)
-    assert (a.subs == np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])).all()
-    assert (a.vals == np.array([[10.5], [1.5], [2.5], [3.5]])).all()
+    assert np.array_equal(
+        a.subs, np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])
+    )
+    assert np.array_equal(a.vals, np.array([[10.5], [1.5], [2.5], [3.5]]))
     assert a.shape == shape
 
     a = ttb.sptensor.from_aggregator(np.array([]), vals, shape)
@@ -160,13 +164,13 @@ def test_sptensor_and_scalar(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     b = sptensorInstance.logical_and(0)
-    assert (b.subs == np.array([])).all()
-    assert (b.vals == np.array([])).all()
+    assert np.array_equal(b.subs, np.array([]))
+    assert np.array_equal(b.vals, np.array([]))
     assert b.shape == data["shape"]
 
     b = sptensorInstance.logical_and(0.5)
-    assert (b.subs == data["subs"]).all()
-    assert (b.vals == np.array([[True], [False], [False], [False]])).all()
+    assert np.array_equal(b.subs, data["subs"])
+    assert np.array_equal(b.vals, np.array([[True], [False], [False], [False]]))
     assert b.shape == data["shape"]
 
 
@@ -174,8 +178,8 @@ def test_sptensor_and_sptensor(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
     b = sptensorInstance.logical_and(sptensorInstance)
 
-    assert (b.subs == data["subs"]).all()
-    assert (b.vals == np.array([[True], [True], [True], [True]])).all()
+    assert np.array_equal(b.subs, data["subs"])
+    assert np.array_equal(b.vals, np.array([[True], [True], [True], [True]]))
     assert b.shape == data["shape"]
 
     with pytest.raises(AssertionError) as excinfo:
@@ -194,8 +198,8 @@ def test_sptensor_and_sptensor(sample_sptensor):
 def test_sptensor_and_tensor(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
     b = sptensorInstance.logical_and(ttb.tensor.from_tensor_type(sptensorInstance))
-    assert (b.subs == data["subs"]).all()
-    assert (b.vals == np.ones(data["vals"].shape)).all()
+    assert np.array_equal(b.subs, data["subs"])
+    assert np.array_equal(b.vals, np.ones(data["vals"].shape))
 
 
 def test_sptensor_full(sample_sptensor):
@@ -205,7 +209,7 @@ def test_sptensor_full(sample_sptensor):
     actualIdx = tuple(data["subs"].transpose())
     denseData[actualIdx] = data["vals"].transpose()[0]
 
-    assert (densetensor.data == denseData).all()
+    assert np.array_equal(densetensor.data, denseData)
     assert densetensor.shape == data["shape"]
 
     # Empty, no shape tensor conversion
@@ -215,16 +219,18 @@ def test_sptensor_full(sample_sptensor):
 
     # Empty, no non-zeros tensor conversion
     emptySptensor = ttb.sptensor.from_data(np.array([]), np.array([]), data["shape"])
-    assert (emptySptensor.full().data == np.zeros(data["shape"])).all()
+    assert np.array_equal(emptySptensor.full().data, np.zeros(data["shape"]))
 
 
 def test_sptensor_subdims(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
-    assert (sptensorInstance.subdims([[1], [1], [1, 3]]) == np.array([0, 1])).all()
-    assert (
-        sptensorInstance.subdims((1, 1, slice(None, None, None))) == np.array([0, 1])
-    ).all()
+    assert np.array_equal(
+        sptensorInstance.subdims([[1], [1], [1, 3]]), np.array([0, 1])
+    )
+    assert np.array_equal(
+        sptensorInstance.subdims((1, 1, slice(None, None, None))), np.array([0, 1])
+    )
 
     with pytest.raises(AssertionError) as excinfo:
         sptensorInstance.subdims([[1], [1, 3]])
@@ -256,13 +262,13 @@ def test_sptensor_extract(sample_sptensor, capsys):
     capsys.readouterr()
 
     # List of subs case
-    assert (
-        sptensorInstance.extract(np.array([[1, 1, 1], [1, 1, 3]])) == [[0.5], [1.5]]
-    ).all()
+    assert np.array_equal(
+        sptensorInstance.extract(np.array([[1, 1, 1], [1, 1, 3]])), [[0.5], [1.5]]
+    )
 
     # Single sub case
     # TODO if you pass a single sub should you get a list of vals with one entry or just a single val
-    assert (sptensorInstance.extract(np.array([1, 1, 1])) == [[0.5]]).all()
+    assert np.array_equal(sptensorInstance.extract(np.array([1, 1, 1])), [[0.5]])
 
 
 class TestGetItem:
@@ -525,8 +531,8 @@ class TestSetItem:
         emptyTensor = ttb.sptensor((4, 4, 4, 4))
         sptensorCopy = ttb.sptensor.from_tensor_type(sptensorInstance)
         sptensorCopy[:4, :4, :4, :4] = emptyTensor
-        assert (sptensorCopy.subs == emptyTensor.subs).all()
-        assert (sptensorCopy.vals == emptyTensor.vals).all()
+        assert np.array_equal(sptensorCopy.subs, emptyTensor.subs)
+        assert np.array_equal(sptensorCopy.vals, emptyTensor.vals)
         assert sptensorCopy.shape == emptyTensor.shape
 
     def test_subtensor_clear(
@@ -639,8 +645,8 @@ class TestSetItem:
         sptensorCopy[0, 0, 0, 0] = 1
         sptensorCopy[1, 1, 1, 1] = 1
         emptyTensor[[0, 1], [0, 1], [0, 1], [0, 1]] = sptensorCopy
-        assert (sptensorCopy.subs == emptyTensor.subs).all()
-        assert (sptensorCopy.vals == emptyTensor.vals).all()
+        assert np.array_equal(sptensorCopy.subs, emptyTensor.subs)
+        assert np.array_equal(sptensorCopy.vals, emptyTensor.vals)
         assert sptensorCopy.shape == emptyTensor.shape
 
 
@@ -656,7 +662,7 @@ def test_sptensor_allsubs(sample_sptensor):
         for j in range(0, data["shape"][1]):
             for k in range(0, data["shape"][2]):
                 result.append([i, j, k])
-    assert (sptensorInstance.allsubs() == np.array(result)).all()
+    assert np.array_equal(sptensorInstance.allsubs(), np.array(result))
 
 
 def test_sptensor_logical_not(sample_sptensor):
@@ -669,8 +675,8 @@ def test_sptensor_logical_not(sample_sptensor):
                 if [i, j, k] not in data_subs:
                     result.append([i, j, k])
     notSptensorInstance = sptensorInstance.logical_not()
-    assert (notSptensorInstance.vals == 1).all()
-    assert (notSptensorInstance.subs == np.array(result)).all()
+    assert all(notSptensorInstance.vals == 1)
+    assert np.array_equal(notSptensorInstance.subs, np.array(result))
     assert notSptensorInstance.shape == data["shape"]
 
 
@@ -680,8 +686,8 @@ def test_sptensor_logical_or(sample_sptensor):
     # Sptensor logical or with another sptensor
     sptensorOr = sptensorInstance.logical_or(sptensorInstance)
     assert sptensorOr.shape == data["shape"]
-    assert (sptensorOr.subs == data["subs"]).all()
-    assert (sptensorOr.vals == np.ones((data["vals"].shape[0], 1))).all()
+    assert np.array_equal(sptensorOr.subs, data["subs"])
+    assert np.array_equal(sptensorOr.vals, np.ones((data["vals"].shape[0], 1)))
 
     # Sptensor logical or with tensor
     sptensorOr = sptensorInstance.logical_or(
@@ -689,15 +695,15 @@ def test_sptensor_logical_or(sample_sptensor):
     )
     nonZeroMatrix = np.zeros(data["shape"])
     nonZeroMatrix[tuple(data["subs"].transpose())] = 1
-    assert (sptensorOr.data == nonZeroMatrix).all()
+    assert np.array_equal(sptensorOr.data, nonZeroMatrix)
 
     # Sptensor logical or with scalar, 0
     sptensorOr = sptensorInstance.logical_or(0)
-    assert (sptensorOr.data == nonZeroMatrix).all()
+    assert np.array_equal(sptensorOr.data, nonZeroMatrix)
 
     # Sptensor logical or with scalar, not 0
     sptensorOr = sptensorInstance.logical_or(1)
-    assert (sptensorOr.data == np.ones(data["shape"])).all()
+    assert np.array_equal(sptensorOr.data, np.ones(data["shape"]))
 
     # Sptensor logical or with wrong shape sptensor
     with pytest.raises(AssertionError) as excinfo:
@@ -717,16 +723,15 @@ def test_sptensor__eq__(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     eqSptensor = sptensorInstance == 0.0
-    assert (eqSptensor.subs == sptensorInstance.logical_not().subs).all()
+    assert np.array_equal(eqSptensor.subs, sptensorInstance.logical_not().subs)
 
     eqSptensor = sptensorInstance == 0.5
-    assert (eqSptensor.subs == data["subs"][0]).all()
+    assert np.array_equal(eqSptensor.subs.squeeze(), data["subs"][0])
 
     eqSptensor = sptensorInstance == sptensorInstance
-    assert (
-        eqSptensor.subs
-        == np.vstack((sptensorInstance.logical_not().subs, data["subs"]))
-    ).all()
+    assert np.array_equal(
+        eqSptensor.subs, np.vstack((sptensorInstance.logical_not().subs, data["subs"]))
+    )
 
     denseTensor = ttb.tensor.from_tensor_type(sptensorInstance)
     eqSptensor = sptensorInstance == denseTensor
@@ -767,13 +772,13 @@ def test_sptensor__ne__(sample_sptensor):
     )
 
     eqSptensor = sptensorInstance != 0.0
-    assert (eqSptensor.vals == 0 * sptensorInstance.vals + 1).all()
+    assert np.array_equal(eqSptensor.vals, 0 * sptensorInstance.vals + 1)
 
     eqSptensor = sptensorInstance != 0.5
-    assert (
-        eqSptensor.subs
-        == np.vstack((data["subs"][1:], sptensorInstance.logical_not().subs))
-    ).all()
+    assert np.array_equal(
+        eqSptensor.subs,
+        np.vstack((data["subs"][1:], sptensorInstance.logical_not().subs)),
+    )
 
     eqSptensor = sptensorInstance != sptensorInstance
     assert eqSptensor.vals.size == 0
@@ -785,7 +790,7 @@ def test_sptensor__ne__(sample_sptensor):
     denseTensor = ttb.tensor.from_tensor_type(sptensorInstance)
     denseTensor[1, 1, 2] = 1
     eqSptensor = sptensorInstance != denseTensor
-    assert (eqSptensor.subs == np.array([1, 1, 2])).all()
+    assert np.array_equal(eqSptensor.subs.squeeze(), np.array([1, 1, 2]))
 
     denseTensor = ttb.tensor.from_data(np.ones((5, 5, 5)))
     with pytest.raises(AssertionError) as excinfo:
@@ -802,8 +807,8 @@ def test_sptensor__ne__(sample_sptensor):
 def test_sptensor__find(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
     subs, vals = sptensorInstance.find()
-    assert (subs == data["subs"]).all()
-    assert (vals == data["vals"]).all()
+    assert np.array_equal(subs, data["subs"])
+    assert np.array_equal(vals, data["vals"])
 
 
 def test_sptensor__sub__(sample_sptensor):
@@ -820,13 +825,13 @@ def test_sptensor__sub__(sample_sptensor):
 
     # Sptensor - tensor
     subSptensor = sptensorInstance - ttb.tensor.from_tensor_type(sptensorInstance)
-    assert (subSptensor.data == np.zeros(data["shape"])).all()
+    assert np.array_equal(subSptensor.data, np.zeros(data["shape"]))
 
     # Sptensor - scalar
     subSptensor = sptensorInstance - 0
-    assert (
-        subSptensor.data == ttb.tensor.from_tensor_type(sptensorInstance).data
-    ).all()
+    assert np.array_equal(
+        subSptensor.data, ttb.tensor.from_tensor_type(sptensorInstance).data
+    )
 
 
 def test_sptensor__add__(sample_sptensor):
@@ -834,7 +839,7 @@ def test_sptensor__add__(sample_sptensor):
 
     # Sptensor + sptensor
     subSptensor = sptensorInstance + sptensorInstance
-    assert (subSptensor.vals == 2 * data["vals"]).all()
+    assert np.array_equal(subSptensor.vals, 2 * data["vals"])
 
     # Sptensor + sptensor of wrong size
     with pytest.raises(AssertionError) as excinfo:
@@ -844,13 +849,13 @@ def test_sptensor__add__(sample_sptensor):
     # Sptensor + tensor
     subSptensor = sptensorInstance + ttb.tensor.from_tensor_type(sptensorInstance)
     results = ttb.tensor.from_tensor_type(sptensorInstance).data * 2
-    assert (subSptensor.data == results).all()
+    assert np.array_equal(subSptensor.data, results)
 
     # Sptensor + scalar
     subSptensor = sptensorInstance + 0
-    assert (
-        subSptensor.data == ttb.tensor.from_tensor_type(sptensorInstance).data
-    ).all()
+    assert np.array_equal(
+        subSptensor.data, ttb.tensor.from_tensor_type(sptensorInstance).data
+    )
 
 
 def test_sptensor_isequal(sample_sptensor):
@@ -891,18 +896,18 @@ def test_sptensor__mul__(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     # Test mul with int
-    assert ((sptensorInstance * 2).vals == 2 * data["vals"]).all()
+    assert np.array_equal((sptensorInstance * 2).vals, 2 * data["vals"])
     # Test mul with float
-    assert ((sptensorInstance * 2.0).vals == 2 * data["vals"]).all()
+    assert np.array_equal((sptensorInstance * 2.0).vals, 2 * data["vals"])
     # Test mul with sptensor
-    assert (
-        (sptensorInstance * sptensorInstance).vals == data["vals"] * data["vals"]
-    ).all()
+    assert np.array_equal(
+        (sptensorInstance * sptensorInstance).vals, data["vals"] * data["vals"]
+    )
     # Test mul with tensor
-    assert (
-        (sptensorInstance * ttb.tensor.from_tensor_type(sptensorInstance)).vals
-        == data["vals"] * data["vals"]
-    ).all()
+    assert np.array_equal(
+        (sptensorInstance * ttb.tensor.from_tensor_type(sptensorInstance)).vals,
+        data["vals"] * data["vals"],
+    )
     # Test mul with ktensor
     weights = np.array([1.0, 2.0])
     fm0 = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -930,9 +935,9 @@ def test_sptensor__rmul__(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     # Test mul with int
-    assert ((2 * sptensorInstance).vals == 2 * data["vals"]).all()
+    assert np.array_equal((2 * sptensorInstance).vals, 2 * data["vals"])
     # Test mul with float
-    assert ((2.0 * sptensorInstance).vals == 2 * data["vals"]).all()
+    assert np.array_equal((2.0 * sptensorInstance).vals, 2 * data["vals"])
     # Test mul with ktensor
     weights = np.array([1.0, 2.0])
     fm0 = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -954,7 +959,7 @@ def test_sptensor__rmul__(sample_sptensor):
 def test_sptensor_ones(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
-    assert (sptensorInstance.ones().vals == (0.0 * data["vals"] + 1)).all()
+    assert np.array_equal(sptensorInstance.ones().vals, (0.0 * data["vals"] + 1))
 
 
 def test_sptensor_double(sample_sptensor):
@@ -963,7 +968,7 @@ def test_sptensor_double(sample_sptensor):
     actualIdx = tuple(data["subs"].transpose())
     denseData[actualIdx] = data["vals"].transpose()[0]
 
-    assert (sptensorInstance.double() == denseData).all()
+    assert np.array_equal(sptensorInstance.double(), denseData)
     assert sptensorInstance.double().shape == data["shape"]
 
 
@@ -971,30 +976,32 @@ def test_sptensor__le__(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     # Test comparison to negative scalar
-    assert ((-sptensorInstance <= -0.1).vals == 0 * data["vals"] + 1).all()
+    assert np.array_equal((-sptensorInstance <= -0.1).vals, 0 * data["vals"] + 1)
     # Test comparison to positive scalar
-    assert ((sptensorInstance <= 0.1).vals == sptensorInstance.logical_not().vals).all()
+    assert np.array_equal(
+        (sptensorInstance <= 0.1).vals, sptensorInstance.logical_not().vals
+    )
 
     # Test comparison to tensor
-    assert (
-        (sptensorInstance <= sptensorInstance.full()).vals
-        == np.ones((np.prod(data["shape"]), 1))
-    ).all()
+    assert np.array_equal(
+        (sptensorInstance <= sptensorInstance.full()).vals,
+        np.ones((np.prod(data["shape"]), 1)),
+    )
 
     # Test comparison to sptensor
-    assert (
-        (sptensorInstance <= sptensorInstance).vals
-        == np.ones((np.prod(data["shape"]), 1))
-    ).all()
+    assert np.array_equal(
+        (sptensorInstance <= sptensorInstance).vals,
+        np.ones((np.prod(data["shape"]), 1)),
+    )
 
     # Test comparison of empty tensor with sptensor, both ways
     emptySptensor = ttb.sptensor.from_data(np.array([]), np.array([]), data["shape"])
-    assert (
-        (emptySptensor <= sptensorInstance).vals == np.ones((np.prod(data["shape"]), 1))
-    ).all()
-    assert (
-        (sptensorInstance <= emptySptensor).vals == sptensorInstance.logical_not().vals
-    ).all()
+    assert np.array_equal(
+        (emptySptensor <= sptensorInstance).vals, np.ones((np.prod(data["shape"]), 1))
+    )
+    assert np.array_equal(
+        (sptensorInstance <= emptySptensor).vals, sptensorInstance.logical_not().vals
+    )
 
     # Test comparison with different size
     with pytest.raises(AssertionError) as excinfo:
@@ -1013,23 +1020,23 @@ def test_sptensor__ge__(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     # Test comparison to positive scalar
-    assert ((sptensorInstance >= 0.1).vals == 0 * data["vals"] + 1).all()
+    assert np.array_equal((sptensorInstance >= 0.1).vals, 0 * data["vals"] + 1)
     # Test comparison to negative scalar
-    assert (
-        (sptensorInstance >= -0.1).vals == np.ones((np.prod(data["shape"]), 1))
-    ).all()
+    assert np.array_equal(
+        (sptensorInstance >= -0.1).vals, np.ones((np.prod(data["shape"]), 1))
+    )
 
     # Test comparison to tensor
-    assert (
-        (sptensorInstance >= sptensorInstance.full()).vals
-        == np.ones((np.prod(data["shape"]), 1))
-    ).all()
+    assert np.array_equal(
+        (sptensorInstance >= sptensorInstance.full()).vals,
+        np.ones((np.prod(data["shape"]), 1)),
+    )
 
     # Test comparison to sptensor
-    assert (
-        (sptensorInstance >= sptensorInstance).vals
-        == np.ones((np.prod(data["shape"]), 1))
-    ).all()
+    assert np.array_equal(
+        (sptensorInstance >= sptensorInstance).vals,
+        np.ones((np.prod(data["shape"]), 1)),
+    )
 
     # Test comparison with different size
     with pytest.raises(AssertionError) as excinfo:
@@ -1048,11 +1055,11 @@ def test_sptensor__gt__(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     # Test comparison to positive scalar
-    assert ((sptensorInstance > 0.1).vals == 0 * data["vals"] + 1).all()
+    assert np.array_equal((sptensorInstance > 0.1).vals, 0 * data["vals"] + 1)
     # Test comparison to negative scalar
-    assert (
-        (sptensorInstance > -0.1).vals == np.ones((np.prod(data["shape"]), 1))
-    ).all()
+    assert np.array_equal(
+        (sptensorInstance > -0.1).vals, np.ones((np.prod(data["shape"]), 1))
+    )
 
     # Test comparison to tensor
     assert (sptensorInstance > sptensorInstance.full()).vals.size == 0
@@ -1060,7 +1067,9 @@ def test_sptensor__gt__(sample_sptensor):
     # Test comparison to tensor of different sparsity patter
     denseTensor = sptensorInstance.full()
     denseTensor[1, 1, 2] = -1
-    assert ((sptensorInstance > denseTensor).subs == np.array([1, 1, 2])).all()
+    assert np.array_equal(
+        (sptensorInstance > denseTensor).subs.squeeze(), np.array([1, 1, 2])
+    )
 
     # Test comparison to sptensor
     assert (sptensorInstance > sptensorInstance).vals.size == 0
@@ -1080,9 +1089,11 @@ def test_sptensor__lt__(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     # Test comparison to negative scalar
-    assert ((-sptensorInstance < -0.1).vals == 0 * data["vals"] + 1).all()
+    assert np.array_equal((-sptensorInstance < -0.1).vals, 0 * data["vals"] + 1)
     # Test comparison to positive scalar
-    assert ((sptensorInstance < 0.1).vals == sptensorInstance.logical_not().vals).all()
+    assert np.array_equal(
+        (sptensorInstance < 0.1).vals, sptensorInstance.logical_not().vals
+    )
 
     # Test comparison to tensor
     assert (sptensorInstance < sptensorInstance.full()).vals.size == 0
@@ -1092,7 +1103,7 @@ def test_sptensor__lt__(sample_sptensor):
 
     # Test comparison of empty tensor with sptensor, both ways
     emptySptensor = ttb.sptensor.from_data(np.array([]), np.array([]), data["shape"])
-    assert ((emptySptensor < sptensorInstance).subs == data["subs"]).all()
+    assert np.array_equal((emptySptensor < sptensorInstance).subs, data["subs"])
     assert (sptensorInstance < emptySptensor).vals.size == 0
 
     # Test comparison with different size
@@ -1155,11 +1166,11 @@ def test_sptensor_logical_xor(sample_sptensor):
 
     # Sptensor logical xor with scalar, 0
     sptensorXor = sptensorInstance.logical_xor(0)
-    assert (sptensorXor.data == nonZeroMatrix).all()
+    assert np.array_equal(sptensorXor.data, nonZeroMatrix)
 
     # Sptensor logical xor with scalar, not 0
     sptensorXor = sptensorInstance.logical_xor(1)
-    assert (sptensorXor.data == sptensorInstance.logical_not().full().data).all()
+    assert np.array_equal(sptensorXor.data, sptensorInstance.logical_not().full().data)
 
     # Sptensor logical xor with another sptensor
     sptensorXor = sptensorInstance.logical_xor(sptensorInstance)
@@ -1170,7 +1181,7 @@ def test_sptensor_logical_xor(sample_sptensor):
     sptensorXor = sptensorInstance.logical_xor(
         ttb.tensor.from_tensor_type(sptensorInstance)
     )
-    assert (sptensorXor.data == np.zeros(data["shape"], dtype=bool)).all()
+    assert np.array_equal(sptensorXor.data, np.zeros(data["shape"], dtype=bool))
 
     # Sptensor logical xor with wrong shape sptensor
     with pytest.raises(AssertionError) as excinfo:
@@ -1189,8 +1200,8 @@ def test_sptensor_squeeze(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     # No singleton dimensions
-    assert (sptensorInstance.squeeze().vals == data["vals"]).all()
-    assert (sptensorInstance.squeeze().subs == data["subs"]).all()
+    assert np.array_equal(sptensorInstance.squeeze().vals, data["vals"])
+    assert np.array_equal(sptensorInstance.squeeze().subs, data["subs"])
 
     # All singleton dimensions
     assert (
@@ -1207,12 +1218,12 @@ def test_sptensor_squeeze(sample_sptensor):
         .subs,
         np.array([[0, 0]]),
     )
-    assert (
+    assert np.array_equal(
         ttb.sptensor.from_data(np.array([[0, 0, 0]]), np.array([4]), (2, 2, 1))
         .squeeze()
-        .vals
-        == np.array([4])
-    ).all()
+        .vals,
+        np.array([4]),
+    )
 
     # Singleton dimension with empty sptensor
     assert ttb.sptensor.from_data(
@@ -1224,23 +1235,23 @@ def test_sptensor_scale(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     # Scale with np array
-    assert (
-        sptensorInstance.scale(np.array([4, 4, 4, 4]), 1).vals == 4 * data["vals"]
-    ).all()
+    assert np.array_equal(
+        sptensorInstance.scale(np.array([4, 4, 4, 4]), 1).vals, 4 * data["vals"]
+    )
 
     # Scale with sptensor
-    assert (
-        sptensorInstance.scale(sptensorInstance, np.arange(0, 3)).vals
-        == data["vals"] ** 2
-    ).all()
+    assert np.array_equal(
+        sptensorInstance.scale(sptensorInstance, np.arange(0, 3)).vals,
+        data["vals"] ** 2,
+    )
 
     # Scale with tensor
-    assert (
+    assert np.array_equal(
         sptensorInstance.scale(
             ttb.tensor.from_tensor_type(sptensorInstance), np.arange(0, 3)
-        ).vals
-        == data["vals"] ** 2
-    ).all()
+        ).vals,
+        data["vals"] ** 2,
+    )
 
     # Incorrect shape np array, sptensor and tensor
     with pytest.raises(AssertionError) as excinfo:
@@ -1288,7 +1299,7 @@ def test_sptensor_mask(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
 
     # Mask captures all non-zero entries
-    assert (sptensorInstance.mask(sptensorInstance) == data["vals"]).all()
+    assert np.array_equal(sptensorInstance.mask(sptensorInstance), data["vals"])
 
     # Mask too large
     with pytest.raises(AssertionError) as excinfo:
@@ -1323,7 +1334,9 @@ def test_sptensor__rtruediv__(sample_sptensor):
     # Scalar / Spensor yields tensor, only resolves when left object doesn't have appropriate __truediv__
     # We ignore the divide by zero errors because np.inf/np.nan is an appropriate representation
     with np.errstate(divide="ignore", invalid="ignore"):
-        assert ((2 / sptensorInstance).data == (2 / sptensorInstance.full().data)).all()
+        assert np.array_equal(
+            (2 / sptensorInstance).data, (2 / sptensorInstance.full().data)
+        )
 
     # Tensor / Spensor yields tensor should be calling tensor.__truediv__
     # We ignore the divide by zero errors because np.inf/np.nan is an appropriate representation
@@ -1345,7 +1358,7 @@ def test_sptensor__truediv__(sample_sptensor):
     emptySptensor = ttb.sptensor.from_data(np.array([]), np.array([]), (4, 4, 4))
 
     # Sptensor/ non-zero scalar
-    assert ((sptensorInstance / 5).vals == data["vals"] / 5).all()
+    assert np.array_equal((sptensorInstance / 5).vals, data["vals"] / 5)
 
     # Sptensor/zero scalar
     np.testing.assert_array_equal(
@@ -1387,9 +1400,9 @@ def test_sptensor__truediv__(sample_sptensor):
     )
 
     # Sptensor/tensor
-    assert (
-        (sptensorInstance / sptensorInstance.full()).vals == data["vals"] / data["vals"]
-    ).all()
+    assert np.array_equal(
+        (sptensorInstance / sptensorInstance.full()).vals, data["vals"] / data["vals"]
+    )
 
     # Sptensor/ktensor
     weights = np.array([1.0, 2.0])
@@ -1425,18 +1438,18 @@ def test_sptensor_collapse(sample_sptensor):
     assert sptensorInstance.collapse(fun=sum) == np.sum(data["vals"])
 
     # Test partial collapse, output vector
-    assert (
-        sptensorInstance.collapse(dims=np.array([0, 1])) == np.array([0, 0.5, 2.5, 5])
-    ).all()
-    assert (
-        emptySptensor.collapse(dims=np.array([0, 1])) == np.array([0, 0, 0, 0])
-    ).all()
+    assert np.array_equal(
+        sptensorInstance.collapse(dims=np.array([0, 1])), np.array([0, 0.5, 2.5, 5])
+    )
+    assert np.array_equal(
+        emptySptensor.collapse(dims=np.array([0, 1])), np.array([0, 0, 0, 0])
+    )
 
     # Test partial collapse, output sptensor
     collapseSptensor = sptensorInstance.collapse(dims=np.array([0]))
-    assert (collapseSptensor.vals == data["vals"]).all()
+    assert np.array_equal(collapseSptensor.vals, data["vals"])
     assert collapseSptensor.shape == (4, 4)
-    assert (collapseSptensor.subs == data["subs"][:, 1:3]).all()
+    assert np.array_equal(collapseSptensor.subs, data["subs"][:, 1:3])
     emptySptensorSmaller = ttb.sptensor.from_tensor_type(emptySptensor)
     emptySptensorSmaller.shape = (4, 4)
     assert emptySptensor.collapse(dims=np.array([0])).isequal(emptySptensorSmaller)
@@ -1459,9 +1472,9 @@ def test_sptensor_contract(sample_sptensor):
     assert contractableSptensor.contract(0, 1) == 6.5
 
     contractableSptensor = ttb.sptensor.from_tensor_type(sptensorInstance)
-    assert (
-        contractableSptensor.contract(0, 1).data == np.array([0, 0.5, 2.5, 5])
-    ).all()
+    assert np.array_equal(
+        contractableSptensor.contract(0, 1).data, np.array([0, 0.5, 2.5, 5])
+    )
 
     contractableSptensor = ttb.sptensor.from_tensor_type(sptensorInstance)
     contractableSptensor[3, 3, 3, 3] = 1
@@ -1474,8 +1487,8 @@ def test_sptensor_elemfun(sample_sptensor):
     def plus1(y):
         return y + 1
 
-    assert (sptensorInstance.elemfun(plus1).vals == 1 + data["vals"]).all()
-    assert (sptensorInstance.elemfun(plus1).subs == data["subs"]).all()
+    assert np.array_equal(sptensorInstance.elemfun(plus1).vals, 1 + data["vals"])
+    assert np.array_equal(sptensorInstance.elemfun(plus1).subs, data["subs"])
 
     emptySptensor = ttb.sptensor.from_data(np.array([]), np.array([]), (4, 4, 4))
     assert emptySptensor.elemfun(plus1).vals.size == 0
@@ -1501,7 +1514,7 @@ def test_sptensor_spmatrix(sample_sptensor):
     fullData = np.zeros(NonEmptySptensor.shape)
     fullData[0, 0] = 1
     b = NonEmptySptensor.spmatrix()
-    assert (b.toarray() == fullData).all()
+    assert np.array_equal(b.toarray(), fullData)
 
     NonEmptySptensor = ttb.sptensor.from_data(
         np.array([[0, 1], [1, 0]]), np.array([[1], [2]]), (4, 4)
@@ -1510,7 +1523,7 @@ def test_sptensor_spmatrix(sample_sptensor):
     fullData[0, 1] = 1
     fullData[1, 0] = 2
     b = NonEmptySptensor.spmatrix()
-    assert (b.toarray() == fullData).all()
+    assert np.array_equal(b.toarray(), fullData)
 
     NonEmptySptensor = ttb.sptensor.from_data(
         np.array([[0, 1], [2, 3]]), np.array([[1], [2]]), (4, 4)
@@ -1519,7 +1532,7 @@ def test_sptensor_spmatrix(sample_sptensor):
     fullData[0, 1] = 1
     fullData[2, 3] = 2
     b = NonEmptySptensor.spmatrix()
-    assert (b.toarray() == fullData).all()
+    assert np.array_equal(b.toarray(), fullData)
 
 
 def test_sptensor_ttv(sample_sptensor):
@@ -1546,7 +1559,9 @@ def test_sptensor_ttv(sample_sptensor):
         ttb.tensor.from_data(np.array([4, 4, 4, 4]))
     )
     emptySptensor[0, 0] = 1
-    assert (emptySptensor.ttv(vector, 0).full().data == np.array([1, 0, 0, 0])).all()
+    assert np.array_equal(
+        emptySptensor.ttv(vector, 0).full().data, np.array([1, 0, 0, 0])
+    )
 
     # Returns tensor shaped object
     emptySptensor = ttb.sptensor.from_data(np.array([]), np.array([]), (4, 4, 4))
@@ -1567,37 +1582,37 @@ def test_sptensor_mttkrp(sample_sptensor):
     # MTTKRP with array of matrices
     # Note this is more of a regression test against the output of MATLAB TTB
     matrix = np.ones((4, 4))
-    assert (
-        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 0)
-        == np.array(
+    assert np.array_equal(
+        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 0),
+        np.array(
             [[0, 0, 0, 0], [2, 2, 2, 2], [2.5, 2.5, 2.5, 2.5], [3.5, 3.5, 3.5, 3.5]]
-        )
-    ).all()
-    assert (
-        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 1)
-        == sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 0)
-    ).all()
-    assert (
-        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 2)
-        == np.array(
+        ),
+    )
+    assert np.array_equal(
+        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 1),
+        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 0),
+    )
+    assert np.array_equal(
+        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 2),
+        np.array(
             [[0, 0, 0, 0], [0.5, 0.5, 0.5, 0.5], [2.5, 2.5, 2.5, 2.5], [5, 5, 5, 5]]
-        )
-    ).all()
+        ),
+    )
 
     # MTTKRP with factor matrices from ktensor
     K = ttb.ktensor([matrix, matrix, matrix])
-    assert (
-        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 0)
-        == sptensorInstance.mttkrp(K, 0)
-    ).all()
-    assert (
-        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 1)
-        == sptensorInstance.mttkrp(K, 1)
-    ).all()
-    assert (
-        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 2)
-        == sptensorInstance.mttkrp(K, 2)
-    ).all()
+    assert np.array_equal(
+        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 0),
+        sptensorInstance.mttkrp(K, 0),
+    )
+    assert np.array_equal(
+        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 1),
+        sptensorInstance.mttkrp(K, 1),
+    )
+    assert np.array_equal(
+        sptensorInstance.mttkrp(np.array([matrix, matrix, matrix]), 2),
+        sptensorInstance.mttkrp(K, 2),
+    )
 
     # Wrong length input
     with pytest.raises(AssertionError) as excinfo:

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -799,12 +799,6 @@ def test_sptensor__ne__(sample_sptensor):
     )
 
 
-def test_sptensor__end(sample_sptensor):
-    (data, sptensorInstance) = sample_sptensor
-    assert sptensorInstance.end() == np.prod(data["shape"]) - 1
-    assert sptensorInstance.end(k=0) == data["shape"][0] - 1
-
-
 def test_sptensor__find(sample_sptensor):
     (data, sptensorInstance) = sample_sptensor
     subs, vals = sptensorInstance.find()

--- a/tests/test_tenmat.py
+++ b/tests/test_tenmat.py
@@ -377,15 +377,6 @@ def test_tenmat_double(sample_tenmat_4way):
 
 
 @pytest.mark.indevelopment
-def test_tenmat_end(sample_tenmat_4way):
-    (params, tenmatInstance) = sample_tenmat_4way
-    shape = params["shape"]
-
-    for k in range(len(shape)):
-        assert tenmatInstance.end(k) == shape[k] - 1
-
-
-@pytest.mark.indevelopment
 def test_tenmat_ndims(sample_tenmat_4way):
     (params, tenmatInstance) = sample_tenmat_4way
 

--- a/tests/test_tenmat.py
+++ b/tests/test_tenmat.py
@@ -679,7 +679,7 @@ def test_tenmat__str__(
     tenmatInstance = ttb.tenmat.from_data(ndarrayInstance1, rdims, cdims, tshape)
     s = ""
     s += "matrix corresponding to a tensor of shape "
-    s += (" x ").join([str(int(d)) for d in tenmatInstance.tshape])
+    s += str(tenmatInstance.tshape)
     s += "\n"
     s += "rindices = "
     s += "[ " + (", ").join([str(int(d)) for d in tenmatInstance.rindices]) + " ] "
@@ -696,7 +696,7 @@ def test_tenmat__str__(
     tenmatInstance = ttb.tenmat.from_data(ndarrayInstance2, rdims, cdims, tshape)
     s = ""
     s += "matrix corresponding to a tensor of shape "
-    s += (" x ").join([str(int(d)) for d in tenmatInstance.tshape])
+    s += str(tenmatInstance.tshape)
     s += "\n"
     s += "rindices = "
     s += "[ " + (", ").join([str(int(d)) for d in tenmatInstance.rindices]) + " ] "
@@ -713,7 +713,7 @@ def test_tenmat__str__(
     tenmatInstance = ttb.tenmat.from_data(ndarrayInstance4, rdims, cdims, tshape)
     s = ""
     s += "matrix corresponding to a tensor of shape "
-    s += (" x ").join([str(int(d)) for d in tenmatInstance.tshape])
+    s += str(tenmatInstance.tshape)
     s += "\n"
     s += "rindices = "
     s += "[ " + (", ").join([str(int(d)) for d in tenmatInstance.rindices]) + " ] "

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -40,13 +40,13 @@ def test_tensor_initialization_empty():
 
     # No args
     tensorInstance = ttb.tensor()
-    assert (tensorInstance.data == empty).all()
+    assert np.array_equal(tensorInstance.data, empty)
     assert tensorInstance.shape == ()
 
 
 def test_tensor_initialization_from_data(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
-    assert (tensorInstance.data == params["data"]).all()
+    assert np.array_equal(tensorInstance.data, params["data"])
     assert tensorInstance.shape == params["shape"]
 
     with pytest.raises(AssertionError) as excinfo:
@@ -76,7 +76,9 @@ def test_tensor_initialization_from_data(sample_tensor_2way):
     assert (
         tensorInstance1.data.shape == data.shape
     ), f"tensorInstance1:\n{tensorInstance1}"
-    assert (tensorInstance1.data == data).all(), f"tensorInstance1:\n{tensorInstance1}"
+    assert np.array_equal(
+        tensorInstance1.data, data
+    ), f"tensorInstance1:\n{tensorInstance1}"
 
     # shape is 1 x 3
     tensorInstance1 = ttb.tensor.from_data(np.array([1, 2, 3]), (1, 3))
@@ -84,7 +86,9 @@ def test_tensor_initialization_from_data(sample_tensor_2way):
     assert (
         tensorInstance1.data.shape == data.shape
     ), f"tensorInstance1:\n{tensorInstance1}"
-    assert (tensorInstance1.data == data).all(), f"tensorInstance1:\n{tensorInstance1}"
+    assert np.array_equal(
+        tensorInstance1.data, data
+    ), f"tensorInstance1:\n{tensorInstance1}"
 
     # shape is 3 x 1
     tensorInstance1 = ttb.tensor.from_data(np.array([1, 2, 3]), (3, 1))
@@ -92,7 +96,9 @@ def test_tensor_initialization_from_data(sample_tensor_2way):
     assert (
         tensorInstance1.data.shape == data.shape
     ), f"tensorInstance1:\n{tensorInstance1}"
-    assert (tensorInstance1.data == data).all(), f"tensorInstance1:\n{tensorInstance1}"
+    assert np.array_equal(
+        tensorInstance1.data, data
+    ), f"tensorInstance1:\n{tensorInstance1}"
 
 
 def test_tensor_initialization_from_tensor_type(sample_tensor_2way, sample_tensor_4way):
@@ -101,7 +107,7 @@ def test_tensor_initialization_from_tensor_type(sample_tensor_2way, sample_tenso
 
     # Copy Constructor
     tensorCopy = ttb.tensor.from_tensor_type(tensorInstance)
-    assert (tensorCopy.data == params["data"]).all()
+    assert np.array_equal(tensorCopy.data, params["data"])
     assert tensorCopy.shape == params["shape"]
 
     subs = np.array([[0, 0], [0, 1], [0, 2], [1, 0]])
@@ -112,7 +118,7 @@ def test_tensor_initialization_from_tensor_type(sample_tensor_2way, sample_tenso
 
     # Sptensor
     b = ttb.tensor.from_tensor_type(a)
-    assert (b.data == data).all()
+    assert np.array_equal(b.data, data)
     assert b.shape == shape
 
     # tenmat
@@ -144,7 +150,7 @@ def test_tensor_initialization_from_function():
     data = np.array([[1, 2, 3], [4, 5, 6]])
 
     a = ttb.tensor.from_function(function_handle, shape)
-    assert (a.data == data).all()
+    assert np.array_equal(a.data, data)
     assert a.shape == shape
 
     with pytest.raises(AssertionError) as excinfo:
@@ -158,7 +164,7 @@ def test_tensor_find(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way)
     a = ttb.tensor.from_tensor_type(
         ttb.sptensor.from_data(subs, vals, tensorInstance.shape)
     )
-    assert (a.data == tensorInstance.data).all(), f"subs: {subs}\nvals: {vals}"
+    assert np.array_equal(a.data, tensorInstance.data), f"subs: {subs}\nvals: {vals}"
     assert a.shape == tensorInstance.shape, f"subs: {subs}\nvals: {vals}"
 
     (params, tensorInstance) = sample_tensor_3way
@@ -166,7 +172,7 @@ def test_tensor_find(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way)
     a = ttb.tensor.from_tensor_type(
         ttb.sptensor.from_data(subs, vals, tensorInstance.shape)
     )
-    assert (a.data == tensorInstance.data).all(), f"subs: {subs}\nvals: {vals}"
+    assert np.array_equal(a.data, tensorInstance.data), f"subs: {subs}\nvals: {vals}"
     assert a.shape == tensorInstance.shape, f"subs: {subs}\nvals: {vals}"
 
     (params, tensorInstance) = sample_tensor_4way
@@ -174,7 +180,7 @@ def test_tensor_find(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way)
     a = ttb.tensor.from_tensor_type(
         ttb.sptensor.from_data(subs, vals, tensorInstance.shape)
     )
-    assert (a.data == tensorInstance.data).all(), f"subs: {subs}\nvals: {vals}"
+    assert np.array_equal(a.data, tensorInstance.data), f"subs: {subs}\nvals: {vals}"
     assert a.shape == tensorInstance.shape, f"subs: {subs}\nvals: {vals}"
 
 
@@ -425,40 +431,44 @@ def test_tensor_logical_and(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor And
-    assert (
-        tensorInstance.logical_and(tensorInstance).data == np.ones((params["shape"]))
-    ).all()
+    assert np.array_equal(
+        tensorInstance.logical_and(tensorInstance).data, np.ones((params["shape"]))
+    )
 
     # Non-zero And
-    assert (tensorInstance.logical_and(1).data == np.ones((params["shape"]))).all()
+    assert np.array_equal(
+        tensorInstance.logical_and(1).data, np.ones((params["shape"]))
+    )
 
     # Zero And
-    assert (tensorInstance.logical_and(0).data == np.zeros((params["shape"]))).all()
+    assert np.array_equal(
+        tensorInstance.logical_and(0).data, np.zeros((params["shape"]))
+    )
 
 
 def test_tensor__eq__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor tensor equality
-    assert ((tensorInstance == tensorInstance).data).all()
+    assert np.all((tensorInstance == tensorInstance).data)
 
     # Tensor scalar equality, not equal
-    assert not ((tensorInstance == 7).data).any()
+    assert not (tensorInstance == 7).data.any()
 
     # Tensor scalar equality, is equal
     data = np.zeros(params["data"].shape)
     data[0, 0] = 1
-    assert ((tensorInstance == 1).data == data).all()
+    assert np.array_equal((tensorInstance == 1).data, data)
 
     (params3, tensorInstance3) = sample_tensor_3way
 
     # Tensor tensor equality
-    assert ((tensorInstance3 == tensorInstance3).data).all()
+    assert np.all((tensorInstance3 == tensorInstance3).data)
 
     (params4, tensorInstance4) = sample_tensor_4way
 
     # Tensor tensor equality
-    assert ((tensorInstance4 == tensorInstance4).data).all()
+    assert np.all((tensorInstance4 == tensorInstance4).data)
 
 
 def test_tensor__ne__(sample_tensor_2way):
@@ -468,7 +478,7 @@ def test_tensor__ne__(sample_tensor_2way):
     assert not ((tensorInstance != tensorInstance).data).any()
 
     # Tensor scalar equality, not equal
-    assert ((tensorInstance != 7).data).all()
+    assert np.all((tensorInstance != 7).data)
 
     # Tensor scalar equality, is equal
     data = np.zeros(params["data"].shape)
@@ -483,7 +493,7 @@ def test_tensor_full(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way)
         f"tensorInstace2.data: {tensorInstance2.data}\n"
         f"tensorInstace2.full(): {tensorInstance2.full()}"
     )
-    assert (tensorInstance2.full().data == params2["data"]).all(), debug_str
+    assert np.array_equal(tensorInstance2.full().data, params2["data"]), debug_str
 
     (params3, tensorInstance3) = sample_tensor_3way
     debug_str = (
@@ -491,7 +501,7 @@ def test_tensor_full(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way)
         f"tensorInstace3.data: {tensorInstance3.data}\n"
         f"tensorInstace3.full(): {tensorInstance3.full()}"
     )
-    assert (tensorInstance3.full().data == params3["data"]).all(), debug_str
+    assert np.array_equal(tensorInstance3.full().data, params3["data"]), debug_str
 
     (params4, tensorInstance4) = sample_tensor_4way
     debug_str = (
@@ -499,7 +509,7 @@ def test_tensor_full(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way)
         f"tensorInstace4.data: {tensorInstance4.data}\n"
         f"tensorInstace4.full(): {tensorInstance4.full()}"
     )
-    assert (tensorInstance4.full().data == params4["data"]).all(), debug_str
+    assert np.array_equal(tensorInstance4.full().data, params4["data"]), debug_str
 
 
 def test_tensor__ge__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
@@ -508,8 +518,8 @@ def test_tensor__ge__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
     tensorLarger = ttb.tensor.from_data(params["data"] + 1)
     tensorSmaller = ttb.tensor.from_data(params["data"] - 1)
 
-    assert ((tensorInstance >= tensorInstance).data).all()
-    assert ((tensorInstance >= tensorSmaller).data).all()
+    assert np.all((tensorInstance >= tensorInstance).data)
+    assert np.all((tensorInstance >= tensorSmaller).data)
     assert not ((tensorInstance >= tensorLarger).data).any()
 
     (params, tensorInstance) = sample_tensor_3way
@@ -517,8 +527,8 @@ def test_tensor__ge__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
     tensorLarger = ttb.tensor.from_data(params["data"] + 1)
     tensorSmaller = ttb.tensor.from_data(params["data"] - 1)
 
-    assert ((tensorInstance >= tensorInstance).data).all()
-    assert ((tensorInstance >= tensorSmaller).data).all()
+    assert np.all((tensorInstance >= tensorInstance).data)
+    assert np.all((tensorInstance >= tensorSmaller).data)
     assert not ((tensorInstance >= tensorLarger).data).any()
 
     (params, tensorInstance) = sample_tensor_4way
@@ -526,8 +536,8 @@ def test_tensor__ge__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
     tensorLarger = ttb.tensor.from_data(params["data"] + 1)
     tensorSmaller = ttb.tensor.from_data(params["data"] - 1)
 
-    assert ((tensorInstance >= tensorInstance).data).all()
-    assert ((tensorInstance >= tensorSmaller).data).all()
+    assert np.all((tensorInstance >= tensorInstance).data)
+    assert np.all((tensorInstance >= tensorSmaller).data)
     assert not ((tensorInstance >= tensorLarger).data).any()
 
 
@@ -538,7 +548,7 @@ def test_tensor__gt__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
     tensorSmaller = ttb.tensor.from_data(params["data"] - 1)
 
     assert not ((tensorInstance > tensorInstance).data).any()
-    assert ((tensorInstance > tensorSmaller).data).all()
+    assert np.all((tensorInstance > tensorSmaller).data)
     assert not ((tensorInstance > tensorLarger).data).any()
 
     (params, tensorInstance) = sample_tensor_3way
@@ -547,7 +557,7 @@ def test_tensor__gt__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
     tensorSmaller = ttb.tensor.from_data(params["data"] - 1)
 
     assert not ((tensorInstance > tensorInstance).data).any()
-    assert ((tensorInstance > tensorSmaller).data).all()
+    assert np.all((tensorInstance > tensorSmaller).data)
     assert not ((tensorInstance > tensorLarger).data).any()
 
     (params, tensorInstance) = sample_tensor_4way
@@ -556,7 +566,7 @@ def test_tensor__gt__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
     tensorSmaller = ttb.tensor.from_data(params["data"] - 1)
 
     assert not ((tensorInstance > tensorInstance).data).any()
-    assert ((tensorInstance > tensorSmaller).data).all()
+    assert np.all((tensorInstance > tensorSmaller).data)
     assert not ((tensorInstance > tensorLarger).data).any()
 
 
@@ -566,27 +576,27 @@ def test_tensor__le__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
     tensorLarger = ttb.tensor.from_data(params["data"] + 1)
     tensorSmaller = ttb.tensor.from_data(params["data"] - 1)
 
-    assert ((tensorInstance <= tensorInstance).data).all()
+    assert np.all((tensorInstance <= tensorInstance).data)
     assert not ((tensorInstance <= tensorSmaller).data).any()
-    assert ((tensorInstance <= tensorLarger).data).all()
+    assert np.all((tensorInstance <= tensorLarger).data)
 
     (params, tensorInstance) = sample_tensor_3way
 
     tensorLarger = ttb.tensor.from_data(params["data"] + 1)
     tensorSmaller = ttb.tensor.from_data(params["data"] - 1)
 
-    assert ((tensorInstance <= tensorInstance).data).all()
+    assert np.all((tensorInstance <= tensorInstance).data)
     assert not ((tensorInstance <= tensorSmaller).data).any()
-    assert ((tensorInstance <= tensorLarger).data).all()
+    assert np.all((tensorInstance <= tensorLarger).data)
 
     (params, tensorInstance) = sample_tensor_4way
 
     tensorLarger = ttb.tensor.from_data(params["data"] + 1)
     tensorSmaller = ttb.tensor.from_data(params["data"] - 1)
 
-    assert ((tensorInstance <= tensorInstance).data).all()
+    assert np.all((tensorInstance <= tensorInstance).data)
     assert not ((tensorInstance <= tensorSmaller).data).any()
-    assert ((tensorInstance <= tensorLarger).data).all()
+    assert np.all((tensorInstance <= tensorLarger).data)
 
 
 def test_tensor__lt__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
@@ -597,7 +607,7 @@ def test_tensor__lt__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
 
     assert not ((tensorInstance < tensorInstance).data).any()
     assert not ((tensorInstance < tensorSmaller).data).any()
-    assert ((tensorInstance < tensorLarger).data).all()
+    assert np.all((tensorInstance < tensorLarger).data)
 
     (params, tensorInstance) = sample_tensor_3way
 
@@ -606,7 +616,7 @@ def test_tensor__lt__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
 
     assert not ((tensorInstance < tensorInstance).data).any()
     assert not ((tensorInstance < tensorSmaller).data).any()
-    assert ((tensorInstance < tensorLarger).data).all()
+    assert np.all((tensorInstance < tensorLarger).data)
 
     (params, tensorInstance) = sample_tensor_4way
 
@@ -615,7 +625,7 @@ def test_tensor__lt__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way
 
     assert not ((tensorInstance < tensorInstance).data).any()
     assert not ((tensorInstance < tensorSmaller).data).any()
-    assert ((tensorInstance < tensorLarger).data).all()
+    assert np.all((tensorInstance < tensorLarger).data)
 
 
 def test_tensor_norm(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
@@ -641,87 +651,93 @@ def test_tensor_norm(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way)
 def test_tensor_logical_not(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
-    assert (tensorInstance.logical_not().data == np.logical_not(params["data"])).all()
+    assert np.array_equal(
+        tensorInstance.logical_not().data, np.logical_not(params["data"])
+    )
 
 
 def test_tensor_logical_or(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor Or
-    assert (
-        tensorInstance.logical_or(tensorInstance).data == np.ones((params["shape"]))
-    ).all()
+    assert np.array_equal(
+        tensorInstance.logical_or(tensorInstance).data, np.ones((params["shape"]))
+    )
 
     # Non-zero Or
-    assert (tensorInstance.logical_or(1).data == np.ones((params["shape"]))).all()
+    assert np.array_equal(tensorInstance.logical_or(1).data, np.ones((params["shape"])))
 
     # Zero Or
-    assert (tensorInstance.logical_or(0).data == np.ones((params["shape"]))).all()
+    assert np.array_equal(tensorInstance.logical_or(0).data, np.ones((params["shape"])))
 
 
 def test_tensor_logical_xor(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
-    # Tensor Or
-    assert (
-        tensorInstance.logical_xor(tensorInstance).data == np.zeros((params["shape"]))
-    ).all()
+    # Tensor xor
+    assert np.array_equal(
+        tensorInstance.logical_xor(tensorInstance).data, np.zeros((params["shape"]))
+    )
 
-    # Non-zero Or
-    assert (tensorInstance.logical_xor(1).data == np.zeros((params["shape"]))).all()
+    # Non-zero xor
+    assert np.array_equal(
+        tensorInstance.logical_xor(1).data, np.zeros((params["shape"]))
+    )
 
-    # Zero Or
-    assert (tensorInstance.logical_xor(0).data == np.ones((params["shape"]))).all()
+    # Zero xor
+    assert np.array_equal(
+        tensorInstance.logical_xor(0).data, np.ones((params["shape"]))
+    )
 
 
 def test_tensor__add__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor + Tensor
-    assert ((tensorInstance + tensorInstance).data == 2 * (params["data"])).all()
+    assert np.array_equal((tensorInstance + tensorInstance).data, 2 * (params["data"]))
 
     # Tensor + scalar
-    assert ((tensorInstance + 1).data == 1 + (params["data"])).all()
+    assert np.array_equal((tensorInstance + 1).data, 1 + (params["data"]))
 
     # scalar + Tensor
-    assert ((1 + tensorInstance).data == 1 + (params["data"])).all()
+    assert np.array_equal((1 + tensorInstance).data, 1 + (params["data"]))
 
 
 def test_tensor__sub__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor - Tensor
-    assert ((tensorInstance - tensorInstance).data == 0 * (params["data"])).all()
+    assert np.array_equal((tensorInstance - tensorInstance).data, 0 * (params["data"]))
 
     # Tensor - scalar
-    assert ((tensorInstance - 1).data == (params["data"] - 1)).all()
+    assert np.array_equal((tensorInstance - 1).data, (params["data"] - 1))
 
 
 def test_tensor__pow__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor** Tensor
-    assert (
-        (tensorInstance**tensorInstance).data == (params["data"] ** params["data"])
-    ).all()
+    assert np.array_equal(
+        (tensorInstance**tensorInstance).data, (params["data"] ** params["data"])
+    )
     # Tensor**Scalar
-    assert ((tensorInstance**2).data == (params["data"] ** 2)).all()
+    assert np.array_equal((tensorInstance**2).data, (params["data"] ** 2))
 
 
 def test_tensor__mul__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor* Tensor
-    assert (
-        (tensorInstance * tensorInstance).data == (params["data"] * params["data"])
-    ).all()
+    assert np.array_equal(
+        (tensorInstance * tensorInstance).data, (params["data"] * params["data"])
+    )
     # Tensor*Scalar
-    assert ((tensorInstance * 2).data == (params["data"] * 2)).all()
+    assert np.array_equal((tensorInstance * 2).data, (params["data"] * 2))
     # Tensor * Sptensor
-    assert (
-        (tensorInstance * ttb.sptensor.from_tensor_type(tensorInstance)).data
-        == (params["data"] * params["data"])
-    ).all()
+    assert np.array_equal(
+        (tensorInstance * ttb.sptensor.from_tensor_type(tensorInstance)).data,
+        (params["data"] * params["data"]),
+    )
 
     # TODO tensor * ktensor
 
@@ -730,29 +746,29 @@ def test_tensor__rmul__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Scalar * Tensor, only resolves when left object doesn't have appropriate __mul__
-    assert ((2 * tensorInstance).data == (params["data"] * 2)).all()
+    assert np.array_equal((2 * tensorInstance).data, (params["data"] * 2))
 
 
 def test_tensor__pos__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # +Tensor yields no change
-    assert ((+tensorInstance).data == params["data"]).all()
+    assert np.array_equal((+tensorInstance).data, params["data"])
 
 
 def test_tensor__neg__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # -Tensor yields negated copy of tensor
-    assert ((-tensorInstance).data == -1 * params["data"]).all()
+    assert np.array_equal((-tensorInstance).data, -1 * params["data"])
     # Original tensor should remain unchanged
-    assert ((tensorInstance).data == params["data"]).all()
+    assert np.array_equal((tensorInstance).data, params["data"])
 
 
 def test_tensor_double(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
-    assert (tensorInstance.double() == params["data"]).all()
+    assert np.array_equal(tensorInstance.double(), params["data"])
 
 
 def test_tensor_isequal(sample_tensor_2way):
@@ -778,25 +794,25 @@ def test_tensor__truediv__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor / Tensor
-    assert (
-        (tensorInstance / tensorInstance).data == (params["data"] / params["data"])
-    ).all()
+    assert np.array_equal(
+        (tensorInstance / tensorInstance).data, (params["data"] / params["data"])
+    )
 
     # Tensor / Sptensor
-    assert (
-        (tensorInstance / ttb.sptensor.from_tensor_type(tensorInstance)).data
-        == (params["data"] / params["data"])
-    ).all()
+    assert np.array_equal(
+        (tensorInstance / ttb.sptensor.from_tensor_type(tensorInstance)).data,
+        (params["data"] / params["data"]),
+    )
 
     # Tensor / Scalar
-    assert ((tensorInstance / 2).data == (params["data"] / 2)).all()
+    assert np.array_equal((tensorInstance / 2).data, (params["data"] / 2))
 
 
 def test_tensor__rtruediv__(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Scalar / Tensor, only resolves when left object doesn't have appropriate __mul__
-    assert ((2 / tensorInstance).data == (2 / params["data"])).all()
+    assert np.array_equal((2 / tensorInstance).data, (2 / params["data"]))
 
 
 def test_tensor_nnz(sample_tensor_2way):
@@ -820,7 +836,7 @@ def test_tensor_reshape(sample_tensor_2way, sample_tensor_3way, sample_tensor_4w
         2,
     ), f"tensorInstance2.reshape((3, 2)): {tensorInstance2}"
     data = np.array([[1.0, 5.0], [4.0, 3.0], [2.0, 6.0]])
-    assert (tensorInstance2.data == data).all()
+    assert np.array_equal(tensorInstance2.data, data)
 
     with pytest.raises(AssertionError) as excinfo:
         tensorInstance2.reshape((3, 3))
@@ -840,7 +856,7 @@ def test_tensor_reshape(sample_tensor_2way, sample_tensor_3way, sample_tensor_4w
             [[3.0, 9.0], [6.0, 12.0]],
         ]
     )
-    assert (tensorInstance3.data == data3).all()
+    assert np.array_equal(tensorInstance3.data, data3)
 
     (params4, tensorInstance4) = sample_tensor_4way
     tensorInstance4 = tensorInstance4.reshape((1, 3, 3, 9))
@@ -871,16 +887,16 @@ def test_tensor_reshape(sample_tensor_2way, sample_tensor_3way, sample_tensor_4w
             ]
         ]
     )
-    assert (tensorInstance4.data == data4).all()
+    assert np.array_equal(tensorInstance4.data, data4)
 
 
 def test_tensor_permute(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Permute rows and columns
-    assert (
-        tensorInstance.permute(np.array([1, 0])).data == np.transpose(params["data"])
-    ).all()
+    assert np.array_equal(
+        tensorInstance.permute(np.array([1, 0])).data, np.transpose(params["data"])
+    )
 
     # len(order) != ndims
     with pytest.raises(AssertionError) as excinfo:
@@ -888,15 +904,15 @@ def test_tensor_permute(sample_tensor_2way, sample_tensor_3way, sample_tensor_4w
     assert "Invalid permutation order" in str(excinfo)
 
     # Try to permute order-1 tensor
-    assert (
-        ttb.tensor.from_data(np.array([1, 2, 3, 4])).permute(np.array([1])).data
-        == np.array([1, 2, 3, 4])
-    ).all()
+    assert np.array_equal(
+        ttb.tensor.from_data(np.array([1, 2, 3, 4])).permute(np.array([1])).data,
+        np.array([1, 2, 3, 4]),
+    )
 
     # Empty order
-    assert (
-        ttb.tensor.from_data(np.array([])).permute(np.array([])).data == np.array([])
-    ).all()
+    assert np.array_equal(
+        ttb.tensor.from_data(np.array([])).permute(np.array([])).data, np.array([])
+    )
 
     # 2-way
     (params2, tensorInstance2) = sample_tensor_2way
@@ -906,7 +922,7 @@ def test_tensor_permute(sample_tensor_2way, sample_tensor_3way, sample_tensor_4w
         2,
     ), f"tensorInstance2.permute(np.array([1, 0])): {tensorInstance2}"
     data2 = np.array([[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]])
-    assert (tensorInstance2.data == data2).all()
+    assert np.array_equal(tensorInstance2.data, data2)
 
     # 3-way
     (params3, tensorInstance3) = sample_tensor_3way
@@ -919,7 +935,7 @@ def test_tensor_permute(sample_tensor_2way, sample_tensor_3way, sample_tensor_4w
     data3 = np.array(
         [[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], [[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]]]
     )
-    assert (tensorInstance3.data == data3).all()
+    assert np.array_equal(tensorInstance3.data, data3)
 
     # 4-way
     (params4, tensorInstance4) = sample_tensor_4way
@@ -949,7 +965,7 @@ def test_tensor_permute(sample_tensor_2way, sample_tensor_3way, sample_tensor_4w
             ],
         ]
     )
-    assert (tensorInstance4.data == data4).all()
+    assert np.array_equal(tensorInstance4.data, data4)
 
 
 def test_tensor_collapse(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
@@ -971,22 +987,22 @@ def test_tensor_collapse(sample_tensor_2way, sample_tensor_3way, sample_tensor_4
     # single dimension collapse
     data = np.array([5, 7, 9])
     tensorCollapse = tensorInstance2.collapse(np.array([0]))
-    assert (tensorCollapse.data == data).all()
+    assert np.array_equal(tensorCollapse.data, data)
 
     # single dimension collapse using max function
     datamax = np.array([4, 5, 6])
     tensorCollapseMax = tensorInstance2.collapse(np.array([0]), fun=np.max)
-    assert (tensorCollapseMax.data == datamax).all()
+    assert np.array_equal(tensorCollapseMax.data, datamax)
 
     # multiple dimensions collapse
     data4 = np.array([[99, 342, 585], [126, 369, 612], [153, 396, 639]])
     tensorCollapse4 = tensorInstance4.collapse(np.array([0, 2]))
-    assert (tensorCollapse4.data == data4).all()
+    assert np.array_equal(tensorCollapse4.data, data4)
 
     # multiple dimensions collapse
     data4max = np.array([[21, 48, 75], [24, 51, 78], [27, 54, 81]])
     tensorCollapse4Max = tensorInstance4.collapse(np.array([0, 2]), fun=np.max)
-    assert (tensorCollapse4Max.data == data4max).all()
+    assert np.array_equal(tensorCollapse4Max.data, data4max)
 
     # Empty tensor collapse
     empty_data = np.array([])
@@ -1017,18 +1033,18 @@ def test_tensor_contract(sample_tensor_2way, sample_tensor_3way, sample_tensor_4
     print("\ntensorInstance3.contract(0,2) = ")
     print(tensorInstance3.contract(0, 2))
     data3 = np.array([9, 13, 17])
-    assert (tensorInstance3.contract(0, 2).data == data3).all()
+    assert np.array_equal(tensorInstance3.contract(0, 2).data, data3)
 
     (params4, tensorInstance4) = sample_tensor_4way
     print("\ntensorInstance4.contract(0,1) = ")
     print(tensorInstance4.contract(0, 1))
     data4 = np.array([[15, 96, 177], [42, 123, 204], [69, 150, 231]])
-    assert (tensorInstance4.contract(0, 1).data == data4).all()
+    assert np.array_equal(tensorInstance4.contract(0, 1).data, data4)
 
     print("\ntensorInstance4.contract(1,3) = ")
     print(tensorInstance4.contract(1, 3))
     data4a = np.array([[93, 120, 147], [96, 123, 150], [99, 126, 153]])
-    assert (tensorInstance4.contract(1, 3).data == data4a).all()
+    assert np.array_equal(tensorInstance4.contract(1, 3).data, data4a)
 
 
 def test_tensor__repr__(sample_tensor_2way):
@@ -1045,7 +1061,7 @@ def test_tensor__repr__(sample_tensor_2way):
 
 def test_tensor_exp(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     (params, tensorInstance) = sample_tensor_2way
-    assert (tensorInstance.exp().data == np.exp(params["data"])).all()
+    assert np.array_equal(tensorInstance.exp().data, np.exp(params["data"]))
 
 
 def test_tensor_innerprod(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
@@ -1094,7 +1110,7 @@ def test_tensor_innerprod(sample_tensor_2way, sample_tensor_3way, sample_tensor_
 def test_tensor_mask(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
     W = ttb.tensor.from_data(np.array([[0, 1, 0], [1, 0, 0]]))
-    assert (tensorInstance.mask(W) == np.array([4, 2])).all()
+    assert np.array_equal(tensorInstance.mask(W), np.array([4, 2]))
 
     # Wrong shape mask
     with pytest.raises(AssertionError) as excinfo:
@@ -1106,7 +1122,7 @@ def test_tensor_squeeze(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # No singleton dimensions
-    assert (tensorInstance.squeeze().data == params["data"]).all()
+    assert np.array_equal(tensorInstance.squeeze().data, params["data"])
 
     # All singleton dimensions
     squeeze_result = ttb.tensor.from_data(np.array([[[4]]])).squeeze()
@@ -1114,10 +1130,9 @@ def test_tensor_squeeze(sample_tensor_2way):
     assert np.isscalar(squeeze_result)
 
     # A singleton dimension
-    assert (
-        ttb.tensor.from_data(np.array([[1, 2, 3]])).squeeze().data
-        == np.array([1, 2, 3])
-    ).all()
+    assert np.array_equal(
+        ttb.tensor.from_data(np.array([[1, 2, 3]])).squeeze().data, np.array([1, 2, 3])
+    )
 
 
 def test_tensor_ttm(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
@@ -1133,14 +1148,14 @@ def test_tensor_ttm(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     assert isinstance(T3, ttb.tensor)
     assert T3.shape == (2, 3, 2)
     data3 = np.array([[[7, 31], [15, 39], [23, 47]], [[10, 46], [22, 58], [34, 70]]])
-    assert (T3.data == data3).all()
+    assert np.array_equal(T3.data, data3)
 
     # 3-way single matrix, transposed
     T3 = tensorInstance3.ttm(M2, 0, transpose=True)
     assert isinstance(T3, ttb.tensor)
     assert T3.shape == (2, 3, 2)
     data3 = np.array([[[5, 23], [11, 29], [17, 35]], [[11, 53], [25, 67], [39, 81]]])
-    assert (T3.data == data3).all()
+    assert np.array_equal(T3.data, data3)
 
     # 3-way, two matrices, negative dimension
     T3 = tensorInstance3.ttm([M2, M2], exclude_dims=1)
@@ -1149,7 +1164,7 @@ def test_tensor_ttm(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     data3 = np.array(
         [[[100, 138], [132, 186], [164, 234]], [[148, 204], [196, 276], [244, 348]]]
     )
-    assert (T3.data == data3).all()
+    assert np.array_equal(T3.data, data3)
 
     # 3-way, two matrices, explicit dimensions
     T3 = tensorInstance3.ttm([M2, M3], [2, 1])
@@ -1158,7 +1173,7 @@ def test_tensor_ttm(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     data3 = np.array(
         [[[408, 576], [498, 702], [588, 828]], [[456, 648], [558, 792], [660, 936]]]
     )
-    assert (T3.data == data3).all()
+    assert np.array_equal(T3.data, data3)
 
     # 3-way, 3 matrices, no dimensions specified
     T3 = tensorInstance3.ttm([M2, M3, M2])
@@ -1170,7 +1185,7 @@ def test_tensor_ttm(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
             [[2640, 3744], [3228, 4572], [3816, 5400]],
         ]
     )
-    assert (T3.data == data3).all()
+    assert np.array_equal(T3.data, data3)
 
     # 3-way, matrix must be np.ndarray
     Tmat = ttb.tenmat.from_data(M2, rdims=np.array([0]))
@@ -1199,9 +1214,9 @@ def test_tensor_ttt(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     data11 = np.array([1, 2, 3, 4])
     data12 = np.array([289, 306, 323, 340])
     data13 = np.array([504, 528, 552, 576])
-    assert (TTT1[:, 0, 0, 0, 0, 0].data == data11).all()
-    assert (TTT1[:, 1, 1, 1, 1, 1].data == data12).all()
-    assert (TTT1[:, 2, 1, 2, 3, 1].data == data13).all()
+    assert np.array_equal(TTT1[:, 0, 0, 0, 0, 0].data, data11)
+    assert np.array_equal(TTT1[:, 1, 1, 1, 1, 1].data, data12)
+    assert np.array_equal(TTT1[:, 2, 1, 2, 3, 1].data, data13)
 
     TTT1_with_dims = M31.ttt(
         M31, selfdims=np.array([0, 1, 2]), otherdims=np.array([0, 1, 2])
@@ -1237,13 +1252,13 @@ def test_tensor_ttv(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     T2 = tensorInstance2.ttv(np.array([2, 2]), 0)
     assert isinstance(T2, ttb.tensor)
     assert T2.shape == (3,)
-    assert (T2.data == np.array([10, 14, 18])).all()
+    assert np.array_equal(T2.data, np.array([10, 14, 18]))
 
     # 2-way Multiply by single vector (exclude dims)
     T2 = tensorInstance2.ttv(np.array([2, 2]), exclude_dims=1)
     assert isinstance(T2, ttb.tensor)
     assert T2.shape == (3,)
-    assert (T2.data == np.array([10, 14, 18])).all()
+    assert np.array_equal(T2.data, np.array([10, 14, 18]))
 
     # Multiply by multiple vectors, infer dimensions
     assert tensorInstance2.ttv([np.array([2, 2]), np.array([1, 1, 1])]) == 42
@@ -1255,7 +1270,7 @@ def test_tensor_ttv(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
     T3 = tensorInstance3.ttv(2 * np.ones((tensorInstance3.shape[0],)), 0)
     assert isinstance(T3, ttb.tensor)
     assert T3.shape == (tensorInstance3.shape[1], tensorInstance3.shape[2])
-    assert (T3.data == np.array([[6, 30], [14, 38], [22, 46]])).all()
+    assert np.array_equal(T3.data, np.array([[6, 30], [14, 38], [22, 46]]))
 
     # Multiply by multiple vectors, infer dimensions
     assert (
@@ -1290,7 +1305,7 @@ def test_tensor_ttv(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
             [[48, 210, 372], [102, 264, 426], [156, 318, 480]],
         ]
     )
-    assert (T4.data == data4).all()
+    assert np.array_equal(T4.data, data4)
 
     # Multiply by multiple vectors, infer dimensions
     assert (
@@ -1313,12 +1328,12 @@ def test_tensor_ttsv(sample_tensor_4way):
     tensorInstance3 = ttb.tensor.from_data(np.ones((4, 4, 4)))
     vector3 = np.array([4, 3, 2, 1])
     assert tensorInstance3.ttsv(vector3, version=1) == 1000
-    assert (
-        tensorInstance3.ttsv(vector3, skip_dim=0, version=1) == 100 * np.ones((4,))
-    ).all()
-    assert (
-        tensorInstance3.ttsv(vector3, skip_dim=1, version=1) == 10 * np.ones((4, 4))
-    ).all()
+    assert np.array_equal(
+        tensorInstance3.ttsv(vector3, skip_dim=0, version=1), 100 * np.ones((4,))
+    )
+    assert np.array_equal(
+        tensorInstance3.ttsv(vector3, skip_dim=1, version=1), 10 * np.ones((4, 4))
+    )
 
     # Invalid dims
     with pytest.raises(ValueError) as excinfo:
@@ -1335,7 +1350,7 @@ def test_tensor_ttsv(sample_tensor_4way):
             [[234, 288, 342], [252, 306, 360], [270, 324, 378]],
         ]
     )
-    assert (T4ttsv.data == data4_3).all()
+    assert np.array_equal(T4ttsv.data, data4_3)
 
     # 5-way dense tensor
     shape = (3, 3, 3, 3, 3)
@@ -1348,18 +1363,18 @@ def test_tensor_ttsv(sample_tensor_4way):
             [[5292, 5616, 5940], [5400, 5724, 6048], [5508, 5832, 6156]],
         ]
     )
-    assert (T5ttsv.data == data5_3).all()
+    assert np.array_equal(T5ttsv.data, data5_3)
 
     # Test new algorithm, version=2
 
     # 3-way
     assert tensorInstance3.ttsv(vector3) == 1000
-    assert (tensorInstance3.ttsv(vector3, 0) == 100 * np.ones((4,))).all()
-    assert (tensorInstance3.ttsv(vector3, 1) == 10 * np.ones((4, 4))).all()
+    assert np.array_equal(tensorInstance3.ttsv(vector3, 0), 100 * np.ones((4,)))
+    assert np.array_equal(tensorInstance3.ttsv(vector3, 1), 10 * np.ones((4, 4)))
 
     # 4-way tensor
     T4ttsv2 = tensorInstance4.ttsv(np.array([1, 2, 3]), 2)
-    assert (T4ttsv2.data == data4_3).all()
+    assert np.array_equal(T4ttsv2.data, data4_3)
 
     # Incorrect version requested
     with pytest.raises(AssertionError) as excinfo:
@@ -1386,7 +1401,7 @@ def test_tensor_issymmetric(sample_tensor_2way):
     assert symmetricTensor.issymmetric(version=1) is True
     answer, diffs, perms = symmetricTensor.issymmetric(version=1, return_details=True)
     assert answer is True
-    assert (diffs == 0).all()
+    assert np.all(diffs == 0)
 
     symmetricData[3, 1, 0] = 3
     symmetricTensor = ttb.tensor.from_data(symmetricData)
@@ -1432,7 +1447,7 @@ def test_tensor_symmetrize(sample_tensor_2way):
             [[3 + 1 / 3, 5 + 2 / 3], [5 + 2 / 3, 8]],
         ]
     )
-    assert (T3sym.data == data3).all()
+    assert np.array_equal(T3sym.data, data3)
 
     # T3syms_2_1_3 = T3.symmetrize(grps=[[1], [0,2]])
     # print(f'\nT3syms_2_1_3:')
@@ -1593,18 +1608,18 @@ def test_tensor_mttkrp(sample_tensor_2way):
         U.append(np.ones((s, 2)))
 
     data0 = np.array([[129600, 129600], [129960, 129960]])
-    assert (T.mttkrp(U, 0) == data0).all()
+    assert np.array_equal(T.mttkrp(U, 0), data0)
 
     data1 = np.array([[86040, 86040], [86520, 86520], [87000, 87000]])
-    assert (T.mttkrp(U, 1) == data1).all()
+    assert np.array_equal(T.mttkrp(U, 1), data1)
 
     data2 = np.array([[63270, 63270], [64350, 64350], [65430, 65430], [66510, 66510]])
-    assert (T.mttkrp(U, 2) == data2).all()
+    assert np.array_equal(T.mttkrp(U, 2), data2)
 
     data3 = np.array(
         [[45000, 45000], [48456, 48456], [51912, 51912], [55368, 55368], [58824, 58824]]
     )
-    assert (T.mttkrp(U, 3) == data3).all()
+    assert np.array_equal(T.mttkrp(U, 3), data3)
 
     data4 = np.array(
         [
@@ -1616,7 +1631,7 @@ def test_tensor_mttkrp(sample_tensor_2way):
             [79260, 79260],
         ]
     )
-    assert (T.mttkrp(U, 4) == data4).all()
+    assert np.array_equal(T.mttkrp(U, 4), data4)
 
     # tensor too small
     with pytest.raises(AssertionError) as excinfo:

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1500,8 +1500,7 @@ def test_tensor__str__(sample_tensor_2way):
     data = np.random.normal(size=(4,))
     tensorInstance = ttb.tensor.from_data(data)
     s = ""
-    s += "tensor of shape "
-    s += (" x ").join([str(int(d)) for d in tensorInstance.shape])
+    s += f"tensor of shape {tensorInstance.shape}"
     s += "\n"
     s += "data"
     s += "[:] = \n"
@@ -1513,8 +1512,7 @@ def test_tensor__str__(sample_tensor_2way):
     data = np.random.normal(size=(4, 3))
     tensorInstance = ttb.tensor.from_data(data)
     s = ""
-    s += "tensor of shape "
-    s += (" x ").join([str(int(d)) for d in tensorInstance.shape])
+    s += f"tensor of shape {tensorInstance.shape}"
     s += "\n"
     s += "data"
     s += "[:, :] = \n"
@@ -1526,8 +1524,7 @@ def test_tensor__str__(sample_tensor_2way):
     data = np.random.normal(size=(4, 3, 2))
     tensorInstance = ttb.tensor.from_data(data)
     s = ""
-    s += "tensor of shape "
-    s += (" x ").join([str(int(d)) for d in tensorInstance.shape])
+    s += f"tensor of shape {tensorInstance.shape}"
     s += "\n"
     for i in range(data.shape[0]):
         s += "data"
@@ -1539,8 +1536,7 @@ def test_tensor__str__(sample_tensor_2way):
     data = np.random.normal(size=(2, 3, 4))
     tensorInstance = ttb.tensor.from_data(data)
     s = ""
-    s += "tensor of shape "
-    s += (" x ").join([str(int(d)) for d in tensorInstance.shape])
+    s += f"tensor of shape {tensorInstance.shape}"
     s += "\n"
     for i in range(data.shape[0]):
         s += "data"
@@ -1553,8 +1549,7 @@ def test_tensor__str__(sample_tensor_2way):
     data = np.random.normal(size=(4, 4, 3, 2))
     tensorInstance = ttb.tensor.from_data(data)
     s = ""
-    s += "tensor of shape "
-    s += (" x ").join([str(int(d)) for d in tensorInstance.shape])
+    s += f"tensor of shape {tensorInstance.shape}"
     s += "\n"
     for i in range(data.shape[0]):
         for j in range(data.shape[1]):
@@ -1568,8 +1563,7 @@ def test_tensor__str__(sample_tensor_2way):
     data = np.random.normal(size=(2, 2, 2, 2, 2))
     tensorInstance = ttb.tensor.from_data(data)
     s = ""
-    s += "tensor of shape "
-    s += (" x ").join([str(int(d)) for d in tensorInstance.shape])
+    s += f"tensor of shape {tensorInstance.shape}"
     s += "\n"
     for i in range(data.shape[0]):
         for j in range(data.shape[1]):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -755,13 +755,6 @@ def test_tensor_double(sample_tensor_2way):
     assert (tensorInstance.double() == params["data"]).all()
 
 
-def test_tensor_end(sample_tensor_2way):
-    (params, tensorInstance) = sample_tensor_2way
-
-    assert tensorInstance.end() == np.prod(params["shape"]) - 1
-    assert tensorInstance.end(k=0) == params["shape"][0] - 1
-
-
 def test_tensor_isequal(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
     subs = []


### PR DESCRIPTION
Catching a few odds and ends:
* https://github.com/sandialabs/pyttb/issues/185
* https://github.com/sandialabs/pyttb/issues/183
* https://github.com/sandialabs/pyttb/issues/179

One commit each. The (array==array).all() pattern caught a few minor bugs but nothing substantial.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--195.org.readthedocs.build/en/195/

<!-- readthedocs-preview pyttb end -->