### PR TITLE
Documentation minor format fixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,6 +55,8 @@ extensions = [
     "myst_nb",
 ]
 
+autodoc_preserve_defaults = True
+
 myst_enable_extensions = [
     "amsmath",
     "dollarmath",
@@ -68,7 +70,7 @@ napoleon_use_rtype = False
 
 intersphinx_mapping = {
     "numpy": ("http://docs.scipy.org/doc/numpy/", "numpy.inv"),
-    "python": ("http://docs.python.org/3.6/", "python.inv"),
+    "python": ("http://docs.python.org/3.8/", "python.inv"),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
     "pytest-cov",
 ]
 doc = [
-    "sphinx >= 3.5",
+    "sphinx >= 4.0",
     "sphinx_rtd_theme",
     "myst-nb",
 ]


### PR DESCRIPTION
   * Our types linked to 3.6, make 3.8
   * collapse displayed wrong, this fixes it by not evaluating default values (updated our minimum sphinx to 4.0 to support the setting)
   
See our [latest ](https://pyttb.readthedocs.io/en/latest/sptensor.html#pyttb.sptensor.sptensor.collapse)for collapse vs the updated [preview ](https://pyttb--196.org.readthedocs.build/en/196/sptensor.html#pyttb.sptensor.sptensor.collapse) as far as I can tell this evaluates `np.sum` which is the function handle and fails to display properly. By just using the literal value things seem to be ok and not break elsewhere. If this ends up causing additional issues we may need to just default to None values and set the default internally.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--196.org.readthedocs.build/en/196/

<!-- readthedocs-preview pyttb end -->