### PR TITLE
Gcp fg

### DIFF
--- a/pyttb/gcp/fg.py
+++ b/pyttb/gcp/fg.py
@@ -14,9 +14,9 @@ from pyttb.gcp.fg_setup import function_type
 def evaluate(
     model: ttb.ktensor,
     data: ttb.tensor,
+    weights: Optional[np.ndarray],
     function_handle: Literal[None],
     gradient_handle: function_type,
-    weights: Optional[np.ndarray],
 ) -> List[np.ndarray]:
     ...  # pragma: no cover see coveragepy/issues/970
 
@@ -25,9 +25,9 @@ def evaluate(
 def evaluate(
     model: ttb.ktensor,
     data: ttb.tensor,
+    weights: Optional[np.ndarray],
     function_handle: function_type,
     gradient_handle: Literal[None],
-    weights: Optional[np.ndarray],
 ) -> float:
     ...  # pragma: no cover see coveragepy/issues/970
 
@@ -36,9 +36,9 @@ def evaluate(
 def evaluate(
     model: ttb.ktensor,
     data: ttb.tensor,
+    weights: Optional[np.ndarray],
     function_handle: function_type,
     gradient_handle: function_type,
-    weights: Optional[np.ndarray],
 ) -> Tuple[float, List[np.ndarray]]:
     ...  # pragma: no cover see coveragepy/issues/970
 
@@ -46,24 +46,24 @@ def evaluate(
 def evaluate(
     model: ttb.ktensor,
     data: ttb.tensor,
+    weights: Optional[np.ndarray] = None,
     function_handle: Optional[function_type] = None,
     gradient_handle: Optional[function_type] = None,
-    weights: Optional[np.ndarray] = None,
 ) -> Union[float, List[np.ndarray], Tuple[float, List[np.ndarray]]]:
     """Evaluate an objective function and/or gradient function
 
     Parameters
     ----------
-    data:
-        Source tensor to decompose.
     model:
         Current decomposition.
+    data:
+        Source tensor to decompose.
+    weights:
+        Weighted values for returned tensor. Can be used as a mask.
     function_handle:
         Objective function.
     gradient_handle:
         Gradient definition.
-    weights:
-        Weighted values for returned tensor. Can be used as a mask.
 
     Returns
     -------

--- a/pyttb/gcp/fg.py
+++ b/pyttb/gcp/fg.py
@@ -1,0 +1,104 @@
+"""Evaluate Function And Gradient Handles"""
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional, Tuple, Union, overload
+
+import numpy as np
+
+import pyttb as ttb
+from pyttb.gcp.fg_setup import function_type
+
+
+@overload
+def evaluate(
+    model: ttb.ktensor,
+    data: ttb.tensor,
+    function_handle: Literal[None],
+    gradient_handle: function_type,
+    weights: Optional[np.ndarray],
+) -> List[np.ndarray]:
+    ...  # pragma: no cover see coveragepy/issues/970
+
+
+@overload
+def evaluate(
+    model: ttb.ktensor,
+    data: ttb.tensor,
+    function_handle: function_type,
+    gradient_handle: Literal[None],
+    weights: Optional[np.ndarray],
+) -> float:
+    ...  # pragma: no cover see coveragepy/issues/970
+
+
+@overload
+def evaluate(
+    model: ttb.ktensor,
+    data: ttb.tensor,
+    function_handle: function_type,
+    gradient_handle: function_type,
+    weights: Optional[np.ndarray],
+) -> Tuple[float, List[np.ndarray]]:
+    ...  # pragma: no cover see coveragepy/issues/970
+
+
+def evaluate(
+    model: ttb.ktensor,
+    data: ttb.tensor,
+    function_handle: Optional[function_type] = None,
+    gradient_handle: Optional[function_type] = None,
+    weights: Optional[np.ndarray] = None,
+) -> Union[float, List[np.ndarray], Tuple[float, List[np.ndarray]]]:
+    """Evaluate an objective function and/or gradient function
+
+    Parameters
+    ----------
+    data:
+        Source tensor to decompose.
+    model:
+        Current decomposition.
+    function_handle:
+        Objective function.
+    gradient_handle:
+        Gradient definition.
+    weights:
+        Weighted values for returned tensor. Can be used as a mask.
+
+    Returns
+    -------
+    Objective function value and/or gradient function value with respect to model.
+    """
+    if function_handle is None and gradient_handle is None:
+        raise ValueError(
+            "Either a function handle, or a gradient handle must be provided."
+        )
+
+    full_model = model.full()
+    # TODO should we early check shapes?
+    # I don't think we always get vectorization for free in python
+    # we should be able to operate on underlying np arrays directly though
+    F: Optional[float] = None
+    G: Optional[List[np.ndarray]] = None
+    if function_handle is not None:
+        Y = function_handle(data.data, full_model.data)
+        if weights is not None:
+            Y *= weights
+        F = float(np.sum(Y))
+
+    if gradient_handle is not None:
+        Y = gradient_handle(data.data, full_model.data)
+        if weights is not None:
+            Y *= weights
+        # TODO take this without a copy when #187 completed
+        G = ttb.tensor.from_data(Y).mttkrps(model.factor_matrices)
+
+    if F is not None and G is not None:
+        return F, G
+    if F is not None:
+        return F
+    if G is not None:
+        return G
+    raise ValueError(
+        "No valid outputs for either function or gradient handles"
+    )  # pragma: no cover

--- a/pyttb/gcp/fg_est.py
+++ b/pyttb/gcp/fg_est.py
@@ -1,0 +1,181 @@
+"""Evaluate Functions And Gradients based on Subsamples"""
+
+from __future__ import annotations
+
+import warnings
+from typing import List, Literal, Optional, Tuple, Union, overload
+
+import numpy as np
+
+import pyttb as ttb
+from pyttb.gcp.fg_setup import function_type
+
+
+# pylint: disable=too-many-arguments
+@overload
+def estimate(
+    model: ttb.ktensor,
+    data_subs: np.ndarray,
+    data_vals: np.ndarray,
+    weights: np.ndarray,
+    function_handle: Literal[None],
+    gradient_handle: function_type,
+    lambda_check: bool,
+    crng: Optional[np.ndarray],
+) -> List[np.ndarray]:
+    ...  # pragma: no cover see coveragepy/issues/970
+
+
+@overload
+def estimate(
+    model: ttb.ktensor,
+    data_subs: np.ndarray,
+    data_vals: np.ndarray,
+    weights: np.ndarray,
+    function_handle: function_type,
+    gradient_handle: Literal[None],
+    lambda_check: bool,
+    crng: Optional[np.ndarray],
+) -> float:
+    ...  # pragma: no cover see coveragepy/issues/970
+
+
+@overload
+def estimate(
+    model: ttb.ktensor,
+    data_subs: np.ndarray,
+    data_vals: np.ndarray,
+    weights: np.ndarray,
+    function_handle: function_type,
+    gradient_handle: function_type,
+    lambda_check: bool,
+    crng: Optional[np.ndarray],
+) -> Tuple[float, List[np.ndarray]]:
+    ...  # pragma: no cover see coveragepy/issues/970
+
+
+def estimate(
+    model: ttb.ktensor,
+    data_subs: np.ndarray,
+    data_vals: np.ndarray,
+    weights: np.ndarray,
+    function_handle: Optional[function_type] = None,
+    gradient_handle: Optional[function_type] = None,
+    lambda_check: bool = True,
+    crng: Optional[np.ndarray] = None,
+) -> Union[float, List[np.ndarray], Tuple[float, List[np.ndarray]]]:
+    """Estimate the GCP function and gradient with a subsample
+
+    Parameters
+    ----------
+    model:
+        Current decomposition.
+    data_subs:
+        Subscripts of data sample.
+    data_vals:
+        Values of data sample.
+    function_handle:
+        Handle to evaluate objective function.
+    gradient_handle:
+        Handle to evaluate gradient of objective function.
+    lambda_check:
+        Whether or not to check decomposition weights are all ones.
+        (Which is assumed in implementation details)
+    crng:
+        Range of indices for correct/adjustment when zeros are sampled accidentally.
+
+    Returns
+    -------
+        Estimated objective function value and/or estimated gradient value with
+        respect to the model.
+    """
+    if function_handle is None and gradient_handle is None:
+        raise ValueError(
+            "Either a function handle, or a gradient handle must be provided."
+        )
+
+    if lambda_check and any(model.weights != 1.0):
+        warnings.warn("Normalizing model to have all 1's for weights")
+        model = model.normalize(1)  # TODO confirm argument correctness
+    model_vals, Zexp = estimate_helper(model.factor_matrices, data_subs)
+
+    F: Optional[float] = None
+    G: Optional[List[np.ndarray]] = None
+
+    if function_handle is not None:
+        Y = function_handle(data_vals, model_vals)
+        if crng is not None:
+            Y[crng] -= function_handle(np.zeros_like(crng), model_vals[crng])
+        F = np.sum(weights * Y)
+
+    if gradient_handle is not None:
+        # Compute sample y values
+        Y = weights * gradient_handle(data_vals, model_vals)
+        if crng is not None:
+            Y[crng] -= weights[crng] * gradient_handle(
+                np.zeros_like(crng), model_vals[crng]
+            )
+        G = [np.empty(())] * model.ndims
+        nsamples = data_subs.shape[0]
+        for k in range(model.ndims):
+            # The row of each element is the row index to accumulate in the gradient.
+            # The columns are the corresponding samples. They are in order because they
+            # match the vector of samples to be multiplied on the right.
+            G[k] = Zexp[k]
+            # Just multiply a slice inplace instead of constructing sparse matrix
+            G[k][data_subs[:, k], np.arange(nsamples)] *= Y
+
+    if F is not None and G is not None:
+        return F, G
+    if F is not None:
+        return F
+    if G is not None:
+        return G
+    raise ValueError(
+        "No valid outputs for either function or gradient handles"
+    )  # pragma: no cover
+
+
+def estimate_helper(
+    factors: List[np.ndarray], subs: np.ndarray
+) -> Tuple[np.ndarray, List[np.ndarray]]:
+    """Extract model values at sample locations and exploded Zk's
+
+    Parameters
+    ----------
+    factors:
+        Factor matrices from model.
+    subs:
+        Subscripts to extract from model.
+
+    Returns
+    -------
+        Model values at subs and exploded Zk's
+    """
+    Zexp: List[np.ndarray] = []
+    if subs.size == 0:
+        return np.array([]), Zexp
+
+    ndim = subs.shape[1]
+
+    # Create exploded U's from the model factor matrices
+    Uexp = [np.empty(())] * ndim
+    for k in range(ndim):
+        Uexp[k] = factors[k][subs[:, k], :]
+
+    # After this pass, Zexp[k] = Hadarmard product of Uexp[0] through
+    # Uexp[k-1] for k = 1,...,ndim
+    Zexp = [np.empty(())] * ndim
+    Zexp[1] = Uexp[0].copy()
+    for k in range(2, ndim):
+        Zexp[k] = Zexp[k - 1] * Uexp[k - 1]
+
+    # After this pass, Zexp[k] = Hadarmard product of Uexcp[0] through
+    # Uexp[d], except Uexp[k] for k = 0, ..., ndim
+    Zexp[0] = Uexp[ndim - 1].copy()
+    for k in range(ndim - 2, 0, -1):
+        Zexp[k] *= Zexp[0]
+        Zexp[0] *= Uexp[k]
+
+    mvals = np.sum(Zexp[ndim - 1] * Uexp[ndim - 1], axis=1)
+    return mvals, Zexp

--- a/pyttb/gcp/fg_setup.py
+++ b/pyttb/gcp/fg_setup.py
@@ -1,0 +1,135 @@
+"""Prepare Function and Gradient Handles for GCP OPT"""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Callable, Optional, Tuple, Union
+
+import numpy as np
+
+import pyttb as ttb
+from pyttb.gcp import handles
+from pyttb.gcp.handles import Objectives
+
+function_type = Callable[[np.ndarray, np.ndarray], np.ndarray]
+fg_return = Tuple[function_type, function_type, float]
+
+
+# pylint: disable=too-many-branches, too-many-statements
+def setup(
+    objective: Objectives,
+    data: Optional[Union[ttb.tensor, ttb.sptensor]] = None,
+    additional_parameter: Optional[float] = None,
+) -> fg_return:
+    """Collects the function and gradient handles for GCP
+
+    Parameters
+    ----------
+    objective:
+        Objective function to gather handles for.
+    data:
+        Tensor to check for consistency with desired objective function.
+    additional_parameter:
+        Additional constant argument provided to objective function if necessary.
+
+    Returns
+    -------
+    Function handle, gradient handle, and lower bound.
+    """
+    if objective == Objectives.GAUSSIAN:
+        function_handle = handles.gaussian
+        gradient_handle = handles.gaussian_grad
+        lower_bound = -np.inf
+    elif objective == Objectives.BERNOULLI_ODDS:
+        if data is not None and not valid_binary(data):
+            raise ValueError(f"{objective.name} requires a binary tensor")
+        function_handle = handles.bernoulli_odds
+        gradient_handle = handles.bernoulli_odds_grad
+        lower_bound = 0.0
+    elif objective == Objectives.BERNOULLI_LOGIT:
+        if data is not None and not valid_binary(data):
+            raise ValueError(f"{objective.name} requires a binary tensor")
+        function_handle = handles.bernoulli_logit
+        gradient_handle = handles.bernoulli_logit_grad
+        lower_bound = -np.inf
+    elif objective == Objectives.POISSON:
+        if data is not None and not valid_natural(data):
+            raise ValueError(f"{objective.name} requires a count tensor")
+        function_handle = handles.poisson
+        gradient_handle = handles.poisson_grad
+        lower_bound = 0.0
+    elif objective == Objectives.POISSON_LOG:
+        if data is not None and not valid_natural(data):
+            raise ValueError(f"{objective.name} requires a count tensor")
+        function_handle = handles.poisson_log
+        gradient_handle = handles.poisson_log_grad
+        lower_bound = -np.inf
+    elif objective == Objectives.RAYLEIGH:
+        if data is not None and not valid_nonneg(data):
+            raise ValueError(f"{objective.name} requires a non-negative tensor")
+        function_handle = handles.rayleigh
+        gradient_handle = handles.rayleigh_grad
+        lower_bound = 0.0
+    elif objective == Objectives.GAMMA:
+        if data is not None and not valid_nonneg(data):
+            raise ValueError(f"{objective.name} requires a non-negative tensor")
+        function_handle = handles.gamma
+        gradient_handle = handles.gamma_grad
+        lower_bound = 0.0
+    elif objective == Objectives.HUBER:
+        if additional_parameter is None:
+            raise ValueError(
+                f"{objective.name} requires additional parameter for `threshold`"
+            )
+        function_handle = partial(handles.huber, threshold=additional_parameter)
+        gradient_handle = partial(handles.huber_grad, threshold=additional_parameter)
+        lower_bound = -np.inf
+    elif objective == Objectives.NEGATIVE_BINOMIAL:
+        if data is not None and not valid_nonneg(data):
+            raise ValueError(f"{objective.name} requires a non-negative tensor")
+        if additional_parameter is None:
+            raise ValueError(
+                f"{objective.name} requires additional parameter for `num_trials`"
+            )
+        function_handle = partial(
+            handles.negative_binomial, num_trials=additional_parameter
+        )
+        gradient_handle = partial(
+            handles.negative_binomial_grad, num_trials=additional_parameter
+        )
+        lower_bound = 0
+    elif objective == Objectives.BETA:
+        if data is not None and not valid_nonneg(data):
+            raise ValueError(f"{objective.name} requires a non-negative tensor")
+        if additional_parameter is None:
+            raise ValueError(f"{objective.name} requires additional parameter for `b`")
+        function_handle = partial(handles.beta, b=additional_parameter)
+        gradient_handle = partial(handles.beta_grad, b=additional_parameter)
+        lower_bound = 0
+    else:
+        raise ValueError(f" Unknown objective: {objective}")
+
+    return function_handle, gradient_handle, lower_bound
+
+
+def valid_nonneg(data: Union[ttb.tensor, ttb.sptensor]) -> bool:
+    """Check if provided data is valid non-negative tensor"""
+    if isinstance(data, ttb.sptensor):
+        return bool(np.all(data.vals > 0))
+    return bool(np.all(data.data > 0))
+
+
+def valid_binary(data: Union[ttb.tensor, ttb.sptensor]) -> bool:
+    """Check if provided data is valid binary tensor"""
+    if isinstance(data, ttb.sptensor):
+        return bool(np.all(data.vals == 1))
+    return bool(np.all(np.isin(np.unique(data.data), [0, 1])))
+
+
+def valid_natural(data: Union[ttb.tensor, ttb.sptensor]) -> bool:
+    """Check if provided data is valid natural number tensor"""
+    if isinstance(data, ttb.sptensor):
+        vals = data.vals
+    else:
+        vals = data.data
+    return bool(np.all(vals % 1 == 0))

--- a/pyttb/gcp/handles.py
+++ b/pyttb/gcp/handles.py
@@ -2,12 +2,29 @@
 
 from __future__ import annotations
 
+from enum import Enum
+
 import numpy as np
 
 import pyttb as ttb
 
 # Epsilon values for distributions
 EPS = 1e-10
+
+
+class Objectives(Enum):
+    """Valid objective functions for GCP"""
+
+    GAUSSIAN = 0
+    BERNOULLI_ODDS = 1
+    BERNOULLI_LOGIT = 2
+    POISSON = 3
+    POISSON_LOG = 4
+    RAYLEIGH = 5
+    GAMMA = 6
+    HUBER = 7
+    NEGATIVE_BINOMIAL = 8
+    BETA = 9
 
 
 def gaussian(data: np.ndarray, model: np.ndarray) -> np.ndarray:

--- a/pyttb/gcp/handles.py
+++ b/pyttb/gcp/handles.py
@@ -1,0 +1,124 @@
+"""Implementation of the different function and gradient handles for GCP OPT"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import pyttb as ttb
+
+# Epsilon values for distributions
+EPS = 1e-10
+
+
+def gaussian(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return objective function for gaussian distributions"""
+    return (model - data) ** 2
+
+
+def gaussian_grad(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return gradient function for gaussian distributions"""
+    return 2 * (model - data)
+
+
+def bernoulli_odds(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return objective function for bernoulli distributions"""
+    return np.log(model + 1) - data * np.log(model + EPS)
+
+
+def bernoulli_odds_grad(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return gradient function for bernoulli distributions"""
+    return 1.0 / (model + 1) - data / (model + EPS)
+
+
+def bernoulli_logit(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return objective function for bernoulli logit distributions"""
+    return np.log(np.exp(model) + 1) - data * model
+
+
+def bernoulli_logit_grad(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return gradient function for bernoulli logit distributions"""
+    return np.exp(model) / (np.exp(model) + 1) - data
+
+
+def poisson(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return objective function for poisson distributions"""
+    return model - data * np.log(model + EPS)
+
+
+def poisson_grad(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return gradient function for poisson distributions"""
+    return 1 - data / (model + EPS)
+
+
+def poisson_log(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return objective function for log poisson distributions"""
+    return np.exp(model) - data * model
+
+
+def poisson_log_grad(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return gradient function for log poisson distributions"""
+    return np.exp(model) - data
+
+
+def rayleigh(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return objective function for rayleigh distributions"""
+    return 2 * np.log(model + EPS) + (np.pi / 4) * (data / (model + EPS)) ** 2
+
+
+def rayleigh_grad(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return gradient function for rayleigh distributions"""
+    return 2 / (model + EPS) - (np.pi / 2) * data**2 / (model + EPS) ** 3
+
+
+def gamma(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return objective function for gamma distributions"""
+    return data / (model + EPS) + np.log(model + EPS)
+
+
+def gamma_grad(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    """Return gradient function for gamma distributions"""
+    return -data / (model + EPS) ** 2 + 1 / (model + EPS)
+
+
+def huber(data: ttb.tensor, model: ttb.tensor, threshold: float) -> np.ndarray:
+    """Return objective function for huber loss"""
+    abs_diff = np.abs(data - model)
+    below_threshold = abs_diff < threshold
+    return abs_diff**2 * below_threshold + (
+        2 * threshold * abs_diff - threshold**2
+    ) * np.logical_not(below_threshold)
+
+
+def huber_grad(data: ttb.tensor, model: ttb.tensor, threshold: float) -> np.ndarray:
+    """Return gradient function for huber loss"""
+    abs_diff = np.abs(data - model)
+    below_threshold = abs_diff < threshold
+    return -2 * (data - model) * below_threshold - (
+        2 * threshold * np.sign(data - model)
+    ) * np.logical_not(below_threshold)
+
+
+def negative_binomial(
+    data: np.ndarray, model: np.ndarray, num_trials: int
+) -> np.ndarray:
+    """Return objective function for negative binomial distributions"""
+    return (num_trials + data) * np.log(model + 1) - data * np.log(model + EPS)
+
+
+def negative_binomial_grad(
+    data: np.ndarray, model: np.ndarray, num_trials: int
+) -> np.ndarray:
+    """Return gradient function for negative binomial distributions"""
+    return (num_trials + 1) / (1 + model) - data / (model + EPS)
+
+
+def beta(data: np.ndarray, model: np.ndarray, b: float) -> np.ndarray:
+    """Return objective function for beta distributions"""
+    return (1 / b) * (model + EPS) ** b - (1 / (b - 1)) * data * (model + EPS) ** (
+        b - 1
+    )
+
+
+def beta_grad(data: np.ndarray, model: np.ndarray, b: float) -> np.ndarray:
+    """Return gradient function for beta distributions"""
+    return (model + EPS) ** (b - 1) - data * (model + EPS) ** (b - 2)

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -721,6 +721,14 @@ class tensor:
                 V[:, [r]] = Y[:, :, r].T @ Ur[:, :, r]
             return V
 
+    def mttkrps(self, U: Union[ttb.ktensor, List[np.ndarray]]) -> List[np.ndarray]:
+        """Sequence of MTTKRP calculations for a tensor.
+
+        Result is equivalent to [X.mttkrp(U, k) for k in range(X.ndims)]
+        """
+        # TODO actually implement but stub to validate fg
+        return list(self.mttkrp(U, k) for k in range(self.ndims))
+
     @property
     def ndims(self) -> int:
         """

--- a/tests/gcp/test_fg.py
+++ b/tests/gcp/test_fg.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from inspect import Parameter, signature
+from math import exp, log, pi
+
+import numpy as np
+import pytest
+import scipy
+
+import pyttb as ttb
+from pyttb.gcp import fg_setup
+from pyttb.gcp.fg import evaluate
+from pyttb.gcp.handles import Objectives
+
+
+def test_evaluate():
+    with pytest.raises(ValueError):
+        model = ttb.ktensor()
+        data = ttb.tensor()
+        evaluate(model, data)
+
+    def no_op(data, model):
+        """Function handle that does nothing"""
+        return data
+
+    # Just function handle
+    model = ttb.ktensor([np.ones((2, 2))] * 2)
+    data = ttb.tenzeros((2, 2))
+    f = evaluate(model, data, function_handle=no_op)
+    assert isinstance(f, float)
+    assert f == np.sum(data.data)
+
+    weight = np.zeros_like(data.data)
+    f = evaluate(model, data, weights=weight, function_handle=no_op)
+    assert isinstance(f, float)
+    assert f == 0.0
+
+    # Just gradient handle
+    model = ttb.ktensor([np.ones((k, 2)) for k in (2, 3, 4)])
+    data = ttb.tenzeros(model.shape)
+    g = evaluate(model, data, gradient_handle=no_op)
+    assert all(isinstance(g_i, np.ndarray) for g_i in g)
+
+    weight = np.zeros_like(data.data)
+    g = evaluate(model, data, weights=weight, gradient_handle=no_op)
+    assert all(isinstance(g_i, np.ndarray) for g_i in g)
+    assert all(np.all(g_i == 0.0) for g_i in g)
+
+    # Both handles
+    f, g = evaluate(
+        model,
+        data,
+        function_handle=no_op,
+        gradient_handle=no_op,
+        weights=weight,
+    )
+    assert isinstance(f, float)
+    assert all(isinstance(g_i, np.ndarray) for g_i in g)

--- a/tests/gcp/test_fg.py
+++ b/tests/gcp/test_fg.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
-from inspect import Parameter, signature
-from math import exp, log, pi
-
 import numpy as np
 import pytest
-import scipy
 
 import pyttb as ttb
-from pyttb.gcp import fg_setup
 from pyttb.gcp.fg import evaluate
-from pyttb.gcp.handles import Objectives
 
 
 def test_evaluate():
+    # No function or gradient handle
     with pytest.raises(ValueError):
         model = ttb.ktensor()
         data = ttb.tensor()

--- a/tests/gcp/test_fg_est.py
+++ b/tests/gcp/test_fg_est.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pyttb as ttb
+from pyttb.gcp.fg_est import estimate, estimate_helper
+
+
+def test_estimate_helper():
+    fm0 = np.array([[1.0, 3.0], [2.0, 4.0]])
+    fm1 = np.array([[5.0, 8.0], [6.0, 9.0], [7.0, 10.0]])
+    fm2 = np.array([[11.0, 15.0], [12.0, 16.0], [13.0, 17.0], [14.0, 18.0]])
+    factor_matrices = [fm0, fm1, fm2]
+    model = ttb.ktensor(factor_matrices)
+    full = model.full()
+    shape = full.shape
+    all_indices = []
+    for i in range(shape[0]):
+        for j in range(shape[1]):
+            for k in range(shape[2]):
+                all_indices.append([i, j, k])
+    all_indices = np.array(all_indices)
+    values, _ = estimate_helper(factor_matrices, np.array(all_indices))
+    np.testing.assert_array_equal(full[all_indices], values)
+    # TODO should probably test Zexploded but thats a pain
+
+    values, Z = estimate_helper(factor_matrices, np.array([]))
+    assert values.size == 0
+    assert len(Z) == 0
+
+
+def test_estimate():
+    fm0 = np.array([[1.0, 3.0], [2.0, 4.0]])
+    fm1 = np.array([[5.0, 8.0], [6.0, 9.0], [7.0, 10.0]])
+    fm2 = np.array([[11.0, 15.0], [12.0, 16.0], [13.0, 17.0], [14.0, 18.0]])
+    factor_matrices = [fm0, fm1, fm2]
+    model = ttb.ktensor(factor_matrices)
+    data_subs = np.array([[0, 0, 0], [1, 1, 1]])
+    data_vals = np.ones((2,))
+    weights = np.ones_like(data_vals)
+
+    def no_op(data, model):
+        """Function handle that does nothing"""
+        return data
+
+    # No function or gradient handle
+    with pytest.raises(ValueError):
+        estimate(model, data_subs, data_vals, weights)
+
+    # Fail lambda check
+    with pytest.warns():
+        bad_model = model.copy()
+        bad_model.weights += 5
+        estimate(bad_model, data_subs, data_vals, weights, function_handle=no_op)
+
+    # Just function handle
+    f = estimate(model, data_subs, data_vals, weights, function_handle=no_op)
+    assert isinstance(f, float)
+    assert f == np.sum(data_vals)
+
+    zero_weights = np.zeros_like(data_vals)
+    f = estimate(model, data_subs, data_vals, zero_weights, function_handle=no_op)
+    assert isinstance(f, float)
+    assert f == 0.0
+
+    # With our no_op function the crng should have no impact
+    crng = np.arange(len(data_vals), dtype=int)
+    f = estimate(model, data_subs, data_vals, weights, function_handle=no_op, crng=crng)
+    assert isinstance(f, float)
+    assert f == np.sum(data_vals)
+
+    # Just gradient handle
+    g = estimate(model, data_subs, data_vals, weights, gradient_handle=no_op)
+    assert all(isinstance(g_i, np.ndarray) for g_i in g)
+
+    nsamples = data_subs.shape[0]
+    g = estimate(model, data_subs, data_vals, zero_weights, gradient_handle=no_op)
+    assert all(isinstance(g_i, np.ndarray) for g_i in g)
+    assert all(
+        np.all(g_i[data_subs[:, i], np.arange(nsamples)] == 0.0)
+        for i, g_i in enumerate(g)
+    )
+
+    g = estimate(
+        model, data_subs, data_vals, zero_weights, gradient_handle=no_op, crng=crng
+    )
+    assert all(isinstance(g_i, np.ndarray) for g_i in g)
+    assert all(
+        np.all(g_i[data_subs[:, i], np.arange(nsamples)] == 0.0)
+        for i, g_i in enumerate(g)
+    )
+
+    # Both handles
+    f, g = estimate(
+        model,
+        data_subs,
+        data_vals,
+        zero_weights,
+        function_handle=no_op,
+        gradient_handle=no_op,
+    )
+    assert isinstance(f, float)
+    assert all(isinstance(g_i, np.ndarray) for g_i in g)

--- a/tests/gcp/test_fg_setup.py
+++ b/tests/gcp/test_fg_setup.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 from inspect import Parameter, signature
-from math import exp, log, pi
 
 import numpy as np
 import pytest
-import scipy
 
 import pyttb as ttb
 from pyttb.gcp import fg_setup

--- a/tests/gcp/test_fg_setup.py
+++ b/tests/gcp/test_fg_setup.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from inspect import Parameter, signature
+from math import exp, log, pi
+
+import numpy as np
+import pytest
+import scipy
+
+import pyttb as ttb
+from pyttb.gcp import fg_setup
+from pyttb.gcp.handles import Objectives
+
+
+def test_setup_success():
+    # Loop over happy case for all known objectives
+    for an_objective in Objectives:
+        fh, gh, lb = fg_setup.setup(an_objective, additional_parameter=0.1)
+
+        # Make sure handles are distinct callables
+        assert callable(fh)
+        assert callable(gh)
+        assert fh is not gh
+
+        # Make sure they take two and only two arguments
+        # our use of partial makes testing this a bit awkward
+        fh_non_default_params = 0
+        for a_param in signature(fh).parameters.values():
+            if a_param.default is Parameter.empty:
+                fh_non_default_params += 1
+        assert fh_non_default_params == 2
+        gh_non_default_params = 0
+        for a_param in signature(fh).parameters.values():
+            if a_param.default is Parameter.empty:
+                gh_non_default_params += 1
+        assert gh_non_default_params == 2
+
+        # Make sure lower bound is a scalar
+        assert np.isscalar(lb)
+
+
+def test_setup_wrong_data():
+    bad_data = -0.1 * ttb.tenones((2, 2))
+    for objective in (
+        Objectives.BERNOULLI_ODDS,
+        Objectives.BERNOULLI_LOGIT,
+        Objectives.POISSON,
+        Objectives.POISSON_LOG,
+        Objectives.RAYLEIGH,
+        Objectives.GAMMA,
+        Objectives.NEGATIVE_BINOMIAL,
+        Objectives.BETA,
+    ):
+        with pytest.raises(ValueError):
+            fg_setup.setup(objective, bad_data)
+
+
+def test_setup_missing_param():
+    for objective in (
+        Objectives.HUBER,
+        Objectives.NEGATIVE_BINOMIAL,
+        Objectives.BETA,
+    ):
+        with pytest.raises(ValueError):
+            fg_setup.setup(objective)
+
+
+def test_setup_bad_objective():
+    with pytest.raises(ValueError):
+        fg_setup.setup("Please Use Enum")
+
+
+def test_valid_nonneg():
+    non_negative_dense = ttb.tenones((2, 2))
+    assert fg_setup.valid_nonneg(non_negative_dense)
+
+    negative_dense = -1 * non_negative_dense
+    assert not fg_setup.valid_nonneg(negative_dense)
+
+    non_negative_sparse = ttb.sptenrand((2, 2), nonzeros=3)
+    non_negative_sparse.vals = np.abs(non_negative_sparse.vals)
+    assert fg_setup.valid_nonneg(non_negative_sparse)
+
+    negative_sparse = -1 * non_negative_sparse
+    assert not fg_setup.valid_nonneg(negative_sparse)
+
+
+def test_valid_binary():
+    binary_dense = ttb.tenones((2, 2))
+    assert fg_setup.valid_binary(binary_dense)
+
+    arbitrary_dense = 4 * binary_dense
+    assert not fg_setup.valid_binary(arbitrary_dense)
+
+    binary_sparse = ttb.sptenrand((2, 2), nonzeros=3)
+    binary_sparse.vals = 1
+    assert fg_setup.valid_binary(binary_sparse)
+
+    arbitrary_sparse = 5 * binary_sparse
+    assert not fg_setup.valid_binary(arbitrary_sparse)
+
+
+def test_valid_natural():
+    natural_dense = 2 * ttb.tenones((2, 2))
+    assert fg_setup.valid_natural(natural_dense)
+
+    arbitrary_dense = 0.5 + natural_dense
+    assert not fg_setup.valid_natural(arbitrary_dense)
+
+    natural_sparse = ttb.sptenrand((2, 2), nonzeros=3)
+    natural_sparse.vals = 2
+    assert fg_setup.valid_natural(natural_sparse)
+
+    arbitrary_sparse = 1.1 * natural_sparse
+    assert not fg_setup.valid_natural(arbitrary_sparse)

--- a/tests/gcp/test_handles.py
+++ b/tests/gcp/test_handles.py
@@ -22,14 +22,14 @@ def test_gaussian(sample_data_model):
     data, model = sample_data_model
     result = handles.gaussian(data, model)
     expected = (model - data) ** 2
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_gaussian_grad(sample_data_model):
     data, model = sample_data_model
     result = handles.gaussian_grad(data, model)
     expected = 2 * (model - data)
-    assert np.array_equal(result.data, expected)
+    np.testing.assert_allclose(result.data, expected)
 
 
 def test_bernoulli_odds(sample_data_model):
@@ -38,7 +38,7 @@ def test_bernoulli_odds(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = log(model[i] + 1) - data[i] * log(model[i] + EPS)
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_bernoulli_odds_grad(sample_data_model):
@@ -47,7 +47,7 @@ def test_bernoulli_odds_grad(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = 1.0 / (model[i] + 1) - data[i] / (model[i] + EPS)
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_bernoulli_logit(sample_data_model):
@@ -56,7 +56,7 @@ def test_bernoulli_logit(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = log(exp(model[i]) + 1) - data[i] * model[i]
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_bernoulli_logit_grad(sample_data_model):
@@ -65,7 +65,7 @@ def test_bernoulli_logit_grad(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = exp(model[i]) / (exp(model[i]) + 1) - data[i]
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_poisson(sample_data_model):
@@ -74,7 +74,7 @@ def test_poisson(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = model[i] - data[i] * log(model[i] + EPS)
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_poisson_grad(sample_data_model):
@@ -83,7 +83,7 @@ def test_poisson_grad(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = 1 - data[i] / (model[i] + EPS)
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_poisson_log(sample_data_model):
@@ -92,7 +92,7 @@ def test_poisson_log(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = exp(model[i]) - data[i] * model[i]
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_poisson_log_grad(sample_data_model):
@@ -101,7 +101,7 @@ def test_poisson_log_grad(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = exp(model[i]) - data[i]
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_rayleigh(sample_data_model):
@@ -112,7 +112,7 @@ def test_rayleigh(sample_data_model):
         expected[i] = (
             2 * log(model[i] + EPS) + (pi / 4) * (data[i] / (model[i] + EPS)) ** 2
         )
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_rayleigh_grad(sample_data_model):
@@ -123,7 +123,7 @@ def test_rayleigh_grad(sample_data_model):
         expected[i] = (
             2 / (model[i] + EPS) - (pi / 2) * data[i] ** 2 / (model[i] + EPS) ** 3
         )
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_gamma(sample_data_model):
@@ -132,7 +132,7 @@ def test_gamma(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = data[i] / (model[i] + EPS) + log(model[i] + EPS)
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_gamma_grad(sample_data_model):
@@ -141,7 +141,7 @@ def test_gamma_grad(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = -data[i] / (model[i] + EPS) ** 2 + 1 / (model[i] + EPS)
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_huber(sample_data_model):
@@ -150,7 +150,7 @@ def test_huber(sample_data_model):
     # TODO maybe just use scipy and use manual to verify?
     expected = 2 * scipy.special.huber(0.1, model - data)
     # Scipy seems to do something clever leading to imperfect match
-    assert np.allclose(result, expected), f"Expected: {expected}\n Got: {result}"
+    np.testing.assert_allclose(result, expected)
 
 
 def test_huber_grad(sample_data_model):
@@ -160,7 +160,7 @@ def test_huber_grad(sample_data_model):
     expected = -2 * (data - model) * (np.abs(data - model) < threshold) - (
         (2 * threshold * np.sign(data - model)) * (np.abs(data - model) >= threshold)
     )
-    assert np.array_equal(result, expected), f"Expected: {expected}\n Got: {result}"
+    np.testing.assert_allclose(result, expected)
 
 
 def test_negative_binomial(sample_data_model):
@@ -172,7 +172,7 @@ def test_negative_binomial(sample_data_model):
         expected[i] = (num_trials + data[i]) * log(model[i] + 1) - data[i] * log(
             model[i] + EPS
         )
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_negative_binomial_grad(sample_data_model):
@@ -182,7 +182,7 @@ def test_negative_binomial_grad(sample_data_model):
     expected = np.zeros_like(result)
     for i, _ in enumerate(expected):
         expected[i] = (num_trials + 1) / (model[i] + 1) - data[i] / (model[i] + EPS)
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_beta(sample_data_model):
@@ -194,7 +194,7 @@ def test_beta(sample_data_model):
         expected[i] = (1 / beta) * (model[i] + EPS) ** beta - (1 / (beta - 1)) * data[
             i
         ] * (model[i] + EPS) ** (beta - 1)
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_beta_grad(sample_data_model):
@@ -206,4 +206,4 @@ def test_beta_grad(sample_data_model):
         expected[i] = (model[i] + EPS) ** (beta - 1) - data[i] * (model[i] + EPS) ** (
             beta - 2
         )
-    assert np.array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)

--- a/tests/gcp/test_handles.py
+++ b/tests/gcp/test_handles.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from math import exp, log, pi
+
+import numpy as np
+import pytest
+import scipy
+
+import pyttb as ttb
+from pyttb.gcp import handles
+from pyttb.gcp.handles import EPS
+
+
+@pytest.fixture()
+def sample_data_model():
+    data = ttb.tenrand((4, 4))[:]
+    model = ttb.tenrand((4, 4))[:]
+    return data, model
+
+
+def test_gaussian(sample_data_model):
+    data, model = sample_data_model
+    result = handles.gaussian(data, model)
+    expected = (model - data) ** 2
+    assert np.array_equal(result, expected)
+
+
+def test_gaussian_grad(sample_data_model):
+    data, model = sample_data_model
+    result = handles.gaussian_grad(data, model)
+    expected = 2 * (model - data)
+    assert np.array_equal(result.data, expected)
+
+
+def test_bernoulli_odds(sample_data_model):
+    data, model = sample_data_model
+    result = handles.bernoulli_odds(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = log(model[i] + 1) - data[i] * log(model[i] + EPS)
+    assert np.array_equal(result, expected)
+
+
+def test_bernoulli_odds_grad(sample_data_model):
+    data, model = sample_data_model
+    result = handles.bernoulli_odds_grad(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = 1.0 / (model[i] + 1) - data[i] / (model[i] + EPS)
+    assert np.array_equal(result, expected)
+
+
+def test_bernoulli_logit(sample_data_model):
+    data, model = sample_data_model
+    result = handles.bernoulli_logit(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = log(exp(model[i]) + 1) - data[i] * model[i]
+    assert np.array_equal(result, expected)
+
+
+def test_bernoulli_logit_grad(sample_data_model):
+    data, model = sample_data_model
+    result = handles.bernoulli_logit_grad(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = exp(model[i]) / (exp(model[i]) + 1) - data[i]
+    assert np.array_equal(result, expected)
+
+
+def test_poisson(sample_data_model):
+    data, model = sample_data_model
+    result = handles.poisson(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = model[i] - data[i] * log(model[i] + EPS)
+    assert np.array_equal(result, expected)
+
+
+def test_poisson_grad(sample_data_model):
+    data, model = sample_data_model
+    result = handles.poisson_grad(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = 1 - data[i] / (model[i] + EPS)
+    assert np.array_equal(result, expected)
+
+
+def test_poisson_log(sample_data_model):
+    data, model = sample_data_model
+    result = handles.poisson_log(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = exp(model[i]) - data[i] * model[i]
+    assert np.array_equal(result, expected)
+
+
+def test_poisson_log_grad(sample_data_model):
+    data, model = sample_data_model
+    result = handles.poisson_log_grad(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = exp(model[i]) - data[i]
+    assert np.array_equal(result, expected)
+
+
+def test_rayleigh(sample_data_model):
+    data, model = sample_data_model
+    result = handles.rayleigh(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = (
+            2 * log(model[i] + EPS) + (pi / 4) * (data[i] / (model[i] + EPS)) ** 2
+        )
+    assert np.array_equal(result, expected)
+
+
+def test_rayleigh_grad(sample_data_model):
+    data, model = sample_data_model
+    result = handles.rayleigh_grad(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = (
+            2 / (model[i] + EPS) - (pi / 2) * data[i] ** 2 / (model[i] + EPS) ** 3
+        )
+    assert np.array_equal(result, expected)
+
+
+def test_gamma(sample_data_model):
+    data, model = sample_data_model
+    result = handles.gamma(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = data[i] / (model[i] + EPS) + log(model[i] + EPS)
+    assert np.array_equal(result, expected)
+
+
+def test_gamma_grad(sample_data_model):
+    data, model = sample_data_model
+    result = handles.gamma_grad(data, model)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = -data[i] / (model[i] + EPS) ** 2 + 1 / (model[i] + EPS)
+    assert np.array_equal(result, expected)
+
+
+def test_huber(sample_data_model):
+    data, model = sample_data_model
+    result = handles.huber(data, model, threshold=0.1)
+    # TODO maybe just use scipy and use manual to verify?
+    expected = 2 * scipy.special.huber(0.1, model - data)
+    # Scipy seems to do something clever leading to imperfect match
+    assert np.allclose(result, expected), f"Expected: {expected}\n Got: {result}"
+
+
+def test_huber_grad(sample_data_model):
+    data, model = sample_data_model
+    threshold = 0.1
+    result = handles.huber_grad(data, model, threshold=threshold)
+    expected = -2 * (data - model) * (np.abs(data - model) < threshold) - (
+        (2 * threshold * np.sign(data - model)) * (np.abs(data - model) >= threshold)
+    )
+    assert np.array_equal(result, expected), f"Expected: {expected}\n Got: {result}"
+
+
+def test_negative_binomial(sample_data_model):
+    data, model = sample_data_model
+    num_trials = 5
+    result = handles.negative_binomial(data, model, num_trials)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = (num_trials + data[i]) * log(model[i] + 1) - data[i] * log(
+            model[i] + EPS
+        )
+    assert np.array_equal(result, expected)
+
+
+def test_negative_binomial_grad(sample_data_model):
+    data, model = sample_data_model
+    num_trials = 5
+    result = handles.negative_binomial_grad(data, model, num_trials)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = (num_trials + 1) / (model[i] + 1) - data[i] / (model[i] + EPS)
+    assert np.array_equal(result, expected)
+
+
+def test_beta(sample_data_model):
+    data, model = sample_data_model
+    beta = 0.5
+    result = handles.beta(data, model, beta)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = (1 / beta) * (model[i] + EPS) ** beta - (1 / (beta - 1)) * data[
+            i
+        ] * (model[i] + EPS) ** (beta - 1)
+    assert np.array_equal(result, expected)
+
+
+def test_beta_grad(sample_data_model):
+    data, model = sample_data_model
+    beta = 0.5
+    result = handles.beta_grad(data, model, beta)
+    expected = np.zeros_like(result)
+    for i, _ in enumerate(expected):
+        expected[i] = (model[i] + EPS) ** (beta - 1) - data[i] * (model[i] + EPS) ** (
+            beta - 2
+        )
+    assert np.array_equal(result, expected)


### PR DESCRIPTION
Resolves https://github.com/sandialabs/pyttb/issues/198 and is the beginning of https://github.com/sandialabs/pyttb/issues/58
This adds `tensor.mttkrps` since that is used in `tt_gcp_fg`

Organization notes:
- I assume we are waiting to cut a new release until 2.0 but I expect some of this to shuffle a bit as I land other pieces so would prefer if we are going to land a 1.X.Y before then we note the gcp pieces are experimental
- Since GCP is a fairly large fairly standalone component I think a subdirectory or some other organization is helpful (at least for me)
- For testing the handles I basically just implemented them twice, once element by element which should be correct by inspection on the test side then vectorized with numpy on the source side. In theory we could calculate point golden values but that seems harder to maintain/inspect

Interface notes:
- I placed all the objective and gradient handles in their own file to validate independently of fg.
- fg_setup should be basically the same. Jeremy had some suggestions on easier workflow but I figured for now keeping things fairly aligned reduces confusion. Can iterate on internals in follow up.
- tt_gcp_fg - I renamed to evaluate inside of pyttb.gcp.fg since we are evaluating the function handles. By defaulting to none for the handles we can drop the flags to compute on or the other. I dropped the vectorization option. That might be a utility I add in later steps but for `tt_gcp_fg` I think it just makes the interface more confusing.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--200.org.readthedocs.build/en/200/

<!-- readthedocs-preview pyttb end -->