### PR TITLE
Sparse logical

### DIFF
--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -704,7 +704,7 @@ class sptensor:
                 C = sptensor(shape=self.shape)
             else:
                 newvals = self.vals == B
-                C = sptensor(self.subs, newvals, self.shape)
+                C = sptensor(self.subs, newvals.astype(self.vals.dtype), self.shape)
             return C
         # Case 2: Argument is a tensor of some sort
         if isinstance(B, sptensor):
@@ -718,6 +718,7 @@ class sptensor:
                 self.shape,
                 lambda x: len(x) == 2,
             )
+            C.vals = C.vals.astype(self.vals.dtype)
 
             return C
 
@@ -741,7 +742,7 @@ class sptensor:
         allsubs = self.allsubs()
         subsIdx = tt_setdiff_rows(allsubs, self.subs)
         subs = allsubs[subsIdx]
-        trueVector = np.ones(shape=(subs.shape[0], 1), dtype=bool)
+        trueVector = np.ones(shape=(subs.shape[0], 1), dtype=self.vals.dtype)
         return sptensor(subs, trueVector, self.shape)
 
     @overload
@@ -771,12 +772,14 @@ class sptensor:
             assert False, "Logical Or requires tensors of the same size"
 
         if isinstance(B, ttb.sptensor):
-            return sptensor.from_aggregator(
+            C = sptensor.from_aggregator(
                 np.vstack((self.subs, B.subs)),
                 np.ones((self.subs.shape[0] + B.subs.shape[0], 1)),
                 self.shape,
                 lambda x: len(x) >= 1,
             )
+            C.vals = C.vals.astype(self.vals.dtype)
+            return C
 
         assert False, "Sptensor Logical Or argument must be scalar or sptensor"
 
@@ -814,9 +817,11 @@ class sptensor:
                 assert False, "Logical XOR requires tensors of the same size"
 
             subs = np.vstack((self.subs, other.subs))
-            return ttb.sptensor.from_aggregator(
+            result = ttb.sptensor.from_aggregator(
                 subs, np.ones((len(subs), 1)), self.shape, lambda x: len(x) == 1
             )
+            result.vals = result.vals.astype(self.vals.dtype)
+            return result
 
         assert False, "The argument must be an sptensor, tensor or scalar"
 

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -703,8 +703,8 @@ class sptensor:
             if B == 0:
                 C = sptensor(shape=self.shape)
             else:
-                newvals = self.vals == B
-                C = sptensor(self.subs, newvals.astype(self.vals.dtype), self.shape)
+                newvals = np.ones_like(self.vals)
+                C = sptensor(self.subs, newvals, self.shape)
             return C
         # Case 2: Argument is a tensor of some sort
         if isinstance(B, sptensor):

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -643,13 +643,13 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2), dtype=bool))
+        >>> T = ttb.tenones((2,2))
         >>> T.logical_and(T).collapse()  # All true
-        4
+        4.0
         """
 
         def logical_and(x, y):
-            return np.logical_and(x, y)
+            return np.logical_and(x, y).astype(dtype=x.dtype)
 
         return tt_tenfun(logical_and, self, other)
 
@@ -659,11 +659,12 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2), dtype=bool))
+        >>> T = ttb.tenones((2,2))
         >>> T.logical_not().collapse()  # All false
-        0
+        0.0
         """
-        return ttb.tensor(np.logical_not(self.data), copy=False)
+        # Np logical not dtype argument seems to not work here
+        return ttb.tensor(np.logical_not(self.data).astype(self.data.dtype), copy=False)
 
     def logical_or(self, other: Union[float, tensor]) -> tensor:
         """
@@ -676,13 +677,13 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2), dtype=bool))
+        >>> T = ttb.tenones((2,2))
         >>> T.logical_or(T.logical_not()).collapse()  # All true
-        4
+        4.0
         """
 
         def tensor_or(x, y):
-            return np.logical_or(x, y)
+            return np.logical_or(x, y).astype(x.dtype)
 
         return tt_tenfun(tensor_or, self, other)
 
@@ -697,13 +698,13 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2), dtype=bool))
+        >>> T = ttb.tenones((2,2))
         >>> T.logical_xor(T.logical_not()).collapse()  # All true
