### PR TITLE
Teneye: Add preliminary implementation and tests

### DIFF
--- a/pyttb/__init__.py
+++ b/pyttb/__init__.py
@@ -24,7 +24,7 @@ from pyttb.sumtensor import sumtensor
 from pyttb.symktensor import symktensor
 from pyttb.symtensor import symtensor
 from pyttb.tenmat import tenmat
-from pyttb.tensor import tendiag, tenones, tenrand, tensor, tenzeros
+from pyttb.tensor import tendiag, teneye, tenones, tenrand, tensor, tenzeros
 from pyttb.ttensor import ttensor
 from pyttb.tucker_als import tucker_als
 
@@ -57,6 +57,7 @@ __all__ = [  # noqa: PLE0604
     sumtensor.__name__,
     symktensor.__name__,
     symtensor.__name__,
+    teneye.__name__,
     tenmat.__name__,
     tendiag.__name__,
     tenones.__name__,

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from itertools import permutations
+from itertools import combinations_with_replacement, permutations
 from math import factorial
 from typing import Any, Callable, List, Optional, Tuple, Union
 
@@ -401,7 +401,7 @@ class tensor:
          [3 4]]
         >>> T_threshold = T > 2
         >>> subs, vals = T_threshold.find()
-        >>> subs
+        >>> subs.astype(int)
         array([[1, 0],
                [1, 1]])
         >>> vals
@@ -2484,6 +2484,53 @@ def tendiag(elements: np.ndarray, shape: Optional[Tuple[int, ...]] = None) -> te
     subs = np.tile(np.arange(0, N)[:, None], (len(constructed_shape),))
     X[subs] = elements
     return X
+
+
+def teneye(order: int, size: int) -> tensor:
+    """ Create identity tensor of specified shape.
+
+    T is an "identity tensor if T.ttsv(x, skip_dim=0) = x for all x such that
+    norm(x) == 1.
+
+    An identity tensor only exists if order is even.
+    This method is resource intensive
+    for even moderate orders or sizes (>=6).
+
+    Parameters
+    ----------
+    order: Number of dimensions of tensor.
+    size: Number of elements in any dimension of the tensor.
+
+    Examples
+    --------
+    >>> ttb.teneye(2, 3)
+    tensor of shape (3, 3)
+    data[:, :] =
+    [[1. 0. 0.]
+     [0. 1. 0.]
+     [0. 0. 1.]]
+    >>> x = np.ones((5,))
+    >>> x /= np.linalg.norm(x)
+    >>> T = ttb.teneye(4, 5)
+    >>> np.allclose(T.ttsv(x, 0), x)
+    True
+
+    Returns
+    -------
+    Identity tensor.
+    """
+    if order % 2 != 0:
+        raise ValueError(f"Order must be even but received {order}")
+    idx_iterator = combinations_with_replacement(range(size), order)
+    A = tenzeros((size,)*order)
+    s = np.zeros((factorial(order), order // 2))
+    for _i, indices in enumerate(idx_iterator):
+        p = np.array(list(permutations(indices)))
+        for j in range(order//2):
+            s[:, j] = p[:, 2*j-1] == p[:, 2*j]
+        v = np.sum(np.sum(s, axis=1) == order//2)
+        A[tuple(zip(*p))] = v / factorial(order)
+    return A
 
 
 def mttv_left(W_in: np.ndarray, U1: np.ndarray) -> np.ndarray:

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -2487,7 +2487,7 @@ def tendiag(elements: np.ndarray, shape: Optional[Tuple[int, ...]] = None) -> te
 
 
 def teneye(order: int, size: int) -> tensor:
-    """ Create identity tensor of specified shape.
+    """Create identity tensor of specified shape.
 
     T is an "identity tensor if T.ttsv(x, skip_dim=0) = x for all x such that
     norm(x) == 1.
@@ -2522,13 +2522,13 @@ def teneye(order: int, size: int) -> tensor:
     if order % 2 != 0:
         raise ValueError(f"Order must be even but received {order}")
     idx_iterator = combinations_with_replacement(range(size), order)
-    A = tenzeros((size,)*order)
+    A = tenzeros((size,) * order)
     s = np.zeros((factorial(order), order // 2))
     for _i, indices in enumerate(idx_iterator):
         p = np.array(list(permutations(indices)))
-        for j in range(order//2):
-            s[:, j] = p[:, 2*j-1] == p[:, 2*j]
-        v = np.sum(np.sum(s, axis=1) == order//2)
+        for j in range(order // 2):
+            s[:, j] = p[:, 2 * j - 1] == p[:, 2 * j]
+        v = np.sum(np.sum(s, axis=1) == order // 2)
         A[tuple(zip(*p))] = v / factorial(order)
     return A
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1692,10 +1692,7 @@ def test_teneye():
     T = ttb.teneye(order, size)
     x = np.random.random((size,))
     x = x / np.linalg.norm(x)
-    np.testing.assert_almost_equal(
-        T.ttsv(x, 0),
-        x
-    )
+    np.testing.assert_almost_equal(T.ttsv(x, 0), x)
 
 
 def test_mttv_left():

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1684,6 +1684,20 @@ def test_tendiag():
         assert X[diag_index] == i
 
 
+def test_teneye():
+    with pytest.raises(ValueError):
+        ttb.teneye(1, 0)
+    size = 5
+    order = 4
+    T = ttb.teneye(order, size)
+    x = np.random.random((size,))
+    x = x / np.linalg.norm(x)
+    np.testing.assert_almost_equal(
+        T.ttsv(x, 0),
+        x
+    )
+
+
 def test_mttv_left():
     m1 = 2
     mi = [range(1, 4)]


### PR DESCRIPTION
I found myself in a loud coffee shop unable to work on other stuff so I picked off #72. I am not sure if the custom combinator code is needed elsewhere but itertools combinations with replacement should be an appropriate replacement with the advantage that it doesn't have to actually generate all the index sets in memory. On my laptop I didn't see any major improvement for this because N>=8, M>=8 had a huge result tensor anyway.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--222.org.readthedocs.build/en/222/

<!-- readthedocs-preview pyttb end -->