### PR TITLE
Gcp opt tutorial fixes

### DIFF
--- a/pyttb/gcp/optimizers.py
+++ b/pyttb/gcp/optimizers.py
@@ -198,6 +198,7 @@ class StochasticSolver(ABC):
                         f", nfails = {self._nfails} (resetting to solution from "
                         "last epoch)"
                     )
+                logging.info(msg)
 
             if failed_epoch:
                 # Reset to best solution so far

--- a/pyttb/gcp/optimizers.py
+++ b/pyttb/gcp/optimizers.py
@@ -166,7 +166,7 @@ class StochasticSolver(ABC):
                 )
 
                 # Check for inf
-                if np.any(np.isinf(g_est)):
+                if any(np.any(np.isinf(g_est_i)) for g_est_i in g_est):
                     raise ValueError(
                         f"Infinite gradient encountered! (epoch = {n_epoch}, "
                         f"iter = {iteration}"

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -175,9 +175,7 @@ class sptensor:
                 self.shape = tuple(shape)
             return
         if subs is None or vals is None:
-            raise ValueError(
-                "For non-empty sptensors subs, vals, and shape must be provided"
-            )
+            raise ValueError("If subs or vals are provided they must both be provided.")
 
         if shape is None:
             shape = tuple(np.max(subs, axis=0) + 1)

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -52,6 +52,12 @@ def test_sptensor_initialization_from_data(sample_sptensor):
     another_sptensor = ttb.sptensor(data["subs"], data["vals"])
     assert another_sptensor.isequal(sptensorInstance)
 
+    # Subs XOR vals
+    with pytest.raises(ValueError):
+        ttb.sptensor(subs=data["subs"])
+    with pytest.raises(ValueError):
+        ttb.sptensor(vals=data["vals"])
+
     with pytest.raises(AssertionError):
         shape = (3, 3, 1)
         invalid_subs = np.array([[1, 1, 1], [1, 3, 2], [2, 2, 2]])


### PR DESCRIPTION
This should resolve #251 and #252. Testing for logging is a little brittle/would require some more thought. I think the tutorials should serve to capture whatever formatting issue I had before with the inf check. I think these are mostly helpful to unblock the tutorial and if people felt strongly could file an issue to follow up with better testing.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--255.org.readthedocs.build/en/255/

<!-- readthedocs-preview pyttb end -->