### PR TITLE
Ktensor tutorial cleanup

### DIFF
--- a/docs/source/tutorial/class_ktensor.ipynb
+++ b/docs/source/tutorial/class_ktensor.ipynb
@@ -362,15 +362,6 @@
    "outputs": [],
    "source": [
     "X = generate_sample_ktensor()\n",
-    "X[0][0][0] # Assemble the (0,0,0) element"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "X.weights[1] # Weight of the 2nd factor."
    ]
   },
@@ -381,15 +372,6 @@
    "outputs": [],
    "source": [
     "X.factor_matrices[1] # Extract a matrix."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X[1] # Same as above."
    ]
   },
   {
@@ -411,13 +393,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### <font color='red'>**TODO:** : Depends on Open Issue</font> (https://github.com/sandialabs/pyttb/issues/165)"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -432,18 +407,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X[2][:,[0]] = np.ones((2,1))\n",
-    "X[2][:,[0]]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "X.factor_matrices[2][:, [0]] = np.ones((2,1)) # Change the matrix for mode 3.\n",
-    "X[2][:,[0]]"
+    "X"
    ]
   },
   {
@@ -460,7 +425,7 @@
    "outputs": [],
    "source": [
     "X = generate_sample_ktensor()\n",
-    "X[1:2,-1:,:]\n",
+    "X.factor_matrices[0][-1:,:]\n",
     "X.shape"
    ]
   },
@@ -471,7 +436,7 @@
    "outputs": [],
    "source": [
     "X = generate_sample_ktensor()\n",
-    "X[0][0][1:(np.prod(X.shape)-1)].item() # Calculates X[0][0][1]"
+    "X.factor_matrices[0][0][1:(np.prod(X.shape)-1)].item() # Calculates factor_matrix[0][1]"
    ]
   },
   {
@@ -661,13 +626,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### <font color='red'>**TODO:** : Depends on Open Issue</font> (https://github.com/sandialabs/pyttb/issues/167)"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -684,8 +642,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "[U,S,V] = np.linalg.svd(A, full_matrices=False) # Compute the SVD.\n",
-    "X = ttb.ktensor([U, V], S) # Store the SVD as a ktensor.\n",
+    "[U,S,Vh] = np.linalg.svd(A, full_matrices=False) # Compute the SVD.\n",
+    "# Numpy Expects U*S*Vh where pyttb expects U*S*V'\n",
+    "X = ttb.ktensor([U, Vh.transpose()], S) # Store the SVD as a ktensor.\n",
     "X"
    ]
   },
@@ -695,9 +654,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"U*S*V:\\n{U@np.diag(S)@V}\")\n",
-    "print(f\"\\nX.factor_matrices[0]@np.diag(X.weights)@X.factor_matrices[1]:\\n\\\n",
-    "{X.factor_matrices[0]@np.diag(X.weights)@X.factor_matrices[1]}\")\n",
+    "print(f\"U*S*Vh:\\n{U@np.diag(S)@Vh}\")\n",
+    "print(f\"\\nX.factor_matrices[0]@np.diag(X.weights)@(X.factor_matrices[1].transpose()):\\n\\\n",
+    "{X.factor_matrices[0]@np.diag(X.weights)@(X.factor_matrices[1].transpose())}\")\n",
     "print(f\"\\nX.full():\\n{X.full()}\") # Reassemble the original matrix."
    ]
   },

