### PR TITLE
SPTENSOR: Infer shape from data

### DIFF
--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -174,10 +174,13 @@ class sptensor:
                     raise ValueError(f"Invalid shape provided: {shape}")
                 self.shape = tuple(shape)
             return
-        if subs is None or vals is None or shape is None:
+        if subs is None or vals is None:
             raise ValueError(
                 "For non-empty sptensors subs, vals, and shape must be provided"
             )
+
+        if shape is None:
+            shape = tuple(np.max(subs, axis=0) + 1)
 
         if subs.size > 0:
             assert subs.shape[1] == len(shape) and np.all(

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -48,8 +48,9 @@ def test_sptensor_initialization_from_data(sample_sptensor):
     assert np.array_equal(sptensorInstance.vals, data["vals"])
     assert sptensorInstance.shape == data["shape"]
 
-    with pytest.raises(ValueError):
-        ttb.sptensor(data["subs"], data["vals"])
+    # Infer shape from data
+    another_sptensor = ttb.sptensor(data["subs"], data["vals"])
+    assert another_sptensor.isequal(sptensorInstance)
 
     with pytest.raises(AssertionError):
         shape = (3, 3, 1)


### PR DESCRIPTION
Quick fix to https://github.com/sandialabs/pyttb/issues/232 to unblock the documentation effort for sptensor.

Probably not critical prior to 2.0 but we might consider a refactor of the constructor internals at some point. Originally (matching MATLAB) we had from_data which basically put all error handling onto the user for the benefit of speed. Then we had from_aggregator which has a lot more error checking but was the recommended approach. Now we moved from_data to our __init__ but are slowly adding in lots of error checking. We might be able to merge from_aggregator into our __init__ then have an optimized happy path with minimal checks then a slower path that covers more edge cases.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--243.org.readthedocs.build/en/243/

<!-- readthedocs-preview pyttb end -->