### PR TITLE
Sptensor mask

### DIFF
--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -580,12 +580,11 @@ class sptensor:
         a = np.zeros(shape=(p, 1), dtype=self.vals.dtype)
 
         # Find which indices already exist and their locations
-        loc = tt_ismember_rows(searchsubs, self.subs)
+        valid, loc = tt_ismember_rows(searchsubs, self.subs)
         # Fill in the non-zero elements in the answer
-        nzsubs = np.where(loc >= 0)
-        non_zeros = self.vals[loc[nzsubs]]
-        if non_zeros.size > 0:
-            a[nzsubs] = non_zeros
+        non_zeros = self.vals[loc[valid]]
+        if np.sum(valid) > 0:
+            a[valid] = non_zeros
         return a
 
     def find(self) -> Tuple[np.ndarray, np.ndarray]:
@@ -844,8 +843,8 @@ class sptensor:
         wsubs, _ = W.find()
 
         # Find which values in the mask match nonzeros in X
-        idx = tt_ismember_rows(wsubs, self.subs)
-        matching_indices = idx[np.where(idx >= 0)[0]]
+        valid, idx = tt_ismember_rows(wsubs, self.subs)
+        matching_indices = idx[valid]
 
         # Assemble return array
         nvals = wsubs.shape[0]
@@ -1581,7 +1580,7 @@ class sptensor:
         newvals = newvals[idx]
 
         # Find which subscripts already exist and their locations
-        tf = tt_ismember_rows(newsubs, self.subs)
+        _, tf = tt_ismember_rows(newsubs, self.subs)
         loc = np.where(tf >= 0)[0].astype(int)
 
         # Split into three groups for processing:

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -845,11 +845,12 @@ class sptensor:
 
         # Find which values in the mask match nonzeros in X
         idx = tt_ismember_rows(wsubs, self.subs)
+        matching_indices = idx[np.where(idx >= 0)[0]]
 
         # Assemble return array
         nvals = wsubs.shape[0]
         vals = np.zeros((nvals, 1))
-        vals[idx] = self.vals[idx]
+        vals[matching_indices] = self.vals[matching_indices]
         return vals
 
     def mttkrp(self, U: Union[ttb.ktensor, List[np.ndarray]], n: int) -> np.ndarray:

--- a/tests/test_pyttb_utils.py
+++ b/tests/test_pyttb_utils.py
@@ -212,11 +212,17 @@ def test_tt_ismember_rows():
     b = np.array(
         [[1, 7], [1, 8], [2, 6], [2, 1], [2, 4], [4, 6], [4, 7], [5, 9], [5, 2], [5, 1]]
     )
-    assert np.array_equal(ttb_utils.tt_ismember_rows(a, b), np.array([5, -1, 2]))
+    valid, result = ttb_utils.tt_ismember_rows(a, b)
+    assert np.array_equal(result, np.array([5, -1, 2]))
+    assert np.all(result[valid] >= 0)
+    assert np.all(result[~valid] < 0)
+    valid, result = ttb_utils.tt_ismember_rows(b, a)
     assert np.array_equal(
-        ttb_utils.tt_ismember_rows(b, a),
+        result,
         np.array([-1, -1, 2, -1, -1, 0, -1, -1, -1, -1]),
     )
+    assert np.all(result[valid] >= 0)
+    assert np.all(result[~valid] < 0)
 
 
 @pytest.mark.indevelopment

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -1282,6 +1282,15 @@ def test_sptensor_mask(sample_sptensor):
     # Mask captures all non-zero entries
     assert np.array_equal(sptensorInstance.mask(sptensorInstance), data["vals"])
 
+    # Mask correctly skips zeros
+    S = ttb.sptensor()
+    S[0, 0] = 1
+    S[1, 1] = 2
+    W = ttb.sptensor()
+    W[0, 0] = 1
+    W[1, 0] = 1
+    assert np.array_equal(S.mask(W), np.array([[S[0, 0]], [S[1, 0]]]))
+
     # Mask too large
     with pytest.raises(AssertionError) as excinfo:
         sptensorInstance.mask(ttb.sptensor(np.array([]), np.array([]), (3, 3, 5)))


### PR DESCRIPTION
We were using `tt_ismember_rows` incorrectly in mask. `-1` was a flag for failed match but also yields a valid index into an array. First fixed the bug then updated the ismember_rows interface to try to make this incorrect usage more obvious in the future.

Resolves https://github.com/sandialabs/pyttb/issues/258

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--259.org.readthedocs.build/en/259/

<!-- readthedocs-preview pyttb end -->