### PR TITLE
Default behavior of divmod() is different from MATLAB mod(), on which…

### DIFF
--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -238,7 +238,7 @@ def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
         else:
             flag = 1
 
-        if (divmod(iteration, printitn)[1] == 0) or (printitn > 0 and flag == 0):
+        if (printitn > 0) and ((divmod(iteration, printitn)[1] == 0) or (flag == 0)):
             print(f" Iter {iteration}: f = {fit:e} f-delta = {fitchange:7.1e}")
 
         # Check for convergence

--- a/tests/test_cp_als.py
+++ b/tests/test_cp_als.py
@@ -206,3 +206,23 @@ def test_cp_als_sptensor_zeros(capsys):
     capsys.readouterr()
     assert pytest.approx(output3["fit"], 1) == 0
     assert output3["normresidual"] == 0
+
+
+def test_cp_als_tensor_printitn(capsys, sample_tensor):
+    _, T = sample_tensor
+
+    # default printitn
+    ttb.cp_als(T, 2, printitn=1, maxiters=2)
+    capsys.readouterr()
+    
+    # zero printitn
+    ttb.cp_als(T, 2, printitn=0, maxiters=2)
+    capsys.readouterr()
+    
+    # negative printitn
+    ttb.cp_als(T, 2, printitn=-1, maxiters=2)
+    capsys.readouterr()
+
+    # float printitn
+    ttb.cp_als(T, 2, printitn=1.5, maxiters=2)
+    capsys.readouterr()

--- a/tests/test_cp_als.py
+++ b/tests/test_cp_als.py
@@ -214,11 +214,11 @@ def test_cp_als_tensor_printitn(capsys, sample_tensor):
     # default printitn
     ttb.cp_als(T, 2, printitn=1, maxiters=2)
     capsys.readouterr()
-    
+
     # zero printitn
     ttb.cp_als(T, 2, printitn=0, maxiters=2)
     capsys.readouterr()
-    
+
     # negative printitn
     ttb.cp_als(T, 2, printitn=-1, maxiters=2)
     capsys.readouterr()


### PR DESCRIPTION
…… (#237)

* Default behavior of divmod() is different from MATLAB mod(), on which the original logic was based. The prior logic threw a ZeroDivisionError if printitn == 0. Instead, this fix avoids this error by testing that printitn > 0. Tests added for various values of printitn.

* Update tests/test_cp_als.py



* Update tests/test_cp_als.py



* Applying Nick's suggesetions to remove mark, change maxiters to save CPU cycles. Also removing output since nothing is actually checked.

* Removes mark

* Closes #235 ---------

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--242.org.readthedocs.build/en/242/

<!-- readthedocs-preview pyttb end -->