### PR TITLE
Nick/tensor scale

### DIFF
--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -12,7 +12,7 @@ import pyttb as ttb
 
 
 def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
-    input_tensor: Union[ttb.tensor, ttb.sptensor],
+    input_tensor: Union[ttb.tensor, ttb.sptensor, ttb.ttensor],
     rank: int,
     stoptol: float = 1e-4,
     maxiters: int = 1000,

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -1055,14 +1055,18 @@ class sptensor:
             tuple(np.concatenate((keep_shape, new_shape))),
         )
 
-    def scale(self, factor: np.ndarray, dims: Union[float, np.ndarray]) -> sptensor:
+    def scale(
+        self,
+        factor: Union[np.ndarray, ttb.tensor, ttb.sptensor],
+        dims: Union[float, np.ndarray],
+    ) -> sptensor:
         """
         Scale along specified dimensions for sparse tensors
 
         Parameters
         ----------
-        factor:
-        dims:
+        factor: Scaling factor
+        dims: Dimensions to scale
 
         Returns
         -------

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1059,7 +1059,7 @@ class tensor:
         elif isinstance(dims, (float, int, np.generic)):
             dims = np.array([dims])
 
-        # TODO example tt_dimscheck overload so I don't need explicit
+        # TODO update tt_dimscheck overload so I don't need explicit
         #   Nones to appease mypy
         dims, _ = tt_dimscheck(self.ndims, None, dims, None)
         remdims = np.setdiff1d(np.arange(0, self.ndims), dims)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1090,6 +1090,25 @@ def test_tensor_mask(sample_tensor_2way):
     assert "Mask cannot be bigger than the data tensor" in str(excinfo)
 
 
+def test_tensor_scale():
+    T = ttb.tenones((3, 4, 5))
+    S = np.arange(5, dtype=float)
+    Y = T.scale(S, 2)
+    assert np.array_equal(Y.data[0, 0, :], S)
+
+    S = ttb.tensor(np.arange(5, dtype=float))
+    Y = T.scale(S, 2)
+    assert np.array_equal(Y.data[0, 0, :], S.data)
+
+    S = ttb.tensor(np.arange(12, dtype=float), shape=(3, 4))
+    Y = T.scale(S, [0, 1])
+    assert np.array_equal(Y.data[:, :, 0], S.data)
+
+    S = ttb.tensor(np.arange(60, dtype=float), shape=(3, 4, 5))
+    Y = T.scale(S, [0, 1, 2])
+    assert np.array_equal(Y.data, S.data)
+
+
 def test_tensor_squeeze(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1108,6 +1108,11 @@ def test_tensor_scale():
     Y = T.scale(S, [0, 1, 2])
     assert np.array_equal(Y.data, S.data)
 
+    # Negative test
+    with pytest.raises(ValueError):
+        S = ttb.tensor(np.arange(60, dtype=float), shape=(3, 4, 5))
+        Y = T.scale(S, 0)
+
 
 def test_tensor_squeeze(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way


### PR DESCRIPTION
Should resolve https://github.com/sandialabs/pyttb/issues/76 since I believe things should just work out of the box with interface similarities. Let me know if you saw a bug or ran into some issue I didn't capture.

Added a limited coverage of scale consistent with our sptensor interface which should resolve https://github.com/sandialabs/pyttb/issues/26. I don't know the full usage so unclear if having exclude dims as well is a must have. Left a few todos where we could probably improve our tt_dimscheck and one weird reshaping issue that I didn't root cause if it was a column vs row thing or C vs Fortran layout thing.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--221.org.readthedocs.build/en/221/

<!-- readthedocs-preview pyttb end -->