### PR TITLE
Gcp samplers

### DIFF
--- a/pyttb/gcp/samplers.py
+++ b/pyttb/gcp/samplers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Tuple
 
 import numpy as np
@@ -39,3 +40,89 @@ def nonzeros(
     subs = data.subs[nidx, :]
     vals = data.vals[nidx]
     return subs, vals
+
+
+def zeros(
+    data: ttb.sptensor,
+    nz_idx: np.ndarray,
+    samples: int,
+    over_sample_rate: float = 1.1,
+    with_replacement=True,
+) -> np.ndarray:
+    """Samples zeros from a sparse tensor
+
+    Parameters
+    ----------
+    data:
+        Tensor to sample.
+    nz_idx:
+        Sorted linear indices of the nonzeros in tensor.
+    samples:
+        Number of samples to retrieve.
+    over_sample_rate:
+        Oversampling rate to allow success if a samples is large relative to data.nnz
+    with_replacement:
+        Whether or not to sample with replacement.
+    """
+    data_size = np.prod(data.shape)
+    nnz = len(nz_idx)
+    num_zeros = data_size - nnz
+
+    if over_sample_rate < 1.1:
+        raise ValueError(
+            f"Over sampling rate must be >= 1.1 but got {over_sample_rate}"
+        )
+
+    # Determine number of samples to generate
+    # We need to oversample to account for potential duplicates and for
+    # nonzeros we may pick
+
+    if not with_replacement and samples > num_zeros:
+        raise ValueError(
+            "Cannot sample more than the total number of zeros without replacement"
+        )
+
+    # Save requested number of zeros
+    samples_requested = samples
+
+    # First determine the number of samples to take accounting for some will be
+    # nonzeros and discarded.
+    ntmp = np.ceil(samples * data_size / num_zeros)
+
+    if not with_replacement and ntmp >= data_size:
+        raise ValueError("Need too many zero samples for this to work")
+
+    # Second determine number of samples given that some will be duplicates,
+    # via coupon collector problem. This only matters if sampling with replacement.from
+    if not with_replacement:
+        ntmp = np.ceil(data_size * np.log(1 / (1 - (ntmp / data_size))))
+
+    # Finally, add a margin of safety by oversampling
+    samples = int(np.ceil(over_sample_rate * ntmp))
+
+    # Generate actual samples, removing duplicates, nonzeros and excess
+    tmpsubs = np.ceil(
+        np.random.uniform(0, 1, (samples, data.ndims)) * (np.array(data.shape) - 1),
+    ).astype(int)
+
+    if not with_replacement:
+        tmpsubs = np.unique(tmpsubs, axis=0)
+
+    # Select out just the zeros
+    tmpidx = ttb.tt_sub2ind(data.shape, tmpsubs)
+    iszero = np.logical_not(np.in1d(tmpidx, nz_idx))
+    tmpsubs = tmpsubs[iszero, :]
+
+    # Trim back to desired numb of samples
+    samples = min(tmpsubs.shape[0], samples_requested)
+
+    # Final return values
+    if samples < samples_requested:
+        logging.warning(
+            "Unable to get number of zero samples requested"
+            "Requested: %d but obtained: %d.",
+            samples_requested,
+            samples,
+        )
+
+    return tmpsubs[:samples, :]

--- a/pyttb/gcp/samplers.py
+++ b/pyttb/gcp/samplers.py
@@ -126,3 +126,27 @@ def zeros(
         )
 
     return tmpsubs[:samples, :]
+
+
+def uniform(
+    data: ttb.tensor, samples: int
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Uniformly samples indices from a tensor
+
+    Parameters
+    ----------
+    data:
+        Tensor to sample.
+    samples:
+        Number of samples to take.
+
+    Returns
+    -------
+        Subscripts of samples, values at those subscripts, and weight of samples.
+    """
+    subs = np.ceil(
+        np.random.uniform(0, 1, (samples, data.ndims)) * (np.array(data.shape) - 1),
+    ).astype(int)
+    vals = data[subs]
+    wgts = (np.prod(data.shape) / samples) * np.ones((samples,))
+    return subs, vals, wgts

--- a/pyttb/gcp/samplers.py
+++ b/pyttb/gcp/samplers.py
@@ -184,3 +184,39 @@ def semistrat(
     all_vals = np.concatenate((nonzero_vals, zero_vals))
     all_weights = np.concatenate((nonzero_weights, zero_weights))
     return all_subs, all_vals, all_weights
+
+
+def stratified(
+    data: ttb.sptensor,
+    nz_idx: np.ndarray,
+    num_nonzeros: int,
+    num_zeros: int,
+    over_sample_rate: float = 1.1,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Sample nonzer and zero entries from a sparse tensor
+
+    Parameters
+    ----------
+    data:
+        Tensor to sample.
+    num_nonzeros:
+        Number of nonzero samples requested.
+    num_zeros:
+        Number of zero samples requested.
+
+    Returns
+    -------
+    Subscripts, values, and weights of samples (Nonzeros then zeros).
+    """
+    [nonzero_subs, nonzero_vals] = nonzeros(data, num_nonzeros, with_replacement=True)
+    nonzero_weights = (data.nnz / num_nonzeros) * np.ones((num_nonzeros,))
+
+    zero_subs = zeros(data, nz_idx, num_zeros, over_sample_rate, with_replacement=True)
+    zero_vals = np.zeros((num_zeros, 1))
+    data_nonzero_count = np.prod(data.shape) - data.nnz
+    zero_weights = (data_nonzero_count / num_zeros) * np.ones((num_zeros,))
+
+    all_subs = np.vstack((nonzero_subs, zero_subs))
+    all_vals = np.concatenate((nonzero_vals, zero_vals))
+    all_weights = np.concatenate((nonzero_weights, zero_weights))
+    return all_subs, all_vals, all_weights

--- a/pyttb/gcp/samplers.py
+++ b/pyttb/gcp/samplers.py
@@ -1,0 +1,41 @@
+"""Implementation of various sampling approaches for GCP OPT"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+import pyttb as ttb
+
+
+def nonzeros(
+    data: ttb.sptensor, samples: int, with_replacement: bool = True
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Sample nonzeros from a sparse tensor.
+
+    Parameters
+    ----------
+    data:
+        Tensor to sample.
+    samples:
+        Number of samples to collect
+    with_replacement:
+        Whether or not to sample with replacement.
+
+    Returns
+    -------
+        Subscripts and values for samples.
+    """
+    nnz = data.nnz
+
+    # Select nonzeros
+    if samples == nnz:
+        nidx = np.arange(0, nnz)
+    elif with_replacement or samples < nnz:
+        nidx = np.random.choice(nnz, size=samples, replace=with_replacement)
+    else:
+        raise ValueError("Tensor doesn't have enough nonzeros to sample")
+    subs = data.subs[nidx, :]
+    vals = data.vals[nidx]
+    return subs, vals

--- a/tests/gcp/test_samplers.py
+++ b/tests/gcp/test_samplers.py
@@ -35,8 +35,9 @@ def test_nonzeros():
 
 
 def test_zeros():
-    data = ttb.sptenrand((2, 2), nonzeros=2)
-    lin_idx = np.sort(ttb.tt_sub2ind((2, 2), data.subs))
+    shape = (2, 2)
+    data = ttb.sptenrand(shape, nonzeros=2)
+    lin_idx = np.sort(ttb.tt_sub2ind(shape, data.subs))
     subs = samplers.zeros(data, lin_idx, 1)
     assert len(subs.shape) == 2
 
@@ -67,7 +68,24 @@ def test_uniform():
 
 def test_semistrat():
     data = ttb.sptenrand((4, 4), nonzeros=2)
-    subs, vals, wgts = samplers.semistrat(data, 2, 2)
+    num_zeros = 2
+    num_nonzeros = 2
+    subs, vals, wgts = samplers.semistrat(data, num_nonzeros, num_zeros)
     assert len(subs.shape) == 2
-    assert len(vals) == 4
+    assert len(vals) == num_zeros + num_nonzeros
     assert len(wgts) == 4
+    assert np.all(vals[:num_nonzeros] != 0.0)
+
+
+def test_stratified():
+    shape = (4, 4)
+    num_zeros = 2
+    num_nonzeros = 2
+    data = ttb.sptenrand(shape, nonzeros=2)
+    lin_idx = np.sort(ttb.tt_sub2ind(shape, data.subs))
+    subs, vals, wgts = samplers.stratified(data, lin_idx, num_nonzeros, num_zeros)
+    assert len(subs.shape) == 2
+    assert len(vals) == num_zeros + num_nonzeros
+    assert len(wgts) == num_zeros + num_nonzeros
+    assert np.all(vals[:num_nonzeros] != 0.0)
+    assert np.all(vals[-num_zeros:] == 0.0)

--- a/tests/gcp/test_samplers.py
+++ b/tests/gcp/test_samplers.py
@@ -55,3 +55,11 @@ def test_zeros():
     # Too many samples without replacement (over sampling)
     with pytest.raises(ValueError):
         samplers.zeros(data, lin_idx, 2, with_replacement=False)
+
+
+def test_uniform():
+    data = ttb.tenrand((4, 4))
+    subs, vals, wgts = samplers.uniform(data, 2)
+    assert np.all(np.isin(vals, data.data))
+    assert len(subs) == 2
+    assert len(wgts) == 2

--- a/tests/gcp/test_samplers.py
+++ b/tests/gcp/test_samplers.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-from math import exp, log, pi
-
 import numpy as np
 import pytest
-import scipy
 
 import pyttb as ttb
 from pyttb.gcp import samplers
-from pyttb.gcp.handles import EPS
 
 
 def test_nonzeros():

--- a/tests/gcp/test_samplers.py
+++ b/tests/gcp/test_samplers.py
@@ -63,3 +63,11 @@ def test_uniform():
     assert np.all(np.isin(vals, data.data))
     assert len(subs) == 2
     assert len(wgts) == 2
+
+
+def test_semistrat():
+    data = ttb.sptenrand((4, 4), nonzeros=2)
+    subs, vals, wgts = samplers.semistrat(data, 2, 2)
+    assert len(subs.shape) == 2
+    assert len(vals) == 4
+    assert len(wgts) == 4

--- a/tests/gcp/test_samplers.py
+++ b/tests/gcp/test_samplers.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from math import exp, log, pi
+
+import numpy as np
+import pytest
+import scipy
+
+import pyttb as ttb
+from pyttb.gcp import samplers
+from pyttb.gcp.handles import EPS
+
+
+def test_nonzeros():
+    data = ttb.sptenrand((2,2), nonzeros=2)
+
+    # Sample all values
+    subs, vals = samplers.nonzeros(data, 2, False)
+    np.testing.assert_array_equal(subs, data.subs)
+    np.testing.assert_array_equal(vals, data.vals)
+
+    # Sample subset
+    subs, vals = samplers.nonzeros(data, 1, False)
+    assert np.all(np.isin(vals, data.vals))
+    assert len(vals) == 1
+
+    # Sample with replacement
+    subs, vals = samplers.nonzeros(data, 4)
+    assert np.all(np.isin(vals, data.vals))
+    assert len(vals) == 4
+
+    with pytest.raises(ValueError):
+        # Sample too many without replacement
+        samplers.nonzeros(data, 4, False)

--- a/tests/gcp/test_samplers.py
+++ b/tests/gcp/test_samplers.py
@@ -12,7 +12,7 @@ from pyttb.gcp.handles import EPS
 
 
 def test_nonzeros():
-    data = ttb.sptenrand((2,2), nonzeros=2)
+    data = ttb.sptenrand((2, 2), nonzeros=2)
 
     # Sample all values
     subs, vals = samplers.nonzeros(data, 2, False)
@@ -32,3 +32,26 @@ def test_nonzeros():
     with pytest.raises(ValueError):
         # Sample too many without replacement
         samplers.nonzeros(data, 4, False)
+
+
+def test_zeros():
+    data = ttb.sptenrand((2, 2), nonzeros=2)
+    lin_idx = np.sort(ttb.tt_sub2ind((2, 2), data.subs))
+    subs = samplers.zeros(data, lin_idx, 1)
+    assert len(subs.shape) == 2
+
+    subs = samplers.zeros(data, lin_idx, 1, with_replacement=False)
+    assert len(subs.shape) == 2
+
+    # Negative tests
+    # Too small over sample rate
+    with pytest.raises(ValueError):
+        samplers.zeros(data, lin_idx, 1, over_sample_rate=0.0)
+
+    # Too many samples without replacement
+    with pytest.raises(ValueError):
+        samplers.zeros(data, lin_idx, 3, with_replacement=False)
+
+    # Too many samples without replacement (over sampling)
+    with pytest.raises(ValueError):
+        samplers.zeros(data, lin_idx, 2, with_replacement=False)


### PR DESCRIPTION
Sampler support for gcp_opt. Related to but doesn't complete https://github.com/sandialabs/pyttb/issues/58.

The tests are probably a little light but I don't have any clever ideas at the moment on how to better validate them. I cover the major portions but for example uniform could be sampling with a totally different distribution and still pass.

I updated my previous comment here, and dropped common commits so this is now distinct from https://github.com/sandialabs/pyttb/pull/200. Merge order shouldn't matter.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--201.org.readthedocs.build/en/201/

<!-- readthedocs-preview pyttb end -->