### PR TITLE
Remove isort pylint

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +31,6 @@ jobs:
         pip install ".[dev]"
     - name: Check auto-formatters
       run: |
-        isort --check .
         black --check .
 #    - name: Lint with flake8
 #      run: |
@@ -41,7 +40,7 @@ jobs:
 #        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Run tests
       run: |
-        coverage run --source pyttb -m pytest tests/ --packaging
+        coverage run --source pyttb -m pytest tests/
         coverage report
     - name: Upload coverage to Coveralls
       env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.284
     hooks:
-      - id: isort
-        name: isort (python)
+      - id: ruff
+        args: [ --fix, --exit-non-zero-on-fix ]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,15 @@ current or filing a new [issue](https://github.com/sandialabs/pyttb/issues).
 ## Working on PYTTB locally
 1. clone your fork and enter the directory
     ```
-    $ git clone git@github.com:<your username>/pyttb.git
-    $ cd pyttb
+    git clone git@github.com:<your username>/pyttb.git
+    cd pyttb
     ```
     1. setup your desired python environment as appropriate
 
 1. install dependencies
     ```
-    $ pip install -e ".[dev]"
-    $ make install_dev # shorthand for above
+    pip install -e ".[dev]"
+    make install_dev # shorthand for above
     ```
 
 1. Checkout a branch and make your changes
@@ -23,16 +23,16 @@ current or filing a new [issue](https://github.com/sandialabs/pyttb/issues).
     git checkout -b my-new-feature-branch
     ```
 1. Formatters and linting
-   1. Run autoformatters from root of project (they will change your code)
+   1. Run autoformatters and linting from root of project (they will change your code)
        ```commandline
-       $ isort .
-       $ black .
+       ruff check pyttb/ --fix
+       black .
        ```
+      1. Ruff's `--fix` won't necessarily address everything and may point out issues that need manual attention
       1. [We](./.pre-commit-config.yaml) optionally support [pre-commit hooks](https://pre-commit.com/) for this
-   1. Pylint and mypy coverage is work in progress (these only raise errors)
+   1. Check typing
       ```commandline
       mypy pyttb/
-      pylint pyttb/file_name.py  //Today only tensor is compliant
       ```
 
 1. Run tests (at desired fidelity)
@@ -43,10 +43,6 @@ current or filing a new [issue](https://github.com/sandialabs/pyttb/issues).
    1. Functional tests
         ```commandline
         pytest .
-        ```
-   1. All tests (linting and formatting checks)
-        ```commandline
-        pytest . --packaging
         ```
    1. With coverage
         ```commandline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ documentation = "https://pyttb.readthedocs.io"
 [project.optional-dependencies]
 dev = [
     "black",
-    "isort",
-    "pylint",
     "mypy",
     "pytest",
     "pytest-cov",
@@ -56,24 +54,6 @@ version = {attr = "pyttb.__version__"}
 [build-system]
 requires = ["setuptools>=61.0", "numpy", "numpy_groupies", "scipy", "wheel"]
 build-backend = "setuptools.build_meta"
-
-[tool.isort]
-profile = "black"
-
-[tool.pylint]
-# Play nice with black
-max-line-length = 88
-disable="fixme,too-many-lines"
-
-[tool.pylint.basic]
-# To match MATLAB Tensortoolbox styles for clarity
-argument-naming-style = "any"
-class-naming-style = "any"
-variable-naming-style = "any"
-
-[tool.pylint.design]
-# MATLAB Tensortoolbox interface
-max-public-methods = 40
 
 [tool.ruff]
 select = ["E", "F", "PL", "W", "I", "N", "NPY", "RUF"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 markers =
     indevelopment: marks tests as in development, should not be run
-    packaging: slow tests that check formatting over function
 
 filterwarnings =
     ignore:.*deprecated.*:

--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -11,8 +11,6 @@ import numpy as np
 import pyttb as ttb
 
 
-# pylint: disable=too-many-arguments,too-many-locals,too-many-branches
-# pylint: disable=too-many-statements
 def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
     input_tensor: Union[ttb.tensor, ttb.sptensor],
     rank: int,

--- a/pyttb/cp_apr.py
+++ b/pyttb/cp_apr.py
@@ -15,7 +15,6 @@ import pyttb as ttb
 from pyttb.pyttb_utils import tt_to_dense_matrix
 
 
-# pylint: disable=too-many-arguments,too-many-locals
 def cp_apr(  # noqa: PLR0913
     input_tensor: Union[ttb.tensor, ttb.sptensor],
     rank: int,
@@ -184,8 +183,6 @@ def cp_apr(  # noqa: PLR0913
     return M, init, output
 
 
-# pylint: disable=too-many-arguments,too-many-locals,too-many-branches
-# pylint: disable=too-many-statements
 def tt_cp_apr_mu(  # noqa: PLR0912,PLR0913,PLR0915
     input_tensor: Union[ttb.tensor, ttb.sptensor],
     rank: int,
@@ -388,8 +385,6 @@ def tt_cp_apr_mu(  # noqa: PLR0912,PLR0913,PLR0915
     return M, output
 
 
-# pylint: disable=too-many-arguments,too-many-locals,too-many-branches
-# pylint: disable=too-many-statements
 def tt_cp_apr_pdnr(  # noqa: PLR0912,PLR0913,PLR0915
     input_tensor: Union[ttb.tensor, ttb.sptensor],
     rank: int,
@@ -511,7 +506,6 @@ def tt_cp_apr_pdnr(  # noqa: PLR0912,PLR0913,PLR0915
     rowsubprobStopTol = stoptol
 
     # Main loop: iterate until convergence or a max threshold is reached
-    # pylint: disable=too-many-nested-blocks
     for iteration in range(maxiters):
         isConverged = True
         kktModeViolations = np.zeros((N,))
@@ -744,8 +738,6 @@ def tt_cp_apr_pdnr(  # noqa: PLR0912,PLR0913,PLR0915
     return M, output
 
 
-# pylint: disable=too-many-arguments,too-many-locals,too-many-branches
-# pylint: disable=too-many-statements
 def tt_cp_apr_pqnr(  # noqa: PLR0912,PLR0913,PLR0915
     input_tensor: Union[ttb.tensor, ttb.sptensor],
     rank: int,
@@ -869,7 +861,6 @@ def tt_cp_apr_pqnr(  # noqa: PLR0912,PLR0913,PLR0915
             print("done")
 
     # Main loop: iterate until convergence or a max threshold is reached
-    # pylint: disable=too-many-nested-blocks
     for iteration in range(maxiters):
         isConverged = True
         kktModeViolations = np.zeros((N,))

--- a/pyttb/export_data.py
+++ b/pyttb/export_data.py
@@ -24,7 +24,6 @@ def export_data(
         assert False, f"Invalid data type for export: {type(data)}"
 
     # open file
-    # pylint: disable=unspecified-encoding
     with open(filename, "w") as fp:
         if isinstance(data, ttb.tensor):
             print("tensor", file=fp)

--- a/pyttb/gcp/fg_est.py
+++ b/pyttb/gcp/fg_est.py
@@ -12,7 +12,6 @@ import pyttb as ttb
 from pyttb.gcp.fg_setup import function_type
 
 
-# pylint: disable=too-many-arguments
 @overload
 def estimate(  # noqa: PLR0913
     model: ttb.ktensor,
@@ -55,7 +54,6 @@ def estimate(  # noqa: PLR0913
     ...  # pragma: no cover see coveragepy/issues/970
 
 
-# pylint: disable=too-many-locals
 def estimate(  # noqa: PLR0913
     model: ttb.ktensor,
     data_subs: np.ndarray,

--- a/pyttb/gcp/fg_setup.py
+++ b/pyttb/gcp/fg_setup.py
@@ -15,7 +15,6 @@ function_type = Callable[[np.ndarray, np.ndarray], np.ndarray]
 fg_return = Tuple[function_type, function_type, float]
 
 
-# pylint: disable=too-many-branches, too-many-statements
 def setup(  # noqa: PLR0912,PLR0915
     objective: Objectives,
     data: Optional[Union[ttb.tensor, ttb.sptensor]] = None,

--- a/pyttb/gcp/optimizers.py
+++ b/pyttb/gcp/optimizers.py
@@ -17,11 +17,9 @@ from pyttb.gcp.fg_setup import function_type
 from pyttb.gcp.samplers import GCPSampler
 
 
-# pylint: disable=too-many-instance-attributes
 class StochasticSolver(ABC):
     """Interface for Stochastic GCP Solvers"""
 
-    # pylint: disable=too-many-arguments
     def __init__(  # noqa: PLR0913
         self,
         rate: float = 1e-3,
@@ -88,7 +86,6 @@ class StochasticSolver(ABC):
     def set_failed_epoch(self):
         """Set internal state on failed epoch"""
 
-    # pylint: disable=too-many-locals
     def solve(  # noqa: PLR0913
         self,
         initial_model: ttb.ktensor,
@@ -259,7 +256,6 @@ class SGD(StochasticSolver):
 class Adam(StochasticSolver):
     """Adam Optimizer"""
 
-    # pylint: disable=too-many-arguments
     def __init__(  # noqa: PLR0913
         self,
         rate: float = 1e-3,
@@ -364,7 +360,6 @@ class Adam(StochasticSolver):
 class Adagrad(StochasticSolver):
     """Adagrad Optimizer"""
 
-    # pylint: disable=too-many-arguments
     def __init__(  # noqa: PLR0913
         self,
         rate: float = 1e-3,
@@ -404,7 +399,6 @@ class Adagrad(StochasticSolver):
 
 
 # If we use more scipy optimizers in the future we should generalize this
-# pylint: disable=too-few-public-methods
 class LBFGSB:
     """Simple wrapper around scipy lbfgsb
 
@@ -412,7 +406,6 @@ class LBFGSB:
     for the implementation.
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(  # noqa: PLR0913
         self,
         m: Optional[int] = None,

--- a/pyttb/gcp/samplers.py
+++ b/pyttb/gcp/samplers.py
@@ -39,7 +39,6 @@ class Samplers(Enum):
 class GCPSampler:
     """Contains Gradient and Function Sampling Details"""
 
-    # pylint: disable=too-many-arguments
     def __init__(  # noqa: PLR0913
         self,
         data: Union[ttb.tensor, ttb.sptensor],
@@ -105,7 +104,6 @@ class GCPSampler:
             max_iters,
         )
 
-    # pylint: disable=too-many-arguments
     def _prepare_function_sampler(  # noqa: PLR0913
         self,
         data: Union[ttb.tensor, ttb.sptensor],
@@ -160,7 +158,6 @@ class GCPSampler:
         else:
             raise ValueError("Invalid choice for function_sampler")
 
-    # pylint: disable=too-many-arguments, too-many-branches
     def _prepare_gradient_sampler(  # noqa: PLR0912,PLR0913
         self,
         data: Union[ttb.tensor, ttb.sptensor],

--- a/pyttb/gcp_opt.py
+++ b/pyttb/gcp_opt.py
@@ -13,7 +13,6 @@ from pyttb.gcp.optimizers import LBFGSB, StochasticSolver
 from pyttb.gcp.samplers import GCPSampler
 
 
-# pylint: disable=too-many-arguments, too-many-locals, too-many-branches
 def gcp_opt(  # noqa:  PLR0912,PLR0913
     data: Union[ttb.tensor, ttb.sptensor],
     rank: int,

--- a/pyttb/hosvd.py
+++ b/pyttb/hosvd.py
@@ -14,8 +14,6 @@ import scipy
 import pyttb as ttb
 
 
-# pylint: disable=too-many-arguments,too-many-locals,too-many-branches
-# pylint: disable=too-many-statements
 def hosvd(  # noqa: PLR0912,PLR0913,PLR0915
     input_tensor: ttb.tensor,
     tol: float,

--- a/pyttb/import_data.py
+++ b/pyttb/import_data.py
@@ -12,7 +12,6 @@ import numpy as np
 import pyttb as ttb
 
 
-# pylint: disable=too-many-locals
 def import_data(
     filename: str, index_base: int = 1
 ) -> Union[ttb.sptensor, ttb.ktensor, ttb.tensor, np.ndarray]:
@@ -31,7 +30,6 @@ def import_data(
         assert False, f"File path {filename} does not exist."
 
     # import
-    # pylint: disable=unspecified-encoding
     with open(filename, "r") as fp:
         # tensor type should be on the first line
         # valid: tensor, sptensor, matrix, ktensor

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -697,7 +697,6 @@ class ktensor:
         else:
             assert False, "Input parameter must be an int, tuple, list or numpy.ndarray"
 
-    # pylint: disable=too-many-locals,too-many-branches
     def fixsigns(self, other: Optional[ktensor] = None) -> Self:  # noqa: PLR0912
         """
         Change the elements of a :class:`pyttb.ktensor` in place so that the
@@ -1453,7 +1452,6 @@ class ktensor:
         """
         return tuple(f.shape[0] for f in self.factor_matrices)
 
-    # pylint: disable=unused-argument,too-many-locals
     def score(
         self,
         other: ktensor,
@@ -1600,7 +1598,6 @@ class ktensor:
             flag = True
 
             # Rearrange the components of A according to the best matching
-            # pylint: disable=disallowed-name
             foo = np.arange(RA)
             tf = np.in1d(foo, best_perm)
             best_perm[RB : RA + 1] = foo[~tf]

--- a/pyttb/pyttb_utils.py
+++ b/pyttb/pyttb_utils.py
@@ -227,7 +227,6 @@ def tt_dimscheck(
     return sdims, vidx
 
 
-# pylint:disable=too-many-branches
 def tt_tenfun(function_handle, *inputs):  # noqa: PLR0912
     """
     Apply a function to each element in a tensor
@@ -463,7 +462,7 @@ def tt_renumber(
     """
     newshape = np.array(shape)
     newsubs = subs
-    for i in range(0, len(shape)):  # pylint: disable=consider-using-enumerate
+    for i in range(0, len(shape)):
         if not number_range[i] == slice(None, None, None):
             if subs.size == 0:
                 if not isinstance(number_range[i], slice):
@@ -518,7 +517,6 @@ def tt_renumberdim(idx: np.ndarray, shape: int, number_range) -> Tuple[int, int]
 
 # TODO make more efficient, decide if we want to support the multiple response
 #  matlab does
-# pylint: disable=line-too-long
 # https://stackoverflow.com/questions/22699756/python-version-of-ismember-with-rows-and-index
 # For thoughts on how to speed this up
 def tt_ismember_rows(search: np.ndarray, source: np.ndarray) -> np.ndarray:
@@ -575,7 +573,7 @@ def tt_ind2sub(shape: Tuple[int, ...], idx: np.ndarray) -> np.ndarray:
     return np.array(np.unravel_index(idx, shape, order="F")).transpose()
 
 
-def tt_subsubsref(obj, s):  # pylint: disable=unused-argument
+def tt_subsubsref(obj, s):
     """
     Helper function for tensor toolbox subsref.
 

--- a/pyttb/sptenmat.py
+++ b/pyttb/sptenmat.py
@@ -4,7 +4,6 @@
 # U.S. Government retains certain rights in this software.
 
 
-# pylint: disable=too-few-public-methods
 class sptenmat:
     """
     SPTENMAT Store sparse tensor as a sparse matrix.

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -1205,7 +1205,6 @@ class sptensor:
 
         return loc
 
-    # pylint: disable=too-many-branches, too-many-locals
     def ttv(  # noqa: PLR0912
         self,
         vector: Union[np.ndarray, List[np.ndarray]],
@@ -1289,7 +1288,6 @@ class sptensor:
 
         return c
 
-    # pylint: disable=too-many-branches,too-many-statements
     def __getitem__(self, item):  # noqa: PLR0912, PLR0915
         """
         Subscripted reference for a sparse tensor.
@@ -1621,7 +1619,6 @@ class sptensor:
             newshape.append(max(dim, smax))
         self.shape = tuple(newshape)
 
-    # pylint:disable=too-many-statements
     def _set_subtensor(self, key, value):  # noqa: PLR0912, PLR0915
         # Case I(a): RHS is another sparse tensor
         if isinstance(value, ttb.sptensor):
@@ -2100,7 +2097,6 @@ class sptensor:
             return self.__mul__(other)
         assert False, "This object cannot be multiplied by sptensor"
 
-    # pylint:disable=too-many-branches
     def __le__(self, other):  # noqa: PLR0912
         """
         Less than or equal (<=) for sptensor
@@ -2192,7 +2188,6 @@ class sptensor:
         # Otherwise
         assert False, "Cannot compare sptensor with that type"
 
-    # pylint:disable=too-many-branches
     def __lt__(self, other):  # noqa: PLR0912
         """
         Less than (<) for sptensor
@@ -2394,7 +2389,6 @@ class sptensor:
         # Otherwise
         assert False, "Cannot compare sptensor with that type"
 
-    # pylint:disable=too-many-statements, too-many-branches, too-many-locals
     def __truediv__(self, other):  # noqa: PLR0912, PLR0915
         """
         Division for sparse tensors (sptensor/other).

--- a/pyttb/sptensor3.py
+++ b/pyttb/sptensor3.py
@@ -4,7 +4,6 @@
 # U.S. Government retains certain rights in this software.
 
 
-# pylint: disable=too-few-public-methods
 class sptensor3:
     """
     SPTENSOR3 a sparse tensor variant.

--- a/pyttb/sumtensor.py
+++ b/pyttb/sumtensor.py
@@ -4,7 +4,6 @@
 # U.S. Government retains certain rights in this software.
 
 
-# pylint: disable=too-few-public-methods
 class sumtensor:
     """
     SUMTENSOR Class for implicit sum of other tensors.

--- a/pyttb/symktensor.py
+++ b/pyttb/symktensor.py
@@ -4,7 +4,6 @@
 # U.S. Government retains certain rights in this software.
 
 
-# pylint: disable=too-few-public-methods
 class symktensor:
     """
     SYMKTENSOR Class for symmetric Kruskal tensors (decomposed).

--- a/pyttb/symtensor.py
+++ b/pyttb/symtensor.py
@@ -4,7 +4,6 @@
 # U.S. Government retains certain rights in this software.
 
 
-# pylint: disable=too-few-public-methods
 class symtensor:
     """
     SYMTENSOR Class for storing only unique entries of symmetric tensor.

--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -109,7 +109,6 @@ class tenmat:
         )
 
     @classmethod
-    # pylint: disable=too-many-branches
     def from_tensor_type(  # noqa: PLR0912
         cls,
         source: Union[ttb.tensor, tenmat],

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -427,7 +427,6 @@ class tensor:
         return False
 
     # TODO: We should probably always return details and let caller drop them
-    # pylint: disable=too-many-branches, too-many-locals
     def issymmetric(  # noqa: PLR0912
         self,
         grps: Optional[np.ndarray] = None,
@@ -480,7 +479,7 @@ class tensor:
         # Substantially different routines are called depending on whether the user
         # requests the permutation information. If permutation is required
         # (or requested) the algorithm is much slower
-        if version is None:  # pylint:disable=no-else-return
+        if version is None:
             # Use new algorithm
             for thisgrp in grps:
                 # Check tensor dimensions first
@@ -644,7 +643,6 @@ class tensor:
         # Extract those non-zero values
         return self.data[tuple(wsubs.transpose())]
 
-    # pylint: disable=too-many-branches
     def mttkrp(  # noqa: PLR0912
         self, U: Union[ttb.ktensor, List[np.ndarray]], n: int
     ) -> np.ndarray:
@@ -713,7 +711,7 @@ class tensor:
             Ur = ttb.khatrirao(*U[1 : self.ndims], reverse=True)
             Y = np.reshape(self.data, (szn, szr), order="F")
             return Y @ Ur
-        if n == self.ndims - 1:  # pylint: disable=no-else-return
+        if n == self.ndims - 1:
             Ul = ttb.khatrirao(*U[0 : self.ndims - 1], reverse=True)
             Y = np.reshape(self.data, (szl, szn), order="F")
             return Y.T @ Ul
@@ -738,8 +736,6 @@ class tensor:
         if isinstance(U, ttb.ktensor):
             U = U.factor_matrices
         split_idx = min_split(self.shape)
-        # Pylint seems confused here
-        # pylint: disable=unexpected-keyword-arg
         V = [np.empty_like(self.data, shape=())] * self.ndims
         K = ttb.khatrirao(*U[split_idx + 1 :], reverse=True)
         W = np.reshape(self.data, (-1, K.shape[0]), order="F").dot(K)
@@ -921,7 +917,7 @@ class tensor:
 
         """
         shapeArray = np.array(self.shape)
-        if np.all(shapeArray > 1):  # pylint: disable=no-else-return
+        if np.all(shapeArray > 1):
             return ttb.tensor.from_tensor_type(self)
         else:
             idx = np.where(shapeArray > 1)
@@ -931,9 +927,7 @@ class tensor:
 
     def symmetrize(  # noqa: PLR0912,PLR0915
         self, grps: Optional[np.ndarray] = None, version: Optional[Any] = None
-    ) -> (
-        tensor
-    ):  # pylint: disable=too-many-branches, too-many-statements, too-many-locals
+    ) -> tensor:
         """
         Symmetrize a tensor in the specified modes
         Notes
@@ -963,7 +957,7 @@ class tensor:
         data = self.data.copy()
 
         # Use default newer faster version
-        if version is None:  # pylint: disable=no-else-return
+        if version is None:
             ngrps = len(grps)
             for i in range(0, ngrps):
                 # Extract current group
@@ -1286,7 +1280,6 @@ class tensor:
             d = self.ndims
             sz = self.shape[0]  # Sizes of all modes must be the same
 
-            # pylint: disable=invalid-unary-operand-type
             dnew = skip_dim + 1  # Number of modes in result
             drem = d - dnew  # Number of modes multiplied out
 

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -37,7 +37,6 @@ class ttensor:
         # Empty constructor
         # TODO explore replacing with typing protocol
         self.core: Union[ttb.tensor, ttb.sptensor] = ttb.tensor()
-        # pylint: disable=invalid-name
         self.u: List[np.ndarray] = []
         # TODO consider factor_matrices to match ktensor
 
@@ -500,7 +499,6 @@ class ttensor:
 
         return ttensor.from_data(self.core, new_u)
 
-    # pylint: disable=too-many-branches
     def reconstruct(  # noqa: PLR0912
         self,
         samples: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
@@ -573,7 +571,6 @@ class ttensor:
 
         return ttensor.from_data(self.core, new_u).full()
 
-    # pylint: disable=too-many-branches,too-many-locals
     def nvecs(  # noqa: PLR0912
         self, n: int, r: int, flipsign: bool = True
     ) -> np.ndarray:

--- a/pyttb/tucker_als.py
+++ b/pyttb/tucker_als.py
@@ -13,8 +13,6 @@ import pyttb as ttb
 from pyttb.ttensor import ttensor
 
 
-# pylint: disable=too-many-arguments,too-many-locals,too-many-branches
-# pylint: disable=too-many-statements
 def tucker_als(  # noqa: PLR0912,PLR0913,PLR0915
     input_tensor: ttb.tensor,
     rank: Union[int, List[int], np.ndarray],

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,8 +6,6 @@
 import os
 import subprocess
 
-import pytest
-
 import pyttb as ttb
 
 
@@ -19,8 +17,8 @@ def test_package_smoke():
     ttb.ignore_warnings(True)
 
 
-def test_ruff_linting():
-    """Confirm linting of the project is enforce"""
+def test_linting():
+    """Confirm linting of the project is enforced"""
     root_dir = os.path.dirname(os.path.dirname(__file__))
     toml_file = os.path.join(root_dir, "pyproject.toml")
     subprocess.run(
@@ -30,31 +28,6 @@ def test_ruff_linting():
     )
 
 
-@pytest.mark.packaging
-def test_formatting():
-    """Confirm formatting of the project is consistent"""
-
-    source_dir = os.path.dirname(ttb.__file__)
-    root_dir = os.path.dirname(source_dir)
-    subprocess.run(
-        f"isort {root_dir} --check --settings-path {root_dir}", check=True, shell=True
-    )
-    subprocess.run(f"black --check {root_dir}", check=True, shell=True)
-
-
-@pytest.mark.packaging
-def test_linting():
-    """Confirm linting of the project is enforce"""
-    root_dir = os.path.dirname(os.path.dirname(__file__))
-    toml_file = os.path.join(root_dir, "pyproject.toml")
-    subprocess.run(
-        f"pylint {os.path.join(root_dir, 'pyttb')} --rcfile {toml_file} -j0",
-        check=True,
-        shell=True,
-    )
-
-
-@pytest.mark.packaging
 def test_typing():
     """Run type checker on package"""
     root_dir = os.path.dirname(os.path.dirname(__file__))


### PR DESCRIPTION
Follow up to: https://github.com/sandialabs/pyttb/pull/211

Remove isort and pylint from the repo after the addition of ruff:
   * Remove packaging from dev deps
   * Remove tests that run them (ci and pytest)
   * Remove packaging pytest marker now that things run fast by default
   * Add python 3.11 to test combinations
   * Remove all the pylint disabled lines