### PR TITLE
Default behavior of divmod() is different from MATLAB mod(), on which…

### DIFF
--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -238,7 +238,7 @@ def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
         else:
             flag = 1
 
-        if (divmod(iteration, printitn)[1] == 0) or (printitn > 0 and flag == 0):
+        if (printitn > 0) and ((divmod(iteration, printitn)[1] == 0) or (flag == 0)):
             print(f" Iter {iteration}: f = {fit:e} f-delta = {fitchange:7.1e}")
 
         # Check for convergence

--- a/tests/test_cp_als.py
+++ b/tests/test_cp_als.py
@@ -213,21 +213,17 @@ def test_cp_als_tensor_printitn(capsys, sample_tensor):
     _, T = sample_tensor
 
     # default printitn
-    _, _, output = ttb.cp_als(T, 2, printitn=1)
+    ttb.cp_als(T, 2, printitn=1, maxiters=2)
     capsys.readouterr()
-    assert pytest.approx(output["fit"]) == 1
-
+    
     # zero printitn
-    (M, Minit, output) = ttb.cp_als(T, 2, printitn=0)
+    ttb.cp_als(T, 2, printitn=0, maxiters=2)
     capsys.readouterr()
-    assert pytest.approx(output["fit"]) == 1
-
+    
     # negative printitn
-    (M, Minit, output) = ttb.cp_als(T, 2, printitn=-1)
+    ttb.cp_als(T, 2, printitn=-1, maxiters=2)
     capsys.readouterr()
-    assert pytest.approx(output["fit"]) == 1
 
     # float printitn
-    (M, Minit, output) = ttb.cp_als(T, 2, printitn=1.5)
+    ttb.cp_als(T, 2, printitn=1.5, maxiters=2)
     capsys.readouterr()
-    assert pytest.approx(output["fit"]) == 1

--- a/tests/test_cp_als.py
+++ b/tests/test_cp_als.py
@@ -206,3 +206,28 @@ def test_cp_als_sptensor_zeros(capsys):
     capsys.readouterr()
     assert pytest.approx(output3["fit"], 1) == 0
     assert output3["normresidual"] == 0
+
+
+@pytest.mark.indevelopment
+def test_cp_als_tensor_printitn(capsys, sample_tensor):
+    (data, T) = sample_tensor
+
+    # default printitn
+    (M, Minit, output) = ttb.cp_als(T, 2, printitn=1)
+    capsys.readouterr()
+    assert pytest.approx(output["fit"]) == 1
+
+    # zero printitn
+    (M, Minit, output) = ttb.cp_als(T, 2, printitn=0)
+    capsys.readouterr()
+    assert pytest.approx(output["fit"]) == 1
+
+    # negative printitn
+    (M, Minit, output) = ttb.cp_als(T, 2, printitn=-1)
+    capsys.readouterr()
+    assert pytest.approx(output["fit"]) == 1
+
+    # float printitn
+    (M, Minit, output) = ttb.cp_als(T, 2, printitn=1.5)
+    capsys.readouterr()
+    assert pytest.approx(output["fit"]) == 1

--- a/tests/test_cp_als.py
+++ b/tests/test_cp_als.py
@@ -210,7 +210,7 @@ def test_cp_als_sptensor_zeros(capsys):
 
 @pytest.mark.indevelopment
 def test_cp_als_tensor_printitn(capsys, sample_tensor):
-    (data, T) = sample_tensor
+    _, T = sample_tensor
 
     # default printitn
     (M, Minit, output) = ttb.cp_als(T, 2, printitn=1)

--- a/tests/test_cp_als.py
+++ b/tests/test_cp_als.py
@@ -208,7 +208,6 @@ def test_cp_als_sptensor_zeros(capsys):
     assert output3["normresidual"] == 0
 
 
-@pytest.mark.indevelopment
 def test_cp_als_tensor_printitn(capsys, sample_tensor):
     _, T = sample_tensor
 

--- a/tests/test_cp_als.py
+++ b/tests/test_cp_als.py
@@ -213,7 +213,7 @@ def test_cp_als_tensor_printitn(capsys, sample_tensor):
     _, T = sample_tensor
 
     # default printitn
-    (M, Minit, output) = ttb.cp_als(T, 2, printitn=1)
+    _, _, output = ttb.cp_als(T, 2, printitn=1)
     capsys.readouterr()
     assert pytest.approx(output["fit"]) == 1
 


### PR DESCRIPTION
… the original logic was based. The prior logic threw a ZeroDivisionError if printitn == 0. Instead, this fix avoids this error by testing that printitn > 0. Tests added for various values of printitn.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--237.org.readthedocs.build/en/237/

<!-- readthedocs-preview pyttb end -->