--- a/pyttb/cp_apr.py
+++ b/pyttb/cp_apr.py
@@ -256,7 +256,7 @@ def tt_cp_apr_mu(  # noqa: PLR0912,PLR0913,PLR0915
     Phi = []  # np.zeros((N,))#cell(N,1)
     for n in range(N):
         # TODO prepopulation Phi instead of appen should be faster
-        Phi.append(np.zeros(M[n].shape))
+        Phi.append(np.zeros(M.factor_matrices[n].shape))
     kktModeViolations = np.zeros((N,))
 
     if printitn > 0:
@@ -277,7 +277,7 @@ def tt_cp_apr_mu(  # noqa: PLR0912,PLR0913,PLR0915
             # slackness conditions.
             # TODO both these zeros were 1 in matlab
             if iteration > 0:
-                V = (Phi[n] > 0) & (M[n] < kappatol)
+                V = (Phi[n] > 0) & (M.factor_matrices[n] < kappatol)
                 if np.any(V):
                     nViolations[iteration] += 1
                     M.factor_matrices[n][V > 0] += kappa
@@ -457,10 +457,10 @@ def tt_cp_apr_pdnr(  # noqa: PLR0912,PLR0913,PLR0915
     # subproblem is not taking log(0). Values will be restored to zero later if the
     # unfolded X for the row has no zeros.
     for n in range(N):
-        rowsum = np.sum(init[n], axis=1)
+        rowsum = np.sum(init.factor_matrices[n], axis=1)
         tmpIdx = np.where(rowsum == 0)[0]
         if tmpIdx.size != 0:
-            init[n][tmpIdx, 0] = 1e-8
+            init.factor_matrices[n][tmpIdx, 0] = 1e-8
 
     # Start with the initial guess, normalized using the vector L1 norm
     M = init.copy()
@@ -492,7 +492,7 @@ def tt_cp_apr_pdnr(  # noqa: PLR0912,PLR0913,PLR0915
             print("\tPrecomuting sparse index sets...")
         sparseIx = []
         for n in range(N):
-            num_rows = M[n].shape[0]
+            num_rows = M.factor_matrices[n].shape[0]
             row_indices = []
             for jj in range(num_rows):
                 row_indices.append(np.where(input_tensor.subs[:, n] == jj)[0])
@@ -522,7 +522,7 @@ def tt_cp_apr_pdnr(  # noqa: PLR0912,PLR0913,PLR0915
                 Pi = tt_calcpi_prowsubprob(input_tensor, M, rank, n, N, isSparse)
                 X_mat = tt_to_dense_matrix(input_tensor, n)
 
-            num_rows = M[n].shape[0]
+            num_rows = M.factor_matrices[n].shape[0]
             isRowNOTconverged = np.zeros((num_rows,))
 
             # Loop over the row subproblems in mode n.
@@ -554,7 +554,7 @@ def tt_cp_apr_pdnr(  # noqa: PLR0912,PLR0913,PLR0915
                     x_row = X_mat[jj, :]
 
                 # Get current values of the row subproblem variables.
-                m_row = M[n][jj, :]
+                m_row = M.factor_matrices[n][jj, :]
 
                 # Iteratively solve the row subproblem with projected Newton steps.
                 if inexact and iteration == 1:
@@ -663,7 +663,7 @@ def tt_cp_apr_pdnr(  # noqa: PLR0912,PLR0913,PLR0915
         # Save output items for the outer iteration.
         num_zero = 0
         for n in range(N):
-            num_zero += np.count_nonzero(M[n] == 0)  # [0].size
+            num_zero += np.count_nonzero(M.factor_matrices[n] == 0)  # [0].size
 
         nzeros[iteration] = num_zero
         kktViolations[iteration] = np.max(kktModeViolations)
@@ -816,10 +816,10 @@ def tt_cp_apr_pqnr(  # noqa: PLR0912,PLR0913,PLR0915
     # subproblem is not taking log(0). Values will be restored to zero later if the
     # unfolded X for the row has no zeros.
     for n in range(N):
-        rowsum = np.sum(init[n], axis=1)
+        rowsum = np.sum(init.factor_matrices[n], axis=1)
         tmpIdx = np.where(rowsum == 0)[0]
         if tmpIdx.size != 0:
-            init[n][tmpIdx, 0] = 1e-8
+            init.factor_matrices[n][tmpIdx, 0] = 1e-8
 
     # Start with the initial guess, normalized using the vector L1 norm
     M = init.copy()
@@ -851,7 +851,7 @@ def tt_cp_apr_pqnr(  # noqa: PLR0912,PLR0913,PLR0915
             print("\tPrecomuting sparse index sets...")
         sparseIx = []
         for n in range(N):
-            num_rows = M[n].shape[0]
+            num_rows = M.factor_matrices[n].shape[0]
             row_indices = []
             for jj in range(num_rows):
                 row_indices.append(np.where(input_tensor.subs[:, n] == jj)[0])
@@ -877,7 +877,7 @@ def tt_cp_apr_pqnr(  # noqa: PLR0912,PLR0913,PLR0915
                 Pi = tt_calcpi_prowsubprob(input_tensor, M, rank, n, N, isSparse)
                 X_mat = tt_to_dense_matrix(input_tensor, n)
 
-            num_rows = M[n].shape[0]
+            num_rows = M.factor_matrices[n].shape[0]
             isRowNOTconverged = np.zeros((num_rows,))
 
             # Loop over the row subproblems in mode n.
@@ -906,7 +906,7 @@ def tt_cp_apr_pqnr(  # noqa: PLR0912,PLR0913,PLR0915
                     x_row = X_mat[jj, :]
 
                 # Get current values of the row subproblem variables.
-                m_row = M[n][jj, :]
+                m_row = M.factor_matrices[n][jj, :]
 
                 # Initialize L-BFGS storage for the row subproblem.
                 delm = np.zeros((rank, lbfgsMem))
@@ -1062,7 +1062,7 @@ def tt_cp_apr_pqnr(  # noqa: PLR0912,PLR0913,PLR0915
         # Save output items for the outer iteration.
         num_zero = 0
         for n in range(N):
-            num_zero += np.count_nonzero(M[n] == 0)  # [0].size
+            num_zero += np.count_nonzero(M.factor_matrices[n] == 0)  # [0].size
 
         nzeros[iteration] = num_zero
         kktViolations[iteration] = np.max(kktModeViolations)
@@ -1206,7 +1206,7 @@ def tt_calcpi_prowsubprob(  # noqa: PLR0913
 
         Pi = np.ones((num_row_nnz, rank))
         for i in np.setdiff1d(np.arange(ndims), factorIndex).astype(int):
-            Pi *= Model[i][Data.subs[sparse_indices, i], :]
+            Pi *= Model.factor_matrices[i][Data.subs[sparse_indices, i], :]
     else:
         Pi = ttb.khatrirao(
             *(
@@ -1735,7 +1735,7 @@ def calculate_pi(
     if isinstance(Data, ttb.sptensor):
         Pi = np.ones((Data.nnz, rank))
         for i in np.setdiff1d(np.arange(ndims), factorIndex).astype(int):
-            Pi *= Model[i][Data.subs[:, i], :]
+            Pi *= Model.factor_matrices[i][Data.subs[:, i], :]
     else:
         Pi = ttb.khatrirao(
             *(

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -2140,64 +2140,6 @@ class ktensor:
             )
         return ttb.ktensor(factor_matrices, weights)
 
-    def __getitem__(self, item):
-        """
-        Subscripted reference for a :class:`pyttb.ktensor`.
-
-        Subscripted reference is used to query the components of a
-        :class:`pyttb.ktensor`.
-
-        Parameters
-        ----------
-        item: tuple(int) or int, required
-
-        Examples
-        --------
-        >>> K = ttb.ktensor.from_function(np.ones, (2, 3, 4), 2)
-        >>> K.weights
-        array([1., 1.])
-        >>> K.factor_matrices
-        [array([[1., 1.],
-               [1., 1.]]), array([[1., 1.],
-               [1., 1.],
-               [1., 1.]]), array([[1., 1.],
-               [1., 1.],
-               [1., 1.],
-               [1., 1.]])]
-        >>> K.factor_matrices[0]
-        array([[1., 1.],
-               [1., 1.]])
-        >>> K[0]
-        array([[1., 1.],
-               [1., 1.]])
-        >>> K[1, 2, 0]
-        2.0
-        >>> K[0][:, [0]]
-        array([[1.],
-               [1.]])
-        """
-        if isinstance(item, tuple):
-            if len(item) == self.ndims:
-                # Extract single element
-                a = 0
-                for k in range(self.ncomponents):
-                    b = self.weights[k]
-                    for i in range(self.ndims):
-                        b = b * self.factor_matrices[i][item[i], k]
-                    a = a + b
-                return a
-            assert (
-                False
-            ), f"ktensor.__getitem__ requires tuples with {self.ndims} elements"
-        elif isinstance(item, (int, np.int_)) and item in range(self.ndims):
-            # Extract factor matrix
-            return self.factor_matrices[item].copy()
-        else:
-            assert False, (
-                "ktensor.__getitem__() can only extract single elements (tuple of "
-                "indices) or factor matrices (single index)"
-            )
-
     def __neg__(self):
         """
         Unary minus (negative) for :class:`pyttb.ktensor` instances.
@@ -2217,49 +2159,6 @@ class ktensor:
         :class:`pyttb.ktensor`
         """
         return self.copy()
-
-    def __setitem__(self, key, value):
-        """
-        Subscripted assignment for :class:`pyttb.ktensor`.
-
-        Subscripted assignment cannot be used to update individual elements of
-        a :class:`pyttb.ktensor`. You can update the weights vector or the
-        factor matrices of a :class:`pyttb.ktensor`.
-
-        Example
-        -------
-        >>> random = np.random.random
-        >>> factors = [random((2,4)), random((3,4)), random((4,4))]
-        >>> weights = np.ones((4,))
-        >>> K = ttb.ktensor(factors, weights)
-        >>> K.weights = 2 * np.ones((4,1))
-        >>> K.factor_matrices[0] = np.zeros((2, 4))
-        >>> K.factor_matrices = [np.zeros((2, 4)), np.zeros((3, 4)), np.zeros((4, 4))]
-        >>> print(K)
-        ktensor of shape (2, 3, 4)
-        weights=[[2.]
-         [2.]
-         [2.]
-         [2.]]
-        factor_matrices[0] =
-        [[0. 0. 0. 0.]
-         [0. 0. 0. 0.]]
-        factor_matrices[1] =
-        [[0. 0. 0. 0.]
-         [0. 0. 0. 0.]
-         [0. 0. 0. 0.]]
-        factor_matrices[2] =
-        [[0. 0. 0. 0.]
-         [0. 0. 0. 0.]
-         [0. 0. 0. 0.]
-         [0. 0. 0. 0.]]
-        """
-        assert False, (
-            "Subscripted assignment cannot be used to update individual elements of a "
-            "ktensor. However, you can update the weights vector or the factor "
-            "matrices of a ktensor. The entire factor matrix or weight vector must be "
-            "provided."
-        )
 
     def __sub__(self, other):
         """

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -2068,7 +2068,7 @@ class sptensor:
                 for n in range(N):
                     # Note other[n][:, r] extracts 1-D instead of column vector,
                     # which necessitates [:, None]
-                    v = other[n][:, r][:, None]
+                    v = other.factor_matrices[n][:, r][:, None]
                     tvals = tvals * v[csubs[:, n]]
                 cvals += tvals
             return ttb.sptensor(csubs, cvals, self.shape)
@@ -2467,7 +2467,7 @@ class sptensor:
             for r in range(R):
                 tvals = np.ones(((vals).size, 1)).dot(other.weights[r])
                 for n in range(N):
-                    v = other[n][:, r][:, None]
+                    v = other.factor_matrices[n][:, r][:, None]
                     tvals = tvals * v[subs[:, n]]
                 vals += tvals
             return ttb.sptensor(

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -415,6 +415,8 @@ class ttensor:
         # NOTE: MATLAB version calculates an unused R here
 
         W = [np.empty(())] * self.ndims
+        if isinstance(U, ttb.ktensor):
+            U = U.factor_matrices
         for i in range(0, self.ndims):
             if i == n:
                 continue

--- a/tests/test_cp_apr.py
+++ b/tests/test_cp_apr.py
@@ -300,19 +300,27 @@ def test_calc_partials():
     Pi = calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     # TODO: These are just verifying same functionality as matlab
     phi, ups = calc_partials(
-        False, Pi, 1e-12, tensorInstance[0, :].data, ktensorInstance[0][0, :]
+        False,
+        Pi,
+        1e-12,
+        tensorInstance[0, :].data,
+        ktensorInstance.factor_matrices[0][0, :],
     )
     assert np.isclose(phi, np.array([0, 0])).all()
     assert np.isclose(ups, np.array([0, 0])).all()
 
     phi, ups = calc_partials(
-        False, Pi, 1e-12, tensorInstance[1, :].data, ktensorInstance[0][0, :]
+        False,
+        Pi,
+        1e-12,
+        tensorInstance[1, :].data,
+        ktensorInstance.factor_matrices[0][0, :],
     )
     assert np.isclose(phi, 1e14 * np.array([5.95, 9.68])).all()
     assert np.isclose(ups, 1e13 * np.array([4.8, 8.5])).all()
 
     phi, ups = calc_partials(
-        True, Pi, 1e-12, sptensorInstance.vals, ktensorInstance[0][0, :]
+        True, Pi, 1e-12, sptensorInstance.vals, ktensorInstance.factor_matrices[0][0, :]
     )
     assert np.isclose(phi, 1e14 * np.array([5.95, 9.68])).all()
     assert np.isclose(ups, 1e13 * np.array([4.8, 8.5])).all()
@@ -363,7 +371,11 @@ def test_getHessian():
     sptensorInstance = tensorInstance.to_sptensor()
     Pi = calculate_pi(sptensorInstance, ktensorInstance, rank, 0, tensorInstance.ndims)
     phi, ups = calc_partials(
-        False, Pi, 1e-12, tensorInstance[1, :].data, ktensorInstance[0][0, :]
+        False,
+        Pi,
+        1e-12,
+        tensorInstance[1, :].data,
+        ktensorInstance.factor_matrices[0][0, :],
     )
     Hessian = get_hessian(ups, Pi, free_indices)
     assert np.allclose(Hessian, Hessian.transpose())
@@ -404,7 +416,7 @@ def test_getSearchDirPdnr():
     # print(tensorInstance[:, 0])
     sptensorInstance = tensorInstance.to_sptensor()
     data_row = tensorInstance[1, :].data
-    model_row = ktensorInstance[0][0, :]
+    model_row = ktensorInstance.factor_matrices[0][0, :]
     Pi = calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     phi, ups = calc_partials(False, Pi, 1e-12, data_row, model_row)
     search, pred = get_search_dir_pdnr(Pi, ups, 2, phi, model_row, 0.1, 1e-6)
@@ -462,7 +474,11 @@ def test_tt_linesearch_prowsubprob():
     sptensorInstance = tensorInstance.to_sptensor()
     Pi = calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     phi, ups = calc_partials(
-        False, Pi, 1e-12, tensorInstance[1, :].data, ktensorInstance[0][0, :]
+        False,
+        Pi,
+        1e-12,
+        tensorInstance[1, :].data,
+        ktensorInstance.factor_matrices[0][0, :],
     )
     search, pred = get_search_dir_pdnr(
         Pi, ups, 2, phi, tensorInstance[1, :].data, 0.1, 1e-6
@@ -498,7 +514,7 @@ def test_getSearchDirPqnr():
     # print(tensorInstance[:, 0])
     sptensorInstance = tensorInstance.to_sptensor()
     data_row = tensorInstance[1, :].data
-    model_row = ktensorInstance[0][0, :]
+    model_row = ktensorInstance.factor_matrices[0][0, :]
     Pi = calculate_pi(sptensorInstance, ktensorInstance, 2, 0, tensorInstance.ndims)
     phi, ups = calc_partials(False, Pi, 1e-12, data_row, model_row)
     delta_model = np.random.normal(size=(2, model_row.shape[0]))

--- a/tests/test_ktensor.py
+++ b/tests/test_ktensor.py
@@ -793,8 +793,8 @@ def test_ktensor_permute(sample_ktensor_3way):
 def test_ktensor_redistribute(sample_ktensor_2way):
     (data, K) = sample_ktensor_2way
     K.redistribute(0)
-    assert np.array_equal(np.array([[1, 4], [3, 8]]), K[0])
-    assert np.array_equal(np.array([[5, 6], [7, 8]]), K[1])
+    assert np.array_equal(np.array([[1, 4], [3, 8]]), K.factor_matrices[0])
+    assert np.array_equal(np.array([[5, 6], [7, 8]]), K.factor_matrices[1])
     assert np.array_equal(np.array([1, 1]), K.weights)
 
 
@@ -1131,28 +1131,6 @@ def test_ktensor__add__(sample_ktensor_2way, sample_ktensor_3way):
     assert "Cannot add instance of this type to a ktensor" in str(excinfo)
 
 
-def test_ktensor__getitem__(sample_ktensor_2way):
-    (data, K) = sample_ktensor_2way
-    # adding ktensor to itself
-    assert K[0, 0] == 29
-    assert K[0, 1] == 39
-    assert K[1, 0] == 63
-    assert K[1, 1] == 85
-    assert np.array_equal(data["factor_matrices"][0], K[0])
-    assert np.array_equal(data["factor_matrices"][1], K[1])
-    # to return a 2D ndarray, the columns must be defined by a slice
-    assert np.array_equal(data["factor_matrices"][0][:, [0]], K[0][:, [0]])
-    with pytest.raises(AssertionError) as excinfo:
-        K[0, 0, 0]
-    assert "ktensor.__getitem__ requires tuples with 2 elements" in str(excinfo)
-    with pytest.raises(AssertionError) as excinfo:
-        K[5]
-    assert (
-        "ktensor.__getitem__() can only extract single elements (tuple of indices) or factor matrices (single index)"
-        in str(excinfo)
-    )
-
-
 def test_ktensor__neg__(sample_ktensor_2way):
     (data0, K0) = sample_ktensor_2way
     # adding ktensor to itself
@@ -1172,17 +1150,6 @@ def test_ktensor__pos__(sample_ktensor_2way):
     for k in range(K1.ndims):
         assert np.array_equal(data0["factor_matrices"][k], K1.factor_matrices[k])
     assert K1.isequal(K0)
-
-
-def test_ktensor__setitem__(sample_ktensor_2way):
-    (data, K) = sample_ktensor_2way
-    # adding ktensor to itself
-    with pytest.raises(AssertionError) as excinfo:
-        K[0, 0] = 1
-    assert (
-        "Subscripted assignment cannot be used to update individual elements of a ktensor."
-        in str(excinfo)
-    )
 
 
 def test_ktensor__sub__(sample_ktensor_2way, sample_ktensor_3way):


### PR DESCRIPTION
Resolves: https://github.com/sandialabs/pyttb/issues/165 by removing getitem and setitem from ktensor. The interpretation for ktensor is different than tensor and sptensor. This brings ktensor closer in line with ttensor and reduces the surface we have to cover.

Resolves: https://github.com/sandialabs/pyttb/issues/168 by incorporating the index changes above and the note from https://github.com/sandialabs/pyttb/issues/167

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--220.org.readthedocs.build/en/220/

<!-- readthedocs-preview pyttb end -->