-        4
+        4.0
         """
 
         def tensor_xor(x, y):
-            return np.logical_xor(x, y)
+            return np.logical_xor(x, y).astype(dtype=x.dtype)
 
         return tt_tenfun(tensor_xor, self, other)
 
@@ -723,7 +724,7 @@ class tensor:
         Examples
         --------
         >>> T = ttb.tensor(np.array([[1, 2], [3, 4]]))
-        >>> W = ttb.tensor(np.ones((2,2)))
+        >>> W = ttb.tenones((2,2))
         >>> T.mask(W)
         array([1, 3, 2, 4])
         """
@@ -758,7 +759,7 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2,2)))
+        >>> T = ttb.tenones((2,2,2))
         >>> U = [np.ones((2,2))] * 3
         >>> T.mttkrp(U, 2)
         array([[4., 4.],
@@ -841,7 +842,7 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2,2)))
+        >>> T = ttb.tenones((2,2,2))
         >>> U = [np.ones((2,2))] * 3
         >>> T.mttkrps(U)
         [array([[4., 4.],
@@ -876,7 +877,7 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2)))
+        >>> T = ttb.tenones((2,2))
         >>> T.ndims
         2
         """
@@ -891,7 +892,7 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2,2)))
+        >>> T = ttb.tenones((2,2,2))
         >>> T.nnz
         8
         """
