### PR TITLE
Gcp opt

### DIFF
--- a/docs/source/algorithms.rst
+++ b/docs/source/algorithms.rst
@@ -5,5 +5,6 @@ Algorithms
 
     cpals.rst
     cpapr.rst
+    gcpopt.rst
     hosvd.rst
     tuckerals.rst

--- a/docs/source/gcp/fg.rst
+++ b/docs/source/gcp/fg.rst
@@ -1,0 +1,7 @@
+pyttb.gcp.fg
+====================
+
+.. automodule:: pyttb.gcp.fg
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/gcp/fg_est.rst
+++ b/docs/source/gcp/fg_est.rst
@@ -1,0 +1,7 @@
+pyttb.gcp.fg_est
+====================
+
+.. automodule:: pyttb.gcp.fg_est
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/gcp/fg_setup.rst
+++ b/docs/source/gcp/fg_setup.rst
@@ -1,0 +1,7 @@
+pyttb.gcp.fg_setup
+====================
+
+.. automodule:: pyttb.gcp.fg_setup
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/gcp/handles.rst
+++ b/docs/source/gcp/handles.rst
@@ -1,0 +1,7 @@
+pyttb.gcp.handles
+====================
+
+.. automodule:: pyttb.gcp.handles
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/gcp/optimizers.rst
+++ b/docs/source/gcp/optimizers.rst
@@ -4,4 +4,5 @@ pyttb.gcp.optimizers
 .. automodule:: pyttb.gcp.optimizers
     :members:
     :undoc-members:
+    :special-members: __init__
     :show-inheritance:

--- a/docs/source/gcp/optimizers.rst
+++ b/docs/source/gcp/optimizers.rst
@@ -1,0 +1,7 @@
+pyttb.gcp.optimizers
+====================
+
+.. automodule:: pyttb.gcp.optimizers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/gcp/samplers.rst
+++ b/docs/source/gcp/samplers.rst
@@ -4,4 +4,5 @@ pyttb.gcp.samplers
 .. automodule:: pyttb.gcp.samplers
     :members:
     :undoc-members:
+    :special-members: __init__
     :show-inheritance:

