### PR TITLE
Sptensor innerprod float

### DIFF
--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -644,14 +644,14 @@ class sptensor:
             else:
                 [subsOther, valsOther] = other.find()
                 valsSelf = self.extract(subsOther)
-            return valsOther.transpose().dot(valsSelf)
+            return valsOther.transpose().dot(valsSelf).item()
 
         if isinstance(other, ttb.tensor):
             if self.shape != other.shape:
                 assert False, "Sptensor and tensor must be same shape for innerproduct"
             [subsSelf, valsSelf] = self.find()
             valsOther = other[subsSelf]
-            return valsOther.transpose().dot(valsSelf)
+            return valsOther.transpose().dot(valsSelf).item()
 
         if isinstance(other, (ttb.ktensor, ttb.ttensor)):  # pragma: no cover
             # Reverse arguments to call ktensor/ttensor implementation

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -1103,15 +1103,17 @@ def test_sptensor_innerprod(sample_sptensor):
     assert emptySptensor.innerprod(sptensorInstance) == 0
 
     # Sptensor innerproduct
-    assert sptensorInstance.innerprod(sptensorInstance) == data["vals"].transpose().dot(
-        data["vals"]
+    assert np.array_equal(
+        sptensorInstance.innerprod(sptensorInstance),
+        data["vals"].squeeze().dot(data["vals"].squeeze()),
     )
 
     # Sptensor innerproduct, other has more elements
     sptensorCopy = sptensorInstance.copy()
     sptensorCopy[0, 0, 0] = 1
-    assert sptensorInstance.innerprod(sptensorCopy) == data["vals"].transpose().dot(
-        data["vals"]
+    assert np.array_equal(
+        sptensorInstance.innerprod(sptensorCopy),
+        data["vals"].squeeze().dot(data["vals"].squeeze()),
     )
 
     # Wrong shape sptensor
@@ -1121,9 +1123,10 @@ def test_sptensor_innerprod(sample_sptensor):
     assert "Sptensors must be same shape for innerproduct" in str(excinfo)
 
     # Tensor innerproduct
-    assert sptensorInstance.innerprod(sptensorInstance.to_tensor()) == data[
-        "vals"
-    ].transpose().dot(data["vals"])
+    assert np.array_equal(
+        sptensorInstance.innerprod(sptensorInstance.to_tensor()),
+        data["vals"].squeeze().dot(data["vals"].squeeze()),
+    )
 
     # Wrong shape tensor
     with pytest.raises(AssertionError) as excinfo:


### PR DESCRIPTION
Should resolve #215 we made things column vectors in sptensor to match MATLAB. We may want to consider just making them flat 1-D vectors in the future to simplify, OR something I haven't written up anywhere is that tensorly uses [this](https://sparse.pydata.org/en/stable/) sparse package for their numpy backend. Might be worth investigating post 2.0.

In the meantime this resolves and I updated our test to enforce this stays resolved. Similar to my previous note where I moved lots of things to np.array_equal continuing to rely on that is probably useful to resolve scalar vs single element in arrays of various inflated shapes.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--217.org.readthedocs.build/en/217/

<!-- readthedocs-preview pyttb end -->