@@ -904,7 +905,7 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2,2,2)))
+        >>> T = ttb.tenones((2,2,2,2))
         >>> T.norm()
         4.0
         """
@@ -1025,7 +1026,7 @@ class tensor:
 
         Examples
         --------
-        >>> T1 = ttb.tensor(np.ones((2,2)))
+        >>> T1 = ttb.tenones((2,2))
         >>> T1.shape
         (2, 2)
         >>> T2 = T1.reshape((4,1))
@@ -1152,7 +1153,7 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2,2)))
+        >>> T = ttb.tenones((2,2,2))
         >>> T.symmetrize(np.array([0,2]))
         tensor of shape (2, 2, 2)
         data[0, :, :] =
@@ -1317,7 +1318,7 @@ class tensor:
 
         Examples
         --------
-        >>> T = ttb.tensor(np.ones((2,2,2,2)))
+        >>> T = ttb.tenones((2,2,2,2))
         >>> A = 2*np.ones((2,1))
         >>> T.ttm([A,A], dims=[0,1], transpose=True)
         tensor of shape (1, 1, 2, 2)
@@ -1665,7 +1666,7 @@ class tensor:
 
         Examples
         --------
-        >>> T = tensor(np.ones((3,4,2)))
+        >>> T = tenones((3,4,2))
         >>> # replaces subtensor
         >>> T[0:2,0:2,0] = np.ones((2,2))
         >>> # replaces two elements
@@ -1810,7 +1811,7 @@ class tensor:
 
         Examples
         --------
-        >>> T = tensor(np.ones((3,4,2,1)))
+        >>> T = tenones((3,4,2,1))
         >>> T[0,0,0,0] # produces a scalar
         1.0
         >>> # produces a tensor of order 1 and size 1

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -174,11 +174,13 @@ def test_sptensor_and_scalar(sample_sptensor):
     assert b.subs.size == 0
     assert b.vals.size == 0
     assert b.shape == data["shape"]
+    assert b.vals.dtype == sptensorInstance.vals.dtype
 
     b = sptensorInstance.logical_and(0.5)
     assert np.array_equal(b.subs, data["subs"])
     assert np.array_equal(b.vals, np.array([[True], [False], [False], [False]]))
     assert b.shape == data["shape"]
+    assert b.vals.dtype == sptensorInstance.vals.dtype
 
 
 def test_sptensor_and_sptensor(sample_sptensor):
@@ -188,6 +190,7 @@ def test_sptensor_and_sptensor(sample_sptensor):
     assert np.array_equal(b.subs, data["subs"])
     assert np.array_equal(b.vals, np.array([[True], [True], [True], [True]]))
     assert b.shape == data["shape"]
+    assert b.vals.dtype == sptensorInstance.vals.dtype
 
     with pytest.raises(AssertionError) as excinfo:
         sptensorInstance.logical_and(
@@ -207,6 +210,7 @@ def test_sptensor_and_tensor(sample_sptensor):
     b = sptensorInstance.logical_and(sptensorInstance.to_tensor())
     assert np.array_equal(b.subs, data["subs"])
     assert np.array_equal(b.vals, np.ones(data["vals"].shape))
+    assert b.vals.dtype == sptensorInstance.vals.dtype
 
 
 def test_sptensor_full(sample_sptensor):
@@ -685,6 +689,7 @@ def test_sptensor_logical_not(sample_sptensor):
     assert all(notSptensorInstance.vals == 1)
     assert np.array_equal(notSptensorInstance.subs, np.array(result))
     assert notSptensorInstance.shape == data["shape"]
+    assert notSptensorInstance.vals.dtype == sptensorInstance.vals.dtype
 
 
 def test_sptensor_logical_or(sample_sptensor):
@@ -695,20 +700,24 @@ def test_sptensor_logical_or(sample_sptensor):
     assert sptensorOr.shape == data["shape"]
     assert np.array_equal(sptensorOr.subs, data["subs"])
     assert np.array_equal(sptensorOr.vals, np.ones((data["vals"].shape[0], 1)))
+    assert sptensorOr.vals.dtype == sptensorInstance.vals.dtype
 
     # Sptensor logical or with tensor
     sptensorOr = sptensorInstance.logical_or(sptensorInstance.to_tensor())
     nonZeroMatrix = np.zeros(data["shape"])
     nonZeroMatrix[tuple(data["subs"].transpose())] = 1
     assert np.array_equal(sptensorOr.data, nonZeroMatrix)
+    assert sptensorOr.data.dtype == sptensorInstance.vals.dtype
 
     # Sptensor logical or with scalar, 0
     sptensorOr = sptensorInstance.logical_or(0)
     assert np.array_equal(sptensorOr.data, nonZeroMatrix)
+    assert sptensorOr.data.dtype == sptensorInstance.vals.dtype
 
     # Sptensor logical or with scalar, not 0
     sptensorOr = sptensorInstance.logical_or(1)
     assert np.array_equal(sptensorOr.data, np.ones(data["shape"]))
+    assert sptensorOr.data.dtype == sptensorInstance.vals.dtype
 
     # Sptensor logical or with wrong shape sptensor
     with pytest.raises(AssertionError) as excinfo:
@@ -1165,19 +1174,23 @@ def test_sptensor_logical_xor(sample_sptensor):
     # Sptensor logical xor with scalar, 0
     sptensorXor = sptensorInstance.logical_xor(0)
     assert np.array_equal(sptensorXor.data, nonZeroMatrix)
+    assert sptensorXor.data.dtype == sptensorInstance.vals.dtype
 
     # Sptensor logical xor with scalar, not 0
     sptensorXor = sptensorInstance.logical_xor(1)
     assert np.array_equal(sptensorXor.data, sptensorInstance.logical_not().full().data)
+    assert sptensorXor.data.dtype == sptensorInstance.vals.dtype
 
     # Sptensor logical xor with another sptensor
     sptensorXor = sptensorInstance.logical_xor(sptensorInstance)
     assert sptensorXor.shape == data["shape"]
     assert sptensorXor.vals.size == 0
+    assert sptensorXor.vals.dtype == sptensorInstance.vals.dtype
 
     # Sptensor logical xor with tensor
     sptensorXor = sptensorInstance.logical_xor(sptensorInstance.to_tensor())
-    assert np.array_equal(sptensorXor.data, np.zeros(data["shape"], dtype=bool))
+    assert np.array_equal(sptensorXor.data, np.zeros(data["shape"]))
+    assert sptensorXor.data.dtype == sptensorInstance.vals.dtype
 
     # Sptensor logical xor with wrong shape sptensor
     with pytest.raises(AssertionError) as excinfo:

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -176,9 +176,10 @@ def test_sptensor_and_scalar(sample_sptensor):
     assert b.shape == data["shape"]
     assert b.vals.dtype == sptensorInstance.vals.dtype
 
+    # Sparsity pattern check not exact value equality
     b = sptensorInstance.logical_and(0.5)
     assert np.array_equal(b.subs, data["subs"])
-    assert np.array_equal(b.vals, np.array([[True], [False], [False], [False]]))
+    assert np.array_equal(b.vals, np.array([[True], [True], [True], [True]]))
     assert b.shape == data["shape"]
     assert b.vals.dtype == sptensorInstance.vals.dtype
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -407,19 +407,19 @@ def test_tensor_logical_and(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor And
-    assert np.array_equal(
-        tensorInstance.logical_and(tensorInstance).data, np.ones((params["shape"]))
-    )
+    tensor_and = tensorInstance.logical_and(tensorInstance).data
+    assert np.array_equal(tensor_and, np.ones((params["shape"])))
+    assert tensor_and.dtype == tensorInstance.data.dtype
 
     # Non-zero And
-    assert np.array_equal(
-        tensorInstance.logical_and(1).data, np.ones((params["shape"]))
-    )
+    non_zero_and = tensorInstance.logical_and(1).data
+    assert np.array_equal(non_zero_and, np.ones((params["shape"])))
+    assert non_zero_and.dtype == tensorInstance.data.dtype
 
     # Zero And
-    assert np.array_equal(
-        tensorInstance.logical_and(0).data, np.zeros((params["shape"]))
-    )
+    zero_and = tensorInstance.logical_and(0).data
+    assert np.array_equal(zero_and, np.zeros((params["shape"])))
+    assert zero_and.dtype == tensorInstance.data.dtype
 
 
 def test_tensor__eq__(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way):
@@ -627,43 +627,47 @@ def test_tensor_norm(sample_tensor_2way, sample_tensor_3way, sample_tensor_4way)
 def test_tensor_logical_not(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
-    assert np.array_equal(
-        tensorInstance.logical_not().data, np.logical_not(params["data"])
-    )
+    not_tensor = tensorInstance.logical_not().data
+    assert np.array_equal(not_tensor, np.logical_not(params["data"]))
+    assert not_tensor.dtype == tensorInstance.data.dtype
 
 
 def test_tensor_logical_or(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor Or
-    assert np.array_equal(
-        tensorInstance.logical_or(tensorInstance).data, np.ones((params["shape"]))
-    )
+    or_tensor = tensorInstance.logical_or(tensorInstance).data
+    assert np.array_equal(or_tensor, np.ones((params["shape"])))
+    assert or_tensor.dtype == tensorInstance.data.dtype
 
     # Non-zero Or
-    assert np.array_equal(tensorInstance.logical_or(1).data, np.ones((params["shape"])))
+    non_zero_or = tensorInstance.logical_or(1).data
+    assert np.array_equal(non_zero_or, np.ones((params["shape"])))
+    assert non_zero_or.dtype == tensorInstance.data.dtype
 
     # Zero Or
-    assert np.array_equal(tensorInstance.logical_or(0).data, np.ones((params["shape"])))
+    zero_or = tensorInstance.logical_or(0).data
+    assert np.array_equal(zero_or, np.ones((params["shape"])))
+    assert zero_or.dtype == tensorInstance.data.dtype
 
 
 def test_tensor_logical_xor(sample_tensor_2way):
     (params, tensorInstance) = sample_tensor_2way
 
     # Tensor xor
-    assert np.array_equal(
-        tensorInstance.logical_xor(tensorInstance).data, np.zeros((params["shape"]))
-    )
+    xor_tensor = tensorInstance.logical_xor(tensorInstance).data
+    assert np.array_equal(xor_tensor, np.zeros((params["shape"])))
+    assert xor_tensor.dtype == tensorInstance.data.dtype
 
     # Non-zero xor
-    assert np.array_equal(
-        tensorInstance.logical_xor(1).data, np.zeros((params["shape"]))
-    )
+    non_zero_xor = tensorInstance.logical_xor(1).data
+    assert np.array_equal(non_zero_xor, np.zeros((params["shape"])))
+    assert non_zero_xor.dtype == tensorInstance.data.dtype
 
     # Zero xor
-    assert np.array_equal(
-        tensorInstance.logical_xor(0).data, np.ones((params["shape"]))
-    )
+    zero_xor = tensorInstance.logical_xor(0).data
+    assert np.array_equal(zero_xor, np.ones((params["shape"])))
+    assert zero_xor.dtype == tensorInstance.data.dtype
 
 
 def test_tensor__add__(sample_tensor_2way):


### PR DESCRIPTION
Resolves #256 and #257 but maybe raises more questions than it answers. It matches what you described as expected behavior. (Indicator tensors with 1.0, 0.0)

It raises the question on if we should track the dtype (could be a hidden variable or a property). Or even more explicitly could be set when constructing the tensor (I kind of hacked the vals in the sptensor to make things make sense; however would be nice to take a dtype argument on construction).

You mentioned in the issue we don't do boolean tensors but for equality we currently do. Should those also get the same indicator treatment?
```python
>> import pyttb as ttb
>> T = ttb.tenones((2,2))
>> T == T
tensor of shape (2, 2)
data[:, :] =
[[ True  True]
 [ True  True]]
```

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--269.org.readthedocs.build/en/269/

<!-- readthedocs-preview pyttb end -->