--- a/docs/source/gcp/samplers.rst
+++ b/docs/source/gcp/samplers.rst
@@ -1,0 +1,7 @@
+pyttb.gcp.samplers
+====================
+
+.. automodule:: pyttb.gcp.samplers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/gcpopt.rst
+++ b/docs/source/gcpopt.rst
@@ -1,0 +1,12 @@
+pyttb.gcp_opt
+====================
+
+.. automodule:: pyttb.gcp_opt
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. toctree::
+    :glob:
+
+    gcp/*

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -2,11 +2,6 @@ Tutorials
 =========
 
 .. toctree::
-   :maxdepth: 2
+   :glob:
 
-   tutorial/CP_APR
-   tutorial/class_ktensor
-   tutorial/class_sptensor
-   tutorial/class_tenmat
-   tutorial/class_tensor
-   tutorial/class_ttensor
+   tutorial/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ module = [
     "scipy",
     "scipy.sparse",
     "scipy.sparse.linalg",
+    "scipy.optimize",
     "numpy_groupies"
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,10 @@ doc = [
     "myst-nb",
 ]
 
-[tool.setuptools]
-packages = ["pyttb"]
+[tool.setuptools.packages.find]
+include = ["pyttb*"]
+exclude = ["tests*"]
+namespaces = false
 
 [tool.setuptools.dynamic]
 version = {attr = "pyttb.__version__"}

--- a/pyttb/__init__.py
+++ b/pyttb/__init__.py
@@ -12,6 +12,7 @@ import warnings
 from pyttb.cp_als import cp_als
 from pyttb.cp_apr import cp_apr
 from pyttb.export_data import export_data
+from pyttb.gcp_opt import gcp_opt
 from pyttb.hosvd import hosvd
 from pyttb.import_data import import_data
 from pyttb.khatrirao import khatrirao

--- a/pyttb/__init__.py
+++ b/pyttb/__init__.py
@@ -10,7 +10,7 @@ __version__ = "1.6.2"
 import warnings
 
 from pyttb.cp_als import cp_als
-from pyttb.cp_apr import *
+from pyttb.cp_apr import cp_apr
 from pyttb.export_data import export_data
 from pyttb.hosvd import hosvd
 from pyttb.import_data import import_data

--- a/pyttb/cp_apr.py
+++ b/pyttb/cp_apr.py
@@ -522,7 +522,7 @@ def tt_cp_apr_pdnr(
             # calculate khatri-rao product of all matrices but the n-th
             if isinstance(input_tensor, ttb.tensor) and isSparse is False:
                 # Data is not a sparse tensor.
-                Pi = ttb.tt_calcpi_prowsubprob(input_tensor, M, rank, n, N, isSparse)
+                Pi = tt_calcpi_prowsubprob(input_tensor, M, rank, n, N, isSparse)
                 X_mat = ttb.tt_to_dense_matrix(input_tensor, n)
 
             num_rows = M[n].shape[0]
@@ -549,7 +549,7 @@ def tt_cp_apr_pdnr(
                     x_row = input_tensor.vals[sparse_indices]
 
                     # Calculate just the columns of Pi needed for this row.
-                    Pi = ttb.tt_calcpi_prowsubprob(
+                    Pi = tt_calcpi_prowsubprob(
                         input_tensor, M, rank, n, N, isSparse, sparse_indices
                     )
 
@@ -620,7 +620,7 @@ def tt_cp_apr_pdnr(
                         f_unit,
                         f_new,
                         num_evals,
-                    ) = ttb.tt_linesearch_prowsubprob(
+                    ) = tt_linesearch_prowsubprob(
                         search_dir.transpose()[0],
                         gradM.transpose(),
                         m_row,
@@ -879,7 +879,7 @@ def tt_cp_apr_pqnr(
             # calculate khatri-rao product of all matrices but the n-th
             if not isinstance(input_tensor, ttb.sptensor) and not isSparse:
                 # Data is not a sparse tensor.
-                Pi = ttb.tt_calcpi_prowsubprob(input_tensor, M, rank, n, N, isSparse)
+                Pi = tt_calcpi_prowsubprob(input_tensor, M, rank, n, N, isSparse)
                 X_mat = ttb.tt_to_dense_matrix(input_tensor, n)
 
             num_rows = M[n].shape[0]
@@ -903,7 +903,7 @@ def tt_cp_apr_pqnr(
                     x_row = input_tensor.vals[sparse_indices]
 
                     # Calculate just the columns of Pi needed for this row.
-                    Pi = ttb.tt_calcpi_prowsubprob(
+                    Pi = tt_calcpi_prowsubprob(
                         input_tensor, M, rank, n, N, isSparse, sparse_indices
                     )
 
@@ -1033,7 +1033,7 @@ def tt_cp_apr_pqnr(
                     # Perform a projected linesearch and update variables.
                     # Start from a unit step length, decrease by 1/2,
                     # stop with sufficicent decrease of 1.0e-4 or at most 10 steps.
-                    m_row, _, _, f_new, num_evals = ttb.tt_linesearch_prowsubprob(
+                    m_row, _, _, f_new, num_evals = tt_linesearch_prowsubprob(
                         search_dir.transpose()[0],
                         gradOLD.transpose(),
                         m_rowOLD,
@@ -1446,7 +1446,7 @@ def tt_linesearch_prowsubprob(
             count += 1
         else:
             # Evaluate objective function at new iterate
-            f_new = -ttb.tt_loglikelihood_row(isSparse, data_row, model_new, Pi)
+            f_new = -tt_loglikelihood_row(isSparse, data_row, model_new, Pi)
             num_evals += 1
             if count == 1:
                 f_1 = f_new
@@ -1474,7 +1474,7 @@ def tt_linesearch_prowsubprob(
 
         # Project to the constraints and reevaluate the subproblem objective
         model_new *= model_new > 0
-        f_new = -ttb.tt_loglikelihood_row(isSparse, data_row, model_new, Pi)
+        f_new = -tt_loglikelihood_row(isSparse, data_row, model_new, Pi)
         num_evals += 1
 
         # Let the caller know the search direction made no progress.

--- a/pyttb/gcp/fg_est.py
+++ b/pyttb/gcp/fg_est.py
@@ -98,7 +98,7 @@ def estimate(
 
     if lambda_check and any(model.weights != 1.0):
         warnings.warn("Normalizing model to have all 1's for weights")
-        model = model.normalize(1)  # TODO confirm argument correctness
+        model = model.normalize(0)
     model_vals, Zexp = estimate_helper(model.factor_matrices, data_subs)
 
     F: Optional[float] = None

--- a/pyttb/gcp/fg_est.py
+++ b/pyttb/gcp/fg_est.py
@@ -55,6 +55,7 @@ def estimate(
     ...  # pragma: no cover see coveragepy/issues/970
 
 
+# pylint: disable=too-many-locals
 def estimate(
     model: ttb.ktensor,
     data_subs: np.ndarray,
@@ -123,7 +124,8 @@ def estimate(
             # The columns are the corresponding samples. They are in order because they
             # match the vector of samples to be multiplied on the right.
             S = csr_array(
-                (Y, (data_subs[:, k], np.arange(nsamples))), shape=(model.shape[k], nsamples)
+                (Y, (data_subs[:, k], np.arange(nsamples))),
+                shape=(model.shape[k], nsamples),
             )
             G[k] = S.dot(Zexp[k])
 

--- a/pyttb/gcp/optimizers.py
+++ b/pyttb/gcp/optimizers.py
@@ -1,0 +1,192 @@
+"""Optimizer Implementations for GCP"""
+from __future__ import annotations
+
+import logging
+import time
+from abc import ABC, abstractmethod
+from math import inf
+from typing import Dict, List, Tuple, Union
+
+import numpy as np
+
+import pyttb as ttb
+from pyttb.gcp.fg_est import estimate
+from pyttb.gcp.fg_setup import function_type
+from pyttb.gcp.samplers import GCPSampler
+
+
+# pylint: disable=too-many-instance-attributes
+class StochasticSolver(ABC):
+    """Interface for Stochastic GCP Solvers"""
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        rate: float = 1e-3,
+        decay: float = 0.1,
+        max_fails: int = 1,
+        epoch_iters: int = 1000,
+        f_est_tol: float = -inf,
+        max_iters: int = 1000,
+        printitn: int = 1,
+    ):
+        self._rate = rate
+        self._decay = decay
+        self._max_fails = max_fails
+        self._epoch_iters = epoch_iters
+        self._f_est_tol = f_est_tol
+        self._max_iters = max_iters
+        self._printitn = printitn
+        self._nfails = 0
+
+    @abstractmethod
+    def update_step(
+        self, model: ttb.ktensor, gradient: List[np.ndarray]
+    ) -> Tuple[List[np.ndarray], float]:
+        """Generate update step"""
+
+    @abstractmethod
+    def set_failed_epoch(self):
+        """Set internal state on failed epoch"""
+
+    # pylint: disable=too-many-locals
+    def solve(
+        self,
+        initial_model: ttb.ktensor,
+        data: Union[ttb.tensor, ttb.sptensor],
+        function_handle: function_type,
+        gradient_handle: function_type,
+        sampler: GCPSampler,
+    ) -> Tuple[ttb.ktensor, Dict]:
+        """Run solver until completion"""
+        solver_start = time.monotonic()
+
+        # Extract samples for estimating function value - these never change
+        f_subs, f_vals, f_wgts = sampler.function_sample(data)
+
+        # Compute initial estimated function value
+        f_est = estimate(
+            initial_model, f_subs, f_vals, f_wgts, function_handle, lambda_check=False
+        )
+
+        # Setup loop variables
+        model = initial_model.copy()
+        self._nfails = 0
+
+        best_model = model.copy()
+        f_est_prev = f_est
+
+        # Tracing the progress in the function value by epoch
+        fest_trace = np.zeros((self._max_iters + 1,))
+        step_trace = np.zeros((self._max_iters + 1,))
+        time_trace = np.zeros((self._max_iters + 1,))
+        fest_trace[0] = f_est
+
+        if self._printitn > 0:
+            logging.info("Begin Main loop\nInitial f-est: %e\n", f_est)
+        # Note in MATLAB this time also includes the time for setting up samplers
+        time_trace[0] = time.monotonic() - solver_start
+        main_start = time.monotonic()
+
+        n_epoch = 0  # In case range short circuits
+        for n_epoch in range(self._max_iters):
+            for iteration in range(self._epoch_iters):
+                # Select subset for stochastic gradient
+                g_subs, g_vals, g_wgts = sampler.gradient_sample(data)
+
+                # Compute gradients for each mode
+                g_est = estimate(
+                    model,
+                    g_subs,
+                    g_vals,
+                    g_wgts,
+                    None,  # Functional handle unused, just to make typing happy
+                    gradient_handle=gradient_handle,
+                    lambda_check=False,
+                    crng=sampler.crng,
+                )
+
+                # Check for inf
+                if np.any(np.isinf(g_est)):
+                    raise ValueError(
+                        f"Infinite gradient encountered! (epoch = {n_epoch}, "
+                        f"iter = {iteration}"
+                    )
+                model.factor_matrices, step = self.update_step(model, g_est)
+            # Estimate objective function value
+            f_est = estimate(
+                model, f_subs, f_vals, f_wgts, function_handle, lambda_check=False
+            )
+            # Save trace
+            fest_trace[n_epoch + 1] = f_est
+            step_trace[n_epoch + 1] = step
+
+            # Check convergence
+            failed_epoch = f_est > f_est_prev
+            self._nfails += failed_epoch
+
+            f_est_tol_test = f_est < self._f_est_tol
+
+            # Reporting
+            if self._printitn > 0 and (
+                n_epoch % self._printitn or failed_epoch or f_est_tol_test
+            ):
+                msg = f"Epoch {n_epoch}: f-est = {f_est}, step = {step}"
+                if failed_epoch:
+                    msg += (
+                        f", nfails = {self._nfails} (resetting to solution from "
+                        "last epoch)"
+                    )
+
+            if failed_epoch:
+                # Reset to best solution so far
+                model = best_model.copy()
+                f_est = f_est_prev
+                self.set_failed_epoch()
+            else:
+                best_model = model.copy()
+                f_est_prev = f_est
+
+            # Save time
+            time_trace[n_epoch + 1] = time.monotonic() - solver_start
+
+            if (self._nfails > self._max_fails) or f_est_tol_test:
+                break
+        main_time = time.monotonic() - main_start
+
+        info = {
+            "f_est_trace": fest_trace[0 : n_epoch + 1],
+            "step_trace": step_trace[0 : n_epoch + 1],
+            "time_trace": time_trace[0 : n_epoch + 1],
+            "n_epoch": n_epoch,
+        }
+
+        if self._printitn > 0:
+            # TODO print setup time which include sampler setup time external to here
+            msg = (
+                "End Main Loop\n"
+                f"Final f-est: {f_est}"
+                f"Main loop time: {main_time}"
+                f"Total iterations: {n_epoch*self._epoch_iters}"
+            )
+            logging.info(msg)
+
+        return model, info
+
+
+class SGD(StochasticSolver):
+    """General Stochastic Gradient Descent"""
+
+    def update_step(
+        self, model: ttb.ktensor, gradient: List[np.ndarray]
+    ) -> Tuple[List[np.ndarray], float]:
+        step = self._decay**self._nfails * self._rate
+        factor_matrices = [
+            np.maximum(0.0, factor - step * grad)
+            for factor, grad in zip(model.factor_matrices, gradient)
+        ]
+        return factor_matrices, step
+
+    def set_failed_epoch(self):
+        # No additional internal state for SGD
+        pass

--- a/pyttb/gcp/optimizers.py
+++ b/pyttb/gcp/optimizers.py
@@ -61,10 +61,12 @@ class StochasticSolver(ABC):
         data: Union[ttb.tensor, ttb.sptensor],
         function_handle: function_type,
         gradient_handle: function_type,
-        sampler: GCPSampler,
         lower_bound: float = -np.inf,
+        sampler: Optional[GCPSampler] = None,
     ) -> Tuple[ttb.ktensor, Dict]:
         """Run solver until completion"""
+        if sampler is None:
+            sampler = GCPSampler(data)
         solver_start = time.monotonic()
 
         # Extract samples for estimating function value - these never change
@@ -173,8 +175,8 @@ class StochasticSolver(ABC):
             # TODO print setup time which include sampler setup time external to here
             msg = (
                 "End Main Loop\n"
-                f"Final f-est: {f_est}"
-                f"Main loop time: {main_time}"
+                f"Final f-est: {f_est: 10.4e}\n"
+                f"Main loop time: {main_time: .2f}\n"
                 f"Total iterations: {n_epoch*self._epoch_iters}"
             )
             logging.info(msg)

--- a/pyttb/gcp/optimizers.py
+++ b/pyttb/gcp/optimizers.py
@@ -32,6 +32,25 @@ class StochasticSolver(ABC):
         max_iters: int = 1000,
         printitn: int = 1,
     ):
+        """General Setup for Stochastic Solvers
+
+        Parameters
+        ----------
+        rate:
+            Rate of descent, proportional to step size.
+        decay:
+            How much to decrease step size on failed epochs.
+        max_fails:
+            How many failed epochs before terminating the solve.
+        epoch_iters:
+            Number of steps to take per epoch.
+        f_est_tol:
+            Tolerance for function estimate changes to terminate solve.
+        max_iters:
+            Maximum number of epochs.
+        printitn:
+            Controls verbosity of information during solve.
+        """
         self._rate = rate
         self._decay = decay
         self._max_fails = max_fails
@@ -48,7 +67,22 @@ class StochasticSolver(ABC):
         gradient: List[np.ndarray],
         lower_bound: float,
     ) -> Tuple[List[np.ndarray], float]:
-        """Generate update step"""
+        """Calculates the update step for the solver
+
+        Parameters
+        ----------
+        model:
+            Current decomposition.
+        gradient:
+            Gradient calculation.
+        lower_bound:
+            Minimum value for the decomposition.
+
+        Returns
+        -------
+            Update to be applied to decomposition (to be applied by caller).
+            Step size used.
+        """
 
     @abstractmethod
     def set_failed_epoch(self):
@@ -64,7 +98,27 @@ class StochasticSolver(ABC):
         lower_bound: float = -np.inf,
         sampler: Optional[GCPSampler] = None,
     ) -> Tuple[ttb.ktensor, Dict]:
-        """Run solver until completion"""
+        """Run solver until completion
+
+        Parameters
+        ----------
+        initial_model:
+            Beginning solution.
+        data:
+            Tensor to solve for.
+        function_handle:
+            Callable to sample objective values.
+        gradient_handle:
+            Callable to sample gradient values.
+        lower_bound:
+            Lower bound on model values.
+        sampler:
+            Sampler to select which values to evaluate or take gradients from.
+
+        Returns
+        -------
+            Final answer and dictionary of details.
+        """
         if sampler is None:
             sampler = GCPSampler(data)
         solver_start = time.monotonic()
@@ -219,6 +273,31 @@ class Adam(StochasticSolver):
         beta_2: float = 0.999,
         epsilon: float = 1e-8,
     ):
+        """General Setup for Adam Solver
+
+        Parameters
+        ----------
+        rate:
+            Rate of descent, proportional to step size.
+        decay:
+            How much to decrease step size on failed epochs.
+        max_fails:
+            How many failed epochs before terminating the solve.
+        epoch_iters:
+            Number of steps to take per epoch.
+        f_est_tol:
+            Tolerance for function estimate changes to terminate solve.
+        max_iters:
+            Maximum number of epochs.
+        printitn:
+            Controls verbosity of information during solve.
+        beta_1:
+            Adam specific momentum parameter beta_1.
+        beta_2:
+            Adam specific momentum parameter beta_2.
+        epsilon:
+            Adam specifi momentum parameter to avoid division by zero.
+        """
         super().__init__(
             rate,
             decay,

--- a/pyttb/gcp/samplers.py
+++ b/pyttb/gcp/samplers.py
@@ -12,9 +12,11 @@ from typing import Callable, Optional, Tuple, Union, cast
 import numpy as np
 
 import pyttb as ttb
+from pyttb.sptensor import sptensor
+from pyttb.tensor import tensor
 
 sample_type = Tuple[np.ndarray, np.ndarray, np.ndarray]
-sampler_type = Callable[[Union[ttb.tensor, ttb.sptensor]], sample_type]
+sampler_type = Callable[[Union[tensor, sptensor]], sample_type]
 
 
 @dataclass
@@ -49,7 +51,7 @@ class GCPSampler:
         max_iters: int = 1000,
         over_sample_rate: float = 1.1,
     ):
-        self._crng = np.array([])
+        self._crng = np.array([], dtype=int)
         # TODO add interface for arbitrary callable with no args that returns ndarray
         # TODO might be simpler to provide mask instead of num_zeros and nonzeros
         if function_sampler is None:
@@ -221,7 +223,7 @@ class GCPSampler:
         return self._gsampler(data)
 
     @property
-    def crng(self):
+    def crng(self) -> np.ndarray:
         """Correction Range for possibly missampled zeros"""
         return self._crng
 

--- a/pyttb/gcp/samplers.py
+++ b/pyttb/gcp/samplers.py
@@ -42,8 +42,6 @@ class GCPSampler:
     def __init__(
         self,
         data: Union[ttb.tensor, ttb.sptensor],
-        num_zeros: int,
-        num_nonzeros: int,
         function_sampler: Optional[Samplers] = None,
         function_samples: Optional[Union[int, StratifiedCount]] = None,
         gradient_sampler: Optional[Samplers] = None,
@@ -53,12 +51,16 @@ class GCPSampler:
     ):
         self._crng = np.array([], dtype=int)
         # TODO add interface for arbitrary callable with no args that returns ndarray
-        # TODO might be simpler to provide mask instead of num_zeros and nonzeros
         if function_sampler is None:
             if isinstance(data, ttb.sptensor):
                 function_sampler = Samplers.STRATIFIED
             else:
                 function_sampler = Samplers.UNIFORM
+
+        tensor_size = int(np.prod(data.shape))
+        num_nonzeros = data.nnz
+        num_zeros = tensor_size - num_nonzeros
+
         self._prepare_function_sampler(
             data,
             function_sampler,

--- a/pyttb/gcp/samplers.py
+++ b/pyttb/gcp/samplers.py
@@ -49,6 +49,26 @@ class GCPSampler:
         max_iters: int = 1000,
         over_sample_rate: float = 1.1,
     ):
+        """Create sampler.
+
+        Parameters
+        ----------
+        data:
+            Tensor we will be sampling. Allows for automated decisions and sanity
+            checks.
+        function_sampler:
+            Type of sampling used for evaluating function estimates.
+        function_samples:
+            How many samples to take of the function every iteration.
+        gradient_sampler:
+            Type of sampling used for evaluating gradient estimates.
+        gradient_samples:
+            How many samples to take of the gradient every iteration.
+        max_iters:
+            Maximum number of iterations to normalize number of samples.
+        over_sample_rate:
+            Ratio of extra samples to take to account for bad draws.
+        """
         self._crng = np.array([], dtype=int)
         # TODO add interface for arbitrary callable with no args that returns ndarray
         if function_sampler is None:
@@ -226,7 +246,7 @@ class GCPSampler:
 
     @property
     def crng(self) -> np.ndarray:
-        """Correction Range for possibly missampled zeros"""
+        """Correction Range for possibly miss-sampled zeros"""
         return self._crng
 
 
@@ -421,10 +441,14 @@ def stratified(
     ----------
     data:
         Tensor to sample.
+    nz_idx:
+        Sorted linear indices of non-zero entries in tensor.
     num_nonzeros:
         Number of nonzero samples requested.
     num_zeros:
         Number of zero samples requested.
+    over_sample_rate:
+        Rate of oversampling to account for bad random draws.
 
     Returns
     -------

--- a/pyttb/gcp/samplers.py
+++ b/pyttb/gcp/samplers.py
@@ -3,11 +3,227 @@
 from __future__ import annotations
 
 import logging
-from typing import Tuple
+from dataclasses import dataclass
+from enum import Enum
+from functools import partial
+from math import ceil
+from typing import Callable, Optional, Tuple, Union, cast
 
 import numpy as np
 
 import pyttb as ttb
+
+sample_type = Tuple[np.ndarray, np.ndarray, np.ndarray]
+sampler_type = Callable[[Union[ttb.tensor, ttb.sptensor]], sample_type]
+
+
+@dataclass
+class StratifiedCount:
+    """Contains stratified sampling counts"""
+
+    num_zeros: int
+    num_nonzeros: int
+
+
+class Samplers(Enum):
+    """Implemented Samplers"""
+
+    UNIFORM = 0
+    SEMISTRATIFIED = 1
+    STRATIFIED = 2
+
+
+class GCPSampler:
+    """Contains Gradient and Function Sampling Details"""
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        data: Union[ttb.tensor, ttb.sptensor],
+        num_zeros: int,
+        num_nonzeros: int,
+        function_sampler: Optional[Samplers] = None,
+        function_samples: Optional[Union[int, StratifiedCount]] = None,
+        gradient_sampler: Optional[Samplers] = None,
+        gradient_samples: Optional[Union[int, StratifiedCount]] = None,
+        max_iters: int = 1000,
+        over_sample_rate: float = 1.1,
+    ):
+        self._crng = np.array([])
+        # TODO add interface for arbitrary callable with no args that returns ndarray
+        # TODO might be simpler to provide mask instead of num_zeros and nonzeros
+        if function_sampler is None:
+            if isinstance(data, ttb.sptensor):
+                function_sampler = Samplers.STRATIFIED
+            else:
+                function_sampler = Samplers.UNIFORM
+        self._prepare_function_sampler(
+            data,
+            function_sampler,
+            num_zeros,
+            num_nonzeros,
+            over_sample_rate,
+            function_samples,
+        )
+        if gradient_sampler is None:
+            if isinstance(data, ttb.sptensor):
+                gradient_sampler = Samplers.STRATIFIED
+            else:
+                gradient_sampler = Samplers.UNIFORM
+        self._prepare_gradient_sampler(
+            data,
+            gradient_sampler,
+            num_zeros,
+            num_nonzeros,
+            over_sample_rate,
+            gradient_samples,
+            max_iters,
+        )
+
+    # pylint: disable=too-many-arguments
+    def _prepare_function_sampler(
+        self,
+        data: Union[ttb.tensor, ttb.sptensor],
+        function_sampler: Samplers,
+        num_zeros: int,
+        num_nonzeros: int,
+        over_sample_rate: float,
+        function_samples: Optional[Union[int, StratifiedCount]],
+    ):
+        if function_sampler == Samplers.STRATIFIED:
+            if not isinstance(data, ttb.sptensor):
+                raise ValueError(
+                    "Stratified sampling is only supported for sptensor data."
+                )
+            if function_samples is None:
+                ftmp = int(max(ceil(num_nonzeros / 100), 10**5))
+                function_samples = StratifiedCount(
+                    num_nonzeros=min(ftmp, num_nonzeros),
+                    num_zeros=min(ftmp, num_nonzeros, num_zeros),
+                )
+            elif isinstance(function_samples, int):
+                function_samples = StratifiedCount(
+                    num_nonzeros=function_samples, num_zeros=function_samples
+                )
+            elif not isinstance(function_samples, StratifiedCount):
+                raise ValueError(
+                    "Function samples should be an int or StratifiedCount but "
+                    f" received: {function_samples}"
+                )
+            xnzidx = np.sort(ttb.tt_sub2ind(data.shape, data.subs))
+            self._fsampler = partial(
+                stratified,
+                nz_idx=xnzidx,
+                num_nonzeros=function_samples.num_nonzeros,
+                num_zeros=function_samples.num_zeros,
+                over_sample_rate=over_sample_rate,
+            )
+        elif function_sampler == Samplers.UNIFORM:
+            if function_samples is None:
+                tensor_size = int(np.prod(data.shape))
+                function_samples = min(
+                    max(ceil(tensor_size / 10), 10**6), tensor_size
+                )
+            if not isinstance(function_samples, int):
+                raise ValueError(
+                    "Uniform sampling only accepts integers for number of samples"
+                )
+            self._fsampler = partial(
+                uniform,
+                samples=function_samples,
+            )
+        else:
+            raise ValueError("Invalid choice for function_sampler")
+
+    # pylint: disable=too-many-arguments, too-many-branches
+    def _prepare_gradient_sampler(
+        self,
+        data: Union[ttb.tensor, ttb.sptensor],
+        gradient_sampler: Samplers,
+        num_zeros: int,
+        num_nonzeros: int,
+        over_sample_rate: float,
+        gradient_samples: Optional[Union[int, StratifiedCount]],
+        max_iters: int,
+    ):
+        if gradient_sampler in (Samplers.STRATIFIED, Samplers.SEMISTRATIFIED):
+            if gradient_samples is None:
+                gtmp = int(max(1000, ceil(3 * num_nonzeros / max_iters)))
+                gradient_samples = StratifiedCount(
+                    num_nonzeros=int(min(gtmp, num_nonzeros)),
+                    num_zeros=int(min(gtmp, num_nonzeros, num_zeros)),
+                )
+            elif isinstance(gradient_samples, int):
+                gradient_samples = StratifiedCount(
+                    num_nonzeros=gradient_samples, num_zeros=gradient_samples
+                )
+            elif not isinstance(gradient_samples, StratifiedCount):
+                raise ValueError(
+                    "Gradient samples should be an int or StratifiedCount but "
+                    f" received: {gradient_samples}"
+                )
+            if gradient_sampler == Samplers.SEMISTRATIFIED:
+                self._gsampler: sampler_type = partial(
+                    semistrat,
+                    num_nonzeros=gradient_samples.num_nonzeros,
+                    num_zeros=gradient_samples.num_zeros,
+                )
+                self._crng = np.arange(gradient_samples.num_nonzeros)
+            else:
+                if not isinstance(data, ttb.sptensor):
+                    raise ValueError(
+                        "Stratified sampling is only supported for sptensor data."
+                    )
+                # TODO store value if computed to avoid duplicate work
+                xnzidx = np.sort(ttb.tt_sub2ind(data.shape, data.subs))
+                self._gsampler = partial(
+                    stratified,
+                    nz_idx=xnzidx,
+                    num_nonzeros=gradient_samples.num_nonzeros,
+                    num_zeros=gradient_samples.num_zeros,
+                    over_sample_rate=over_sample_rate,
+                )
+        elif gradient_sampler == Samplers.UNIFORM:
+            tensor_size = int(np.prod(data.shape))
+            if gradient_samples is None:
+                gradient_samples = int(
+                    min(max(1000, ceil(10 * tensor_size / max_iters)), tensor_size)
+                )
+            if not isinstance(gradient_samples, int):
+                raise ValueError(
+                    "Uniform sampling only accepts integers for number of samples"
+                )
+            if isinstance(data, ttb.sptensor):
+                exp_nonzeros = gradient_samples * num_nonzeros / tensor_size
+                exp_zeros = gradient_samples * num_zeros / tensor_size
+                xnzidx = np.sort(ttb.tt_sub2ind(data.shape, data.subs))
+                # NOTE: Must use lambda over partial because we need late binding,
+                # every draw should first uniquely sample num_nonzeros
+                self._gsampler = lambda data: stratified(
+                    data=cast(ttb.sptensor, data),
+                    nz_idx=xnzidx,
+                    num_nonzeros=np.random.poisson(exp_nonzeros),
+                    num_zeros=np.random.poisson(exp_zeros),
+                    over_sample_rate=over_sample_rate,
+                )
+            else:
+                self._gsampler = partial(uniform, samples=gradient_samples)
+
+        else:
+            raise ValueError("Invalid choice for function_sampler")
+
+    def function_sample(self, data: Union[ttb.tensor, ttb.sptensor]) -> sample_type:
+        """Draw a sample from the objective function"""
+        return self._fsampler(data)
+
+    def gradient_sample(self, data: Union[ttb.tensor, ttb.sptensor]) -> sample_type:
+        """Draw a sample from the gradient function"""
+        return self._gsampler(data)
+
+    @property
+    def crng(self):
+        """Correction Range for possibly missampled zeros"""
+        return self._crng
 
 
 def nonzeros(
@@ -128,9 +344,7 @@ def zeros(
     return tmpsubs[:samples, :]
 
 
-def uniform(
-    data: ttb.tensor, samples: int
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+def uniform(data: ttb.tensor, samples: int) -> sample_type:
     """Uniformly samples indices from a tensor
 
     Parameters
@@ -152,9 +366,7 @@ def uniform(
     return subs, vals, wgts
 
 
-def semistrat(
-    data: ttb.sptensor, num_nonzeros: int, num_zeros: int
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+def semistrat(data: ttb.sptensor, num_nonzeros: int, num_zeros: int) -> sample_type:
     """Sample nonzero and zero entries from a sparse tensor
 
     Parameters
@@ -192,8 +404,8 @@ def stratified(
     num_nonzeros: int,
     num_zeros: int,
     over_sample_rate: float = 1.1,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Sample nonzer and zero entries from a sparse tensor
+) -> sample_type:
+    """Sample nonzero and zero entries from a sparse tensor
 
     Parameters
     ----------

--- a/pyttb/gcp/samplers.py
+++ b/pyttb/gcp/samplers.py
@@ -423,12 +423,16 @@ def stratified(
     Subscripts, values, and weights of samples (Nonzeros then zeros).
     """
     [nonzero_subs, nonzero_vals] = nonzeros(data, num_nonzeros, with_replacement=True)
-    nonzero_weights = (data.nnz / num_nonzeros) * np.ones((num_nonzeros,))
+    nonzero_weights = np.ones((num_nonzeros,))
+    if num_nonzeros > 0:
+        nonzero_weights *= data.nnz / num_nonzeros
 
     zero_subs = zeros(data, nz_idx, num_zeros, over_sample_rate, with_replacement=True)
     zero_vals = np.zeros((num_zeros, 1))
     data_nonzero_count = np.prod(data.shape) - data.nnz
-    zero_weights = (data_nonzero_count / num_zeros) * np.ones((num_zeros,))
+    zero_weights = np.ones((num_zeros,))
+    if num_zeros > 0:
+        zero_weights *= data_nonzero_count / num_zeros
 
     all_subs = np.vstack((nonzero_subs, zero_subs))
     all_vals = np.concatenate((nonzero_vals, zero_vals))

--- a/pyttb/gcp_opt.py
+++ b/pyttb/gcp_opt.py
@@ -24,7 +24,33 @@ def gcp_opt(
     sampler: Optional[GCPSampler] = None,
     printitn: int = 1,
 ) -> Tuple[ttb.ktensor, ttb.ktensor, Dict]:
-    """Fits Generalized CP decomposition with user-specified function."""
+    """Fits Generalized CP decomposition with user-specified function.
+
+    Parameters
+    ----------
+    data:
+        Tensor to decompose.
+    rank:
+        Rank of desired CP decomposition.
+    objective:
+        Objective function to minimize for the CP decomposition. Either a pre-defined
+        objective or a tuple of function_handle, gradient_handle, and lower_bound.
+    optimizer:
+        Optimizer class for solving the decompistion problem defined.
+    init:
+        Initial solution to the problem.
+    mask:
+        A binary mask to note missing rather than sparse data.
+        (Only valid for dense, LBFGSB solves)
+    sampler:
+        Class that defined sampling strategy for stochastic solves.
+    printitn:
+        Controls verbosity of printing throughout the solve
+
+    Returns
+    -------
+        Solution, Initial Guess, Dictionary of meta data
+    """
     if not isinstance(objective, Objectives):
         # TODO probably do some runtime type validation here to make
         #  sure tuple is correct

--- a/pyttb/gcp_opt.py
+++ b/pyttb/gcp_opt.py
@@ -1,0 +1,126 @@
+"""Generalized CP Decomposition"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Literal, Optional, Tuple, Union
+
+import numpy as np
+
+import pyttb as ttb
+from pyttb.gcp.fg_setup import function_type, setup
+from pyttb.gcp.handles import Objectives
+from pyttb.gcp.optimizers import LBFGSB, StochasticSolver
+from pyttb.gcp.samplers import GCPSampler
+
+
+# pylint: disable=too-many-arguments, too-many-locals, too-many-branches
+def gcp_opt(
+    data: Union[ttb.tensor, ttb.sptensor],
+    rank: int,
+    objective: Union[Objectives, Tuple[function_type, function_type, float]],
+    optimizer: Union[StochasticSolver, LBFGSB],
+    init: Union[Literal["random"], ttb.ktensor, List[np.ndarray]] = "random",
+    mask: Optional[Union[ttb.tensor, np.ndarray]] = None,
+    sampler: Optional[GCPSampler] = None,
+    printitn: int = 1,
+) -> Tuple[ttb.ktensor, ttb.ktensor, Dict]:
+    """Fits Generalized CP decomposition with user-specified function."""
+    if not isinstance(objective, Objectives):
+        # TODO probably do some runtime type validation here to make
+        #  sure tuple is correct
+        if len(objective) != 3:
+            raise ValueError(
+                "Objective must either be an Objectives enum or a tuple containing a "
+                "function handle, gradient_handle and lower bound."
+            )
+
+    if isinstance(objective, Objectives):
+        # TODO not clear how to pass in other params to setup for ex huber
+        function_handle, gradient_handle, lower_bound = setup(objective, data)
+    else:
+        function_handle, gradient_handle, lower_bound = objective
+
+    if not isinstance(data, (ttb.tensor, ttb.sptensor)):
+        raise ValueError("Input data must be tensor or sptensor.")
+
+    tensor_size = int(np.prod(data.shape))
+
+    if isinstance(data, ttb.tensor) and isinstance(mask, ttb.tensor):
+        data *= mask
+        nmissing = tensor_size - mask.nnz
+    elif isinstance(data, ttb.sptensor) and mask is not None:
+        raise ValueError("Cannot specify missing entries for sparse tensors")
+    else:
+        nmissing = 0
+
+    # Create initial guess
+    M0 = _get_initial_guess(data, rank, init)
+
+    if not isinstance(optimizer, (StochasticSolver, LBFGSB)):
+        raise ValueError("Must select a supported optimizer.")
+
+    if isinstance(data, ttb.sptensor) and isinstance(optimizer, LBFGSB):
+        raise ValueError("For sparse tensor must use: ADAM, SGD, or ADAGRAD.")
+
+    if isinstance(optimizer, StochasticSolver) and mask is not None:
+        raise ValueError("Mask isn't supported for stochastic solves")
+
+    # Welcome Message
+    if printitn > 0:
+        # TODO capture full verbosity from MATLAB
+        optimizer_name = type(optimizer).__name__
+        objective_name = "user-provided"
+        if isinstance(objective, Objectives):
+            objective_name = objective.name
+        welcome_msg = (
+            f"\nGCP-OPT-{optimizer_name} (Generalized CP Tensor Decomposition)\n"
+            f"\nTensor shape: {data.shape} ({tensor_size} total entries)\n"
+            f"GCP rank: {rank}\nGeneralized function type: {objective_name}"
+        )
+        if nmissing > 0:
+            welcome_msg += (
+                f"Missing entries: {nmissing} ({100*nmissing/tensor_size:.2g}%)"
+            )
+        logging.info(welcome_msg)
+
+    if isinstance(optimizer, StochasticSolver):
+        result, info = optimizer.solve(
+            M0, data, function_handle, gradient_handle, lower_bound, sampler
+        )
+    else:
+        if isinstance(mask, ttb.tensor):
+            mask = mask.data
+        assert isinstance(data, ttb.tensor)
+        result, info = optimizer.solve(
+            M0, data, function_handle, gradient_handle, lower_bound, mask
+        )
+    return result, M0, info
+
+
+def _get_initial_guess(
+    data: Union[ttb.tensor, ttb.sptensor],
+    rank: int,
+    init: Union[Literal["random"], ttb.ktensor, List[np.ndarray]],
+) -> ttb.ktensor:
+    """Get initial guess for gcp_opt
+
+    Returns
+    -------
+        Normalized ktensor.
+    """
+    # TODO might be nice to merge with ALS/other CP methods
+    if isinstance(init, list):
+        return ttb.ktensor(init)
+    if isinstance(init, ttb.ktensor):
+        if np.any(init.weights != 1.0):
+            init.normalize(0)
+        return init
+    if init == "random":
+        factor_matrices = []
+        for n in range(data.ndims):
+            factor_matrices.append(np.random.uniform(0, 1, (data.shape[n], rank)))
+        M0 = ttb.ktensor(factor_matrices)
+        M0 *= data.norm() / M0.norm()
+        M0.normalize(0)
+        return M0
+    raise ValueError(f"Unexpected input for init received: {init}")

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -1975,7 +1975,7 @@ class ktensor:
         """
         Updates a :class:`pyttb.ktensor` in the specific dimensions with the
         values in `data` (in vector or matrix form). The value of `modes` must
-        be a value in [-1,...,self.ndoms]. If the Further, the number of elements in
+        be a value in [-1,...,self.ndims]. If the Further, the number of elements in
         `data` must equal self.shape[modes] * self.ncomponents. The update is
         performed in place.
 
@@ -2070,9 +2070,12 @@ class ktensor:
 
         """
         if not isinstance(modes, int):
-            assert modes == sorted(modes), "Modes must be sorted in ascending order"
+            modes = np.array(modes)
+            assert np.all(
+                modes[:-1] <= modes[1:]
+            ), "Modes must be sorted in ascending order"
         else:
-            modes = [modes]
+            modes = np.array([modes])
 
         loc = 0  # Location in data array
         for k in modes:

--- a/tests/gcp/test_gcp_opt.py
+++ b/tests/gcp/test_gcp_opt.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pyttb as ttb
+from pyttb.gcp import samplers
+from pyttb.gcp.handles import Objectives, gaussian, gaussian_grad
+from pyttb.gcp.optimizers import LBFGSB, SGD, Adagrad, Adam
+
+
+class TestGcpOpt:
+    def test_external_solves(
+        self,
+    ):
+        dense_data = ttb.tenones((2, 2))
+        dense_data[0, 1] = 0.0
+        dense_data[1, 0] = 0.0
+        rank = 2
+        optimizer = LBFGSB(maxiter=2)
+        result_gauss, initial_guess, info = ttb.gcp_opt(
+            dense_data, rank, Objectives.GAUSSIAN, optimizer
+        )
+        assert not result_gauss.isequal(initial_guess)
+        assert all(initial_guess.weights == 1.0)
+
+        # Test with missing data
+        mask = ttb.tenones(dense_data.shape)
+        mask[0] = 0
+        result_gauss, initial_guess, info = ttb.gcp_opt(
+            dense_data, rank, Objectives.GAUSSIAN, optimizer, mask=mask
+        )
+        assert not result_gauss.isequal(initial_guess)
+        assert all(initial_guess.weights == 1.0)
+
+    def test_stochastic_solves(
+        self,
+    ):
+        dense_data = ttb.tenones((2, 2))
+        dense_data[0, 1] = 0.0
+        dense_data[1, 0] = 0.0
+        rank = 2
+
+        np.random.seed(1)
+        optimizer = SGD(max_iters=2, epoch_iters=1)
+        result_gauss, initial_guess, info = ttb.gcp_opt(
+            dense_data, rank, Objectives.GAUSSIAN, optimizer
+        )
+        assert not result_gauss.isequal(initial_guess)
+        assert all(initial_guess.weights == 1.0)
+
+        # Providing an initial guess skips the rng to generate initial ktensor
+        np.random.seed(1)
+        optimizer = SGD(max_iters=2, epoch_iters=1)
+        result_gauss, initial_guess, info = ttb.gcp_opt(
+            dense_data, rank, Objectives.GAUSSIAN, optimizer, initial_guess
+        )
+        assert not result_gauss.isequal(initial_guess)
+        assert all(initial_guess.weights == 1.0)
+
+        # Test custom objective equivalent to GAUSSIAN
+        np.random.seed(1)
+        optimizer = SGD(max_iters=2, epoch_iters=1)
+        result, initial_guess_custom, info = ttb.gcp_opt(
+            dense_data,
+            rank,
+            (gaussian, gaussian_grad, -np.inf),
+            optimizer,
+            initial_guess,
+        )
+        assert not result.isequal(initial_guess)
+        assert initial_guess_custom.isequal(initial_guess)
+        assert all(
+            np.allclose(obj_factor, custom_factor)
+            for obj_factor, custom_factor in zip(
+                result.factor_matrices, result_gauss.factor_matrices
+            )
+        )
+
+        # Test non-normalized initial guess
+        np.random.seed(1)
+        optimizer = SGD(max_iters=2, epoch_iters=1)
+        non_norm_guess = initial_guess.copy()
+        non_norm_guess.weights *= 2
+        result_gauss, initial_guess, info = ttb.gcp_opt(
+            dense_data, rank, Objectives.GAUSSIAN, optimizer, non_norm_guess
+        )
+        assert not result_gauss.isequal(initial_guess)
+        assert all(initial_guess.weights == 1.0)
+
+        # Test just providing factor matrices
+        np.random.seed(1)
+        optimizer = SGD(max_iters=2, epoch_iters=1)
+        result_gauss, initial_guess, info = ttb.gcp_opt(
+            dense_data,
+            rank,
+            Objectives.GAUSSIAN,
+            optimizer,
+            initial_guess.factor_matrices,
+        )
+        assert not result_gauss.isequal(initial_guess)
+        assert all(initial_guess.weights == 1.0)
+
+    def test_invalid_optimizer_options(
+        self,
+    ):
+        dense_data = ttb.tenones((2, 2))
+        dense_data[0, 1] = 0.0
+        dense_data[1, 0] = 0.0
+        rank = 2
+
+        # No mask with stochastic solve
+        with pytest.raises(ValueError):
+            optimizer = SGD(max_iters=2, epoch_iters=1)
+            ttb.gcp_opt(
+                dense_data,
+                rank,
+                Objectives.GAUSSIAN,
+                optimizer,
+                mask=ttb.tenones(dense_data.shape),
+            )
+
+        # LBFGSB only supports dense
+        with pytest.raises(ValueError):
+            sparse_data = ttb.sptensor.from_tensor_type(dense_data)
+            ttb.gcp_opt(sparse_data, rank, Objectives.GAUSSIAN, LBFGSB())
+
+    def test_general_invalid_options(
+        self,
+    ):
+        dense_data = ttb.tenones((2, 2))
+        dense_data[0, 1] = 0.0
+        dense_data[1, 0] = 0.0
+        rank = 2
+        optimizer = SGD(max_iters=2, epoch_iters=1)
+
+        # Incorrect customer objective
+        with pytest.raises(ValueError):
+            ttb.gcp_opt(dense_data, rank, (1, 2), optimizer)
+
+        # Sptensor with mask
+        with pytest.raises(ValueError):
+            ttb.gcp_opt(
+                ttb.sptensor(),
+                rank,
+                Objectives.GAUSSIAN,
+                optimizer,
+                mask=np.ones((2, 2)),
+            )
+
+        # Non-tensor data
+        with pytest.raises(ValueError):
+            result, initial_guess_custom, info = ttb.gcp_opt(
+                [], rank, (gaussian, gaussian_grad, -np.inf), optimizer
+            )
+
+        # Invalid optimizer choices
+        with pytest.raises(ValueError):
+            ttb.gcp_opt(dense_data, rank, Objectives.GAUSSIAN, "Not an optimizer")
+        # Invalid Init
+        with pytest.raises(ValueError):
+            optimizer = SGD(max_iters=2, epoch_iters=1)
+            ttb.gcp_opt(
+                dense_data,
+                rank,
+                Objectives.GAUSSIAN,
+                optimizer,
+                init="Not a supported choice",
+            )

--- a/tests/gcp/test_optimizers.py
+++ b/tests/gcp/test_optimizers.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pyttb as ttb
+from pyttb.gcp import samplers
+from pyttb.gcp.optimizers import SGD
+from pyttb.gcp.handles import gaussian, gaussian_grad
+
+
+def test_sgd():
+    num_zeros = 2
+    num_nonzeros = 2
+    dense_data = ttb.tenones((2, 2))
+    dense_data[0, 1] = 0.0
+    dense_data[1, 0] = 0.0
+    sampler = samplers.GCPSampler(dense_data, num_zeros, num_nonzeros)
+    model = ttb.ktensor([np.ones((2, 2))] * 2)
+
+    solver = SGD(max_iters=1, epoch_iters=1)
+    result, info = solver.solve(model, dense_data, gaussian, gaussian_grad, sampler)

--- a/tests/gcp/test_optimizers.py
+++ b/tests/gcp/test_optimizers.py
@@ -6,7 +6,7 @@ import pytest
 import pyttb as ttb
 from pyttb.gcp import samplers
 from pyttb.gcp.handles import gaussian, gaussian_grad
-from pyttb.gcp.optimizers import SGD, Adagrad, Adam
+from pyttb.gcp.optimizers import LBFGSB, SGD, Adagrad, Adam
 
 global f_est
 f_est = 0.0
@@ -84,3 +84,13 @@ def test_adagrad(generate_problem):
     assert model.isequal(result)
     assert solver._gnormsum == 0.0
     assert solver._nfails == min(solver._max_iters, solver._max_fails + 1)
+
+
+def test_lbfgsb(generate_problem):
+    dense_data, model, sampler = generate_problem
+
+    solver = LBFGSB(maxiter=2)
+    result, info = solver.solve(model, dense_data, gaussian, gaussian_grad)
+    assert isinstance(info, dict)
+    assert not model.isequal(result)
+    assert (model.full() - dense_data).norm() > (result.full() - dense_data).norm()

--- a/tests/gcp/test_optimizers.py
+++ b/tests/gcp/test_optimizers.py
@@ -32,18 +32,20 @@ def test_sgd(generate_problem):
     dense_data, model, sampler = generate_problem
 
     solver = SGD(max_iters=2, epoch_iters=1)
-    result, info = solver.solve(model, dense_data, gaussian, gaussian_grad, sampler)
+    result, info = solver.solve(
+        model, dense_data, gaussian, gaussian_grad, sampler=sampler
+    )
     assert isinstance(info, dict)
     assert (model.full() - dense_data).norm() > (result.full() - dense_data).norm()
 
     # Force inf grad
     with pytest.raises(ValueError):
-        inf_data = np.inf * dense_data
-        solver.solve(model, inf_data, gaussian, gaussian_grad, sampler)
+        inf_data = np.inf * ttb.tenones(dense_data.shape)
+        solver.solve(model, inf_data, gaussian, gaussian_grad, sampler=sampler)
 
     # Force bad step
     result, info = solver.solve(
-        model, dense_data, diverging_function_handle, gaussian_grad, sampler
+        model, dense_data, diverging_function_handle, gaussian_grad, sampler=sampler
     )
     assert model.isequal(result)
     assert solver._nfails == min(solver._max_iters, solver._max_fails + 1)
@@ -53,14 +55,16 @@ def test_adam(generate_problem):
     dense_data, model, sampler = generate_problem
 
     solver = Adam(max_iters=1, epoch_iters=1)
-    result, info = solver.solve(model, dense_data, gaussian, gaussian_grad, sampler)
+    result, info = solver.solve(
+        model, dense_data, gaussian, gaussian_grad, sampler=sampler
+    )
     assert isinstance(info, dict)
     assert (model.full() - dense_data).norm() > (result.full() - dense_data).norm()
 
     # Force bad step
     solver = Adam(max_iters=1, epoch_iters=1)
     result, info = solver.solve(
-        model, dense_data, diverging_function_handle, gaussian_grad, sampler
+        model, dense_data, diverging_function_handle, gaussian_grad, sampler=sampler
     )
     assert model.isequal(result)
     assert [np.testing.assert_array_equal(mk, np.zeros_like(mk)) for mk in solver._m]
@@ -72,14 +76,16 @@ def test_adagrad(generate_problem):
     dense_data, model, sampler = generate_problem
 
     solver = Adagrad(max_iters=1, epoch_iters=1)
-    result, info = solver.solve(model, dense_data, gaussian, gaussian_grad, sampler)
+    result, info = solver.solve(
+        model, dense_data, gaussian, gaussian_grad, sampler=sampler
+    )
     assert isinstance(info, dict)
     assert (model.full() - dense_data).norm() > (result.full() - dense_data).norm()
 
     # Force bad step
     solver = Adagrad(max_iters=1, epoch_iters=1)
     result, info = solver.solve(
-        model, dense_data, diverging_function_handle, gaussian_grad, sampler
+        model, dense_data, diverging_function_handle, gaussian_grad, sampler=sampler
     )
     assert model.isequal(result)
     assert solver._gnormsum == 0.0

--- a/tests/gcp/test_optimizers.py
+++ b/tests/gcp/test_optimizers.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from unittest import mock
+
 import numpy as np
 import pytest
 
 import pyttb as ttb
 from pyttb.gcp import samplers
-from pyttb.gcp.optimizers import SGD
 from pyttb.gcp.handles import gaussian, gaussian_grad
+from pyttb.gcp.optimizers import SGD, Adagrad, Adam
 
 
 def test_sgd():
@@ -18,5 +20,42 @@ def test_sgd():
     sampler = samplers.GCPSampler(dense_data, num_zeros, num_nonzeros)
     model = ttb.ktensor([np.ones((2, 2))] * 2)
 
-    solver = SGD(max_iters=1, epoch_iters=1)
+    solver = SGD(max_iters=2, epoch_iters=1)
     result, info = solver.solve(model, dense_data, gaussian, gaussian_grad, sampler)
+    assert isinstance(info, dict)
+    assert (model.full() - dense_data).norm() > (result.full() - dense_data).norm()
+
+    # Force inf grad
+    with pytest.raises(ValueError):
+        inf_data = np.inf * dense_data
+        solver.solve(model, inf_data, gaussian, gaussian_grad, sampler)
+
+
+def test_adam():
+    num_zeros = 2
+    num_nonzeros = 2
+    dense_data = ttb.tenones((2, 2))
+    dense_data[0, 1] = 0.0
+    dense_data[1, 0] = 0.0
+    sampler = samplers.GCPSampler(dense_data, num_zeros, num_nonzeros)
+    model = ttb.ktensor([np.ones((2, 2))] * 2)
+
+    solver = Adam(max_iters=1, epoch_iters=1)
+    result, info = solver.solve(model, dense_data, gaussian, gaussian_grad, sampler)
+    assert isinstance(info, dict)
+    assert (model.full() - dense_data).norm() > (result.full() - dense_data).norm()
+
+
+def test_adagrad():
+    num_zeros = 2
+    num_nonzeros = 2
+    dense_data = ttb.tenones((2, 2))
+    dense_data[0, 1] = 0.0
+    dense_data[1, 0] = 0.0
+    sampler = samplers.GCPSampler(dense_data, num_zeros, num_nonzeros)
+    model = ttb.ktensor([np.ones((2, 2))] * 2)
+
+    solver = Adagrad(max_iters=1, epoch_iters=1)
+    result, info = solver.solve(model, dense_data, gaussian, gaussian_grad, sampler)
+    assert isinstance(info, dict)
+    assert (model.full() - dense_data).norm() > (result.full() - dense_data).norm()

--- a/tests/gcp/test_optimizers.py
+++ b/tests/gcp/test_optimizers.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest import mock
-
 import numpy as np
 import pytest
 
@@ -10,15 +8,28 @@ from pyttb.gcp import samplers
 from pyttb.gcp.handles import gaussian, gaussian_grad
 from pyttb.gcp.optimizers import SGD, Adagrad, Adam
 
+global f_est
+f_est = 0.0
 
-def test_sgd():
-    num_zeros = 2
-    num_nonzeros = 2
+
+def diverging_function_handle(data: np.ndarray, model: np.ndarray) -> np.ndarray:
+    global f_est
+    f_est += 1.0
+    return f_est * data
+
+
+@pytest.fixture()
+def generate_problem():
     dense_data = ttb.tenones((2, 2))
     dense_data[0, 1] = 0.0
     dense_data[1, 0] = 0.0
-    sampler = samplers.GCPSampler(dense_data, num_zeros, num_nonzeros)
+    sampler = samplers.GCPSampler(dense_data)
     model = ttb.ktensor([np.ones((2, 2))] * 2)
+    return dense_data, model, sampler
+
+
+def test_sgd(generate_problem):
+    dense_data, model, sampler = generate_problem
 
     solver = SGD(max_iters=2, epoch_iters=1)
     result, info = solver.solve(model, dense_data, gaussian, gaussian_grad, sampler)
@@ -30,32 +41,46 @@ def test_sgd():
         inf_data = np.inf * dense_data
         solver.solve(model, inf_data, gaussian, gaussian_grad, sampler)
 
+    # Force bad step
+    result, info = solver.solve(
+        model, dense_data, diverging_function_handle, gaussian_grad, sampler
+    )
+    assert model.isequal(result)
+    assert solver._nfails == min(solver._max_iters, solver._max_fails + 1)
 
-def test_adam():
-    num_zeros = 2
-    num_nonzeros = 2
-    dense_data = ttb.tenones((2, 2))
-    dense_data[0, 1] = 0.0
-    dense_data[1, 0] = 0.0
-    sampler = samplers.GCPSampler(dense_data, num_zeros, num_nonzeros)
-    model = ttb.ktensor([np.ones((2, 2))] * 2)
+
+def test_adam(generate_problem):
+    dense_data, model, sampler = generate_problem
 
     solver = Adam(max_iters=1, epoch_iters=1)
     result, info = solver.solve(model, dense_data, gaussian, gaussian_grad, sampler)
     assert isinstance(info, dict)
     assert (model.full() - dense_data).norm() > (result.full() - dense_data).norm()
 
+    # Force bad step
+    solver = Adam(max_iters=1, epoch_iters=1)
+    result, info = solver.solve(
+        model, dense_data, diverging_function_handle, gaussian_grad, sampler
+    )
+    assert model.isequal(result)
+    assert [np.testing.assert_array_equal(mk, np.zeros_like(mk)) for mk in solver._m]
+    assert [np.testing.assert_array_equal(vk, np.zeros_like(vk)) for vk in solver._v]
+    assert solver._nfails == min(solver._max_iters, solver._max_fails + 1)
 
-def test_adagrad():
-    num_zeros = 2
-    num_nonzeros = 2
-    dense_data = ttb.tenones((2, 2))
-    dense_data[0, 1] = 0.0
-    dense_data[1, 0] = 0.0
-    sampler = samplers.GCPSampler(dense_data, num_zeros, num_nonzeros)
-    model = ttb.ktensor([np.ones((2, 2))] * 2)
+
+def test_adagrad(generate_problem):
+    dense_data, model, sampler = generate_problem
 
     solver = Adagrad(max_iters=1, epoch_iters=1)
     result, info = solver.solve(model, dense_data, gaussian, gaussian_grad, sampler)
     assert isinstance(info, dict)
     assert (model.full() - dense_data).norm() > (result.full() - dense_data).norm()
+
+    # Force bad step
+    solver = Adagrad(max_iters=1, epoch_iters=1)
+    result, info = solver.solve(
+        model, dense_data, diverging_function_handle, gaussian_grad, sampler
+    )
+    assert model.isequal(result)
+    assert solver._gnormsum == 0.0
+    assert solver._nfails == min(solver._max_iters, solver._max_fails + 1)

--- a/tests/gcp/test_samplers.py
+++ b/tests/gcp/test_samplers.py
@@ -26,16 +26,16 @@ def test_nonzeros():
     # Sample all values
     subs, vals = samplers.nonzeros(data, 2, False)
     np.testing.assert_array_equal(subs, data.subs)
-    np.testing.assert_array_equal(vals, data.vals)
+    np.testing.assert_array_equal(vals, data.vals.squeeze())
 
     # Sample subset
     subs, vals = samplers.nonzeros(data, 1, False)
-    assert np.all(np.isin(vals, data.vals))
+    assert np.all(np.isin(vals, data.vals.squeeze()))
     assert len(vals) == 1
 
     # Sample with replacement
     subs, vals = samplers.nonzeros(data, 4)
-    assert np.all(np.isin(vals, data.vals))
+    assert np.all(np.isin(vals, data.vals.squeeze()))
     assert len(vals) == 4
 
     with pytest.raises(ValueError):

--- a/tests/gcp/test_samplers.py
+++ b/tests/gcp/test_samplers.py
@@ -109,6 +109,7 @@ def test_gcp_sampler():
     subs, vals, wgts = sampler.gradient_sample(dense_data)
     check_sample_output(subs, vals, wgts, num_zeros, num_nonzeros)
     assert sampler.crng.size == 0
+    assert np.issubdtype(sampler.crng.dtype, np.integer)
 
     # Sparse data defaults
     sparse_data = ttb.sptensor.from_tensor_type(dense_data)
@@ -118,6 +119,7 @@ def test_gcp_sampler():
     subs, vals, wgts = sampler.gradient_sample(sparse_data)
     check_sample_output(subs, vals, wgts, num_zeros, num_nonzeros)
     assert sampler.crng.size == 0
+    assert np.issubdtype(sampler.crng.dtype, np.integer)
 
     # Sparse stratified integer sample count
     sampler = samplers.GCPSampler(
@@ -132,6 +134,7 @@ def test_gcp_sampler():
     subs, vals, wgts = sampler.gradient_sample(sparse_data)
     check_sample_output(subs, vals, wgts, num_zeros, num_nonzeros)
     assert sampler.crng.size == 0
+    assert np.issubdtype(sampler.crng.dtype, np.integer)
 
     # Sparse stratified stratified count
     sampler = samplers.GCPSampler(
@@ -146,6 +149,7 @@ def test_gcp_sampler():
     subs, vals, wgts = sampler.gradient_sample(sparse_data)
     check_sample_output(subs, vals, wgts, num_zeros, num_nonzeros)
     assert sampler.crng.size == 0
+    assert np.issubdtype(sampler.crng.dtype, np.integer)
 
     # Sparse uniform sampling
     sampler = samplers.GCPSampler(
@@ -160,6 +164,7 @@ def test_gcp_sampler():
     sampler.gradient_sample(sparse_data)
     # We skip verifying sptensor UNIFORM gradient samples since it can vary in shape
     assert sampler.crng.size == 0
+    assert np.issubdtype(sampler.crng.dtype, np.integer)
 
     # Sparse semi-stratified sampling
     sampler = samplers.GCPSampler(
@@ -174,6 +179,7 @@ def test_gcp_sampler():
     subs, vals, wgts = sampler.gradient_sample(sparse_data)
     check_sample_output(subs, vals, wgts, num_zeros, num_nonzeros)
     assert sampler.crng.size != 0
+    assert np.issubdtype(sampler.crng.dtype, np.integer)
 
     # Negative tests
 

--- a/tests/gcp/test_samplers.py
+++ b/tests/gcp/test_samplers.py
@@ -103,7 +103,7 @@ def test_gcp_sampler():
     dense_data = ttb.tenones((2, 2))
     dense_data[0, 1] = 0.0
     dense_data[1, 0] = 0.0
-    sampler = samplers.GCPSampler(dense_data, num_zeros, num_nonzeros)
+    sampler = samplers.GCPSampler(dense_data)
     subs, vals, wgts = sampler.function_sample(dense_data)
     check_sample_output(subs, vals, wgts, num_zeros, num_nonzeros)
     subs, vals, wgts = sampler.gradient_sample(dense_data)
@@ -113,7 +113,7 @@ def test_gcp_sampler():
 
     # Sparse data defaults
     sparse_data = ttb.sptensor.from_tensor_type(dense_data)
-    sampler = samplers.GCPSampler(sparse_data, num_zeros, num_nonzeros)
+    sampler = samplers.GCPSampler(sparse_data)
     subs, vals, wgts = sampler.function_sample(sparse_data)
     check_sample_output(subs, vals, wgts, num_zeros, num_nonzeros)
     subs, vals, wgts = sampler.gradient_sample(sparse_data)
@@ -124,8 +124,6 @@ def test_gcp_sampler():
     # Sparse stratified integer sample count
     sampler = samplers.GCPSampler(
         sparse_data,
-        num_zeros,
-        num_nonzeros,
         function_samples=2,
         gradient_samples=2,
     )
@@ -139,8 +137,6 @@ def test_gcp_sampler():
     # Sparse stratified stratified count
     sampler = samplers.GCPSampler(
         sparse_data,
-        num_zeros,
-        num_nonzeros,
         function_samples=samplers.StratifiedCount(2, 2),
         gradient_samples=samplers.StratifiedCount(2, 2),
     )
@@ -154,8 +150,6 @@ def test_gcp_sampler():
     # Sparse uniform sampling
     sampler = samplers.GCPSampler(
         sparse_data,
-        num_zeros,
-        num_nonzeros,
         function_sampler=samplers.Samplers.UNIFORM,
         gradient_sampler=samplers.Samplers.UNIFORM,
     )
@@ -169,8 +163,6 @@ def test_gcp_sampler():
     # Sparse semi-stratified sampling
     sampler = samplers.GCPSampler(
         sparse_data,
-        num_zeros,
-        num_nonzeros,
         function_sampler=samplers.Samplers.UNIFORM,
         gradient_sampler=samplers.Samplers.SEMISTRATIFIED,
     )
@@ -187,45 +179,29 @@ def test_gcp_sampler():
     with pytest.raises(ValueError):
         samplers.GCPSampler(
             dense_data,
-            num_zeros,
-            num_nonzeros,
             function_sampler=samplers.Samplers.STRATIFIED,
         )
     # No dense stratified gradient
     with pytest.raises(ValueError):
         samplers.GCPSampler(
             dense_data,
-            num_zeros,
-            num_nonzeros,
             gradient_sampler=samplers.Samplers.STRATIFIED,
         )
     # Incorrect function samples type stratified
     with pytest.raises(ValueError):
-        samplers.GCPSampler(
-            sparse_data, num_zeros, num_nonzeros, function_samples=(2, 2)
-        )
+        samplers.GCPSampler(sparse_data, function_samples=(2, 2))
     # Incorrect gradient samples type stratified
     with pytest.raises(ValueError):
-        samplers.GCPSampler(
-            sparse_data, num_zeros, num_nonzeros, gradient_samples=(2, 2)
-        )
+        samplers.GCPSampler(sparse_data, gradient_samples=(2, 2))
     # Incorrect function samples type uniform
     with pytest.raises(ValueError):
-        samplers.GCPSampler(
-            dense_data, num_zeros, num_nonzeros, function_samples=(2, 2)
-        )
+        samplers.GCPSampler(dense_data, function_samples=(2, 2))
     # Incorrect gradient samples type uniform
     with pytest.raises(ValueError):
-        samplers.GCPSampler(
-            dense_data, num_zeros, num_nonzeros, gradient_samples=(2, 2)
-        )
+        samplers.GCPSampler(dense_data, gradient_samples=(2, 2))
     # Bad function sampler type
     with pytest.raises(ValueError):
-        samplers.GCPSampler(
-            dense_data, num_zeros, num_nonzeros, function_sampler="Something bad"
-        )
+        samplers.GCPSampler(dense_data, function_sampler="Something bad")
     # Bad gradient sampler type
     with pytest.raises(ValueError):
-        samplers.GCPSampler(
-            dense_data, num_zeros, num_nonzeros, gradient_sampler="Something bad"
-        )
+        samplers.GCPSampler(dense_data, gradient_sampler="Something bad")

--- a/tests/test_cp_apr.py
+++ b/tests/test_cp_apr.py
@@ -6,13 +6,26 @@ import numpy as np
 import pytest
 
 import pyttb as ttb
+from pyttb.cp_apr import (
+    calc_partials,
+    calculate_phi,
+    calculate_pi,
+    get_hessian,
+    get_search_dir_pdnr,
+    get_search_dir_pqnr,
+    tt_calcpi_prowsubprob,
+    tt_linesearch_prowsubprob,
+    tt_loglikelihood,
+    tt_loglikelihood_row,
+    vectorize_for_mu,
+)
 
 
 @pytest.mark.indevelopment
 def test_vectorizeForMu():
     matrix = np.array([[1, 2], [3, 4]])
     vector = np.array([1, 2, 3, 4])
-    assert np.array_equal(ttb.vectorize_for_mu(matrix), vector)
+    assert np.array_equal(vectorize_for_mu(matrix), vector)
 
 
 @pytest.mark.indevelopment
@@ -32,11 +45,9 @@ def test_loglikelihood():
     vector = [element for element in vector if element > 0]
     explicitAnswer = -np.sum(np.array(vector) - np.array(vector2))
     assert np.isclose(
-        explicitAnswer, ttb.tt_loglikelihood(sptensorInstance, ktensorInstance)
+        explicitAnswer, tt_loglikelihood(sptensorInstance, ktensorInstance)
     )
-    assert np.isclose(
-        explicitAnswer, ttb.tt_loglikelihood(tensorInstance, ktensorInstance)
-    )
+    assert np.isclose(explicitAnswer, tt_loglikelihood(tensorInstance, ktensorInstance))
 
     # Test case for randomly selected model and data
     np.random.seed(123)
@@ -61,11 +72,9 @@ def test_loglikelihood():
             vector2.append(data[idx] * np.log(element))
     explicitAnswer = -np.sum(np.array(vector) - np.array(vector2))
     assert np.isclose(
-        explicitAnswer, ttb.tt_loglikelihood(sptensorInstance, ktensorInstance)
+        explicitAnswer, tt_loglikelihood(sptensorInstance, ktensorInstance)
     )
-    assert np.isclose(
-        explicitAnswer, ttb.tt_loglikelihood(tensorInstance, ktensorInstance)
-    )
+    assert np.isclose(explicitAnswer, tt_loglikelihood(tensorInstance, ktensorInstance))
 
 
 @pytest.mark.indevelopment
@@ -81,15 +90,13 @@ def test_calculatePi():
     answer = np.array([[0, 6], [7, 8]])
     assert np.all(
         np.isclose(
-            ttb.calculate_pi(
-                tensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims
-            ),
+            calculate_pi(tensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims),
             answer,
         )
     )
     assert np.all(
         np.isclose(
-            ttb.calculate_pi(
+            calculate_pi(
                 sptensorInstance, ktensorInstance, 2, 0, sptensorInstance.ndims
             ),
             answer,
@@ -110,10 +117,10 @@ def test_calculatePi():
 
     print(tensorInstance.shape)
     print(sptensorInstance.shape)
-    print(ttb.calculate_pi(tensorInstance, ktensorInstance, n, 0, tensorInstance.ndims).shape)
-    print(ttb.calculate_pi(sptensorInstance, ktensorInstance, n, 0, sptensorInstance.ndims).shape)
-    print(np.all(np.isclose(ttb.calculate_pi(tensorInstance, ktensorInstance, n, 0, tensorInstance.ndims),
-               ttb.calculate_pi(sptensorInstance, ktensorInstance, n, 0, sptensorInstance.ndims))))
+    print(calculate_pi(tensorInstance, ktensorInstance, n, 0, tensorInstance.ndims).shape)
+    print(calculate_pi(sptensorInstance, ktensorInstance, n, 0, sptensorInstance.ndims).shape)
+    print(np.all(np.isclose(calculate_pi(tensorInstance, ktensorInstance, n, 0, tensorInstance.ndims),
+               calculate_pi(sptensorInstance, ktensorInstance, n, 0, sptensorInstance.ndims))))
     assert True
     """
 
@@ -129,12 +136,12 @@ def test_calculatePhi():
     tensorInstance = ktensorInstance.full()
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
     answer = np.array([[0, 0], [11.226415094339623, 24.830188679245282]])
-    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    Pi = calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     assert np.isclose(
-        ttb.calculate_phi(sptensorInstance, ktensorInstance, 2, 0, Pi, 1e-12), answer
+        calculate_phi(sptensorInstance, ktensorInstance, 2, 0, Pi, 1e-12), answer
     ).all()
     assert np.isclose(
-        ttb.calculate_phi(tensorInstance, ktensorInstance, 2, 0, Pi, 1e-12), answer
+        calculate_phi(tensorInstance, ktensorInstance, 2, 0, Pi, 1e-12), answer
     ).all()
 
 
@@ -259,7 +266,7 @@ def test_calculatepi_prowsubprob():
     # Reproduce calculate pi with the appropriate inputs
     assert np.all(
         np.isclose(
-            ttb.tt_calcpi_prowsubprob(
+            tt_calcpi_prowsubprob(
                 tensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims
             ),
             answer,
@@ -267,7 +274,7 @@ def test_calculatepi_prowsubprob():
     )
     assert np.all(
         np.isclose(
-            ttb.tt_calcpi_prowsubprob(
+            tt_calcpi_prowsubprob(
                 sptensorInstance,
                 ktensorInstance,
                 2,
@@ -292,21 +299,21 @@ def test_calc_partials():
     # print(tensorInstance[:, 0])
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
     answer = np.array([[0, 6], [7, 8]])
-    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    Pi = calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     # TODO: These are just verifying same functionality as matlab
-    phi, ups = ttb.calc_partials(
+    phi, ups = calc_partials(
         False, Pi, 1e-12, tensorInstance[0, :].data, ktensorInstance[0][0, :]
     )
     assert np.isclose(phi, np.array([0, 0])).all()
     assert np.isclose(ups, np.array([0, 0])).all()
 
-    phi, ups = ttb.calc_partials(
+    phi, ups = calc_partials(
         False, Pi, 1e-12, tensorInstance[1, :].data, ktensorInstance[0][0, :]
     )
     assert np.isclose(phi, 1e14 * np.array([5.95, 9.68])).all()
     assert np.isclose(ups, 1e13 * np.array([4.8, 8.5])).all()
 
-    phi, ups = ttb.calc_partials(
+    phi, ups = calc_partials(
         True, Pi, 1e-12, sptensorInstance.vals, ktensorInstance[0][0, :]
     )
     assert np.isclose(phi, 1e14 * np.array([5.95, 9.68])).all()
@@ -339,7 +346,7 @@ def test_calc_partials():
 
         gradM[r] = grad_sum
 
-    phi, ups = ttb.calc_partials(False, Pi, eps_div_zero, x_row, m_row)
+    phi, ups = calc_partials(False, Pi, eps_div_zero, x_row, m_row)
     assert np.allclose(phi, gradM)
     assert np.allclose(ups, hessM)
 
@@ -356,13 +363,11 @@ def test_getHessian():
     free_indices = [0, 1]
     rank = 2
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
-    Pi = ttb.calculate_pi(
-        sptensorInstance, ktensorInstance, rank, 0, tensorInstance.ndims
-    )
-    phi, ups = ttb.calc_partials(
+    Pi = calculate_pi(sptensorInstance, ktensorInstance, rank, 0, tensorInstance.ndims)
+    phi, ups = calc_partials(
         False, Pi, 1e-12, tensorInstance[1, :].data, ktensorInstance[0][0, :]
     )
-    Hessian = ttb.get_hessian(ups, Pi, free_indices)
+    Hessian = get_hessian(ups, Pi, free_indices)
     assert np.allclose(Hessian, Hessian.transpose())
 
     # Element indexed simple test
@@ -371,9 +376,9 @@ def test_getHessian():
     m_row = np.random.normal(size=(rank,))
     x_row = np.random.normal(size=(length,))
     Pi = np.random.normal(size=(length, rank))
-    phi, ups = ttb.calc_partials(False, Pi, 1e-12, x_row, m_row)
+    phi, ups = calc_partials(False, Pi, 1e-12, x_row, m_row)
     free_indices = [0, 1]
-    Hessian = ttb.get_hessian(ups, Pi, free_indices)
+    Hessian = get_hessian(ups, Pi, free_indices)
 
     #
     num_free = len(free_indices)
@@ -402,9 +407,9 @@ def test_getSearchDirPdnr():
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
     data_row = tensorInstance[1, :].data
     model_row = ktensorInstance[0][0, :]
-    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
-    phi, ups = ttb.calc_partials(False, Pi, 1e-12, data_row, model_row)
-    search, pred = ttb.get_search_dir_pdnr(Pi, ups, 2, phi, model_row, 0.1, 1e-6)
+    Pi = calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    phi, ups = calc_partials(False, Pi, 1e-12, data_row, model_row)
+    search, pred = get_search_dir_pdnr(Pi, ups, 2, phi, model_row, 0.1, 1e-6)
     # TODO validate this projection formulation
     projGradStep = (model_row - ups.transpose()) * (
         model_row - (ups.transpose() > 0).astype(float)
@@ -420,7 +425,7 @@ def test_getSearchDirPdnr():
             assert search[r] == ups[r]
         else:
             free_indices.append(r)
-    Hessian_free = ttb.get_hessian(ups, Pi, free_indices)
+    Hessian_free = get_hessian(ups, Pi, free_indices)
     direction = np.linalg.solve(
         Hessian_free + (0.1 * np.eye(len(free_indices))), -ups[free_indices]
     )[:, None]
@@ -439,8 +444,8 @@ def test_tt_loglikelihood_row():
     tensorInstance = ktensorInstance.full()
     # print(tensorInstance[:, 0])
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
-    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
-    loglikelihood = ttb.tt_loglikelihood_row(
+    Pi = calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    loglikelihood = tt_loglikelihood_row(
         False, tensorInstance[1, :].data, tensorInstance[1, :].data, Pi
     )
     # print(loglikelihood)
@@ -457,15 +462,15 @@ def test_tt_linesearch_prowsubprob():
     tensorInstance = ktensorInstance.full()
     # print(tensorInstance[:, 0])
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
-    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
-    phi, ups = ttb.calc_partials(
+    Pi = calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    phi, ups = calc_partials(
         False, Pi, 1e-12, tensorInstance[1, :].data, ktensorInstance[0][0, :]
     )
-    search, pred = ttb.get_search_dir_pdnr(
+    search, pred = get_search_dir_pdnr(
         Pi, ups, 2, phi, tensorInstance[1, :].data, 0.1, 1e-6
     )
     with pytest.warns(Warning) as record:
-        ttb.tt_linesearch_prowsubprob(
+        tt_linesearch_prowsubprob(
             search.transpose()[0],
             phi.transpose(),
             tensorInstance[1, :].data,
@@ -496,11 +501,11 @@ def test_getSearchDirPqnr():
     sptensorInstance = ttb.sptensor.from_tensor_type(tensorInstance)
     data_row = tensorInstance[1, :].data
     model_row = ktensorInstance[0][0, :]
-    Pi = ttb.calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
-    phi, ups = ttb.calc_partials(False, Pi, 1e-12, data_row, model_row)
+    Pi = calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
+    phi, ups = calc_partials(False, Pi, 1e-12, data_row, model_row)
     delta_model = np.random.normal(size=(2, model_row.shape[0]))
     delta_grad = np.random.normal(size=(2, phi.shape[0]))
-    search, pred = ttb.get_search_dir_pqnr(
+    search, pred = get_search_dir_pqnr(
         model_row, phi, 1e-6, delta_model, delta_grad, phi, 1, 5, False
     )
     # This only verifies that for the right shaped input nothing crashes. Doesn't verify correctness


### PR DESCRIPTION
Here is the initial land of the variety of gcp_opt components. The implementations should match pretty closely to MATLAB however in MATLAB there are so many parameters. I tried to group things in a few different ways. This is documented in the code/sphinx but wanted to elaborate here in case it is unclear so we can address earlier.
- `Sampler` class to be responsible for all of our different random draws
- `Optimizers` classes to have less branching inside of gcp_opt. IMO this should also make it easier to drop in other optimizers and keep things organized.


Major remaining tasks I can begin filing tickets for are:
- Nicer print statements/capturing all our parameters per class
- More examples/elaboration in our docstrings.
- Quick profile for hot spots since just setting up the small tests things seemed to run slower than I would expect (but I didn't look into that at all)
- Thoughts around more involved numeric validation (probably related to the above profiling where we run a few things to convergence)

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--206.org.readthedocs.build/en/206/

<!-- readthedocs-preview pyttb end -->