### PR TITLE
Add sptenmat

### DIFF
--- a/docs/source/sptenmat.rst
+++ b/docs/source/sptenmat.rst
@@ -1,2 +1,8 @@
 pyttb.sptenmat
-======================
+----------------------
+
+.. autoclass:: pyttb.sptenmat
+    :members:
+    :special-members:
+    :exclude-members: __dict__, __weakref__, __slots__, __init__
+    :show-inheritance:

--- a/docs/source/tensor_classes.rst
+++ b/docs/source/tensor_classes.rst
@@ -5,6 +5,7 @@ Tensor Classes
     :maxdepth: 2
 
     ktensor.rst
+    sptenmat.rst
     sptensor.rst
     sumtensor.rst
     tensor.rst

--- a/docs/source/tutorial/class_sptenmat.ipynb
+++ b/docs/source/tutorial/class_sptenmat.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.random.seed(0) # Random seed for reproducibility\n",
+    "np.random.seed(0)  # Random seed for reproducibility\n",
     "X = ttb.sptenrand((10, 10, 10, 10), nonzeros=10)\n",
     "X"
    ]
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = ttb.sptenmat.from_tensor_type(X, np.array([0])) # Mode-0 matricization\n",
+    "A = ttb.sptenmat.from_tensor_type(X, np.array([0]))  # Mode-0 matricization\n",
     "A"
    ]
   },
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = ttb.sptenmat.from_tensor_type(X, np.array([1, 2])) # Multiple modes mapped to rows.\n",
+    "A = ttb.sptenmat.from_tensor_type(X, np.array([1, 2]))  # Multiple modes mapped to rows.\n",
     "A"
    ]
   },
@@ -92,7 +92,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = ttb.sptenmat.from_tensor_type(X, cdims=np.array([1, 2])) # Specify column dimensions.\n",
+    "A = ttb.sptenmat.from_tensor_type(\n",
+    "    X, cdims=np.array([1, 2])\n",
+    ")  # Specify column dimensions.\n",
     "A"
    ]
   },
@@ -103,7 +105,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = ttb.sptenmat.from_tensor_type(X, np.arange(4)) # All modes mapped to rows, i.e., vectorize.\n",
+    "A = ttb.sptenmat.from_tensor_type(\n",
+    "    X, np.arange(4)\n",
+    ")  # All modes mapped to rows, i.e., vectorize.\n",
     "A"
    ]
   },
@@ -114,7 +118,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = ttb.sptenmat.from_tensor_type(X, np.array([1])) # By default, columns are ordered as [0, 2, 3]\n",
+    "A = ttb.sptenmat.from_tensor_type(\n",
+    "    X, np.array([1])\n",
+    ")  # By default, columns are ordered as [0, 2, 3]\n",
     "A"
    ]
   },
@@ -125,7 +131,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = ttb.sptenmat.from_tensor_type(X, np.array([1]), np.array([3, 0, 2])) # Specify explicit ordering\n",
+    "A = ttb.sptenmat.from_tensor_type(\n",
+    "    X, np.array([1]), np.array([3, 0, 2])\n",
+    ")  # Specify explicit ordering\n",
     "A"
    ]
   },
@@ -136,7 +144,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = ttb.sptenmat.from_tensor_type(X, np.array([1]), cdims_cyclic=\"fc\") # Forward cyclic column ordering\n",
+    "A = ttb.sptenmat.from_tensor_type(\n",
+    "    X, np.array([1]), cdims_cyclic=\"fc\"\n",
+    ")  # Forward cyclic column ordering\n",
     "A"
    ]
   },
@@ -147,7 +157,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = ttb.sptenmat.from_tensor_type(X, np.array([1]), cdims_cyclic=\"bc\") # Backward cyclic column ordering\n",
+    "A = ttb.sptenmat.from_tensor_type(\n",
+    "    X, np.array([1]), cdims_cyclic=\"bc\"\n",
+    ")  # Backward cyclic column ordering\n",
     "A"
    ]
   },
@@ -166,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A.subs # Subscripts of the nonzeros."
+    "A.subs  # Subscripts of the nonzeros."
    ]
   },
   {
@@ -176,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A.vals # Corresponding nonzero values."
+    "A.vals  # Corresponding nonzero values."
    ]
   },
   {
@@ -186,7 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A.tshape # Shape of the original tensor."
+    "A.tshape  # Shape of the original tensor."
    ]
   },
   {
@@ -196,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A.rdims # Dimensions that were mapped to the rows."
+    "A.rdims  # Dimensions that were mapped to the rows."
    ]
   },
   {
@@ -206,7 +218,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A.cdims # Dimensions that were mapped to the columns."
+    "A.cdims  # Dimensions that were mapped to the columns."
    ]
   },
   {
@@ -224,7 +236,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "B = ttb.sptenmat.from_data(A.subs, A.vals, A.rdims, A.cdims, A.tshape) # Effectively copies A\n",
+    "B = ttb.sptenmat.from_data(\n",
+    "    A.subs, A.vals, A.rdims, A.cdims, A.tshape\n",
+    ")  # Effectively copies A\n",
     "B"
    ]
   },
@@ -243,7 +257,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = ttb.sptenmat.from_data(rdims=A.rdims, cdims=A.cdims, tshape=A.tshape) # An empty sptenmat\n",
+    "A = ttb.sptenmat.from_data(\n",
+    "    rdims=A.rdims, cdims=A.cdims, tshape=A.tshape\n",
+    ")  # An empty sptenmat\n",
     "A"
    ]
   },
@@ -262,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A = ttb.sptenmat() # A really empty sptenmat\n",
+    "A = ttb.sptenmat()  # A really empty sptenmat\n",
     "A"
    ]
   },
@@ -281,8 +297,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X = ttb.sptenrand((10, 10, 10, 10), nonzeros=10) # Create sptensor\n",
-    "A = ttb.sptenmat.from_tensor_type(X, np.array([0])) # Convert to an sptenmat\n",
+    "X = ttb.sptenrand((10, 10, 10, 10), nonzeros=10)  # Create sptensor\n",
+    "A = ttb.sptenmat.from_tensor_type(X, np.array([0]))  # Convert to an sptenmat\n",
     "A"
    ]
   },
@@ -293,7 +309,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "B = A.double() # Convert to scipy\n",
+    "B = A.double()  # Convert to scipy\n",
     "B"
    ]
   },
@@ -332,7 +348,7 @@
    "id": "c4c3139d",
    "metadata": {},
    "source": [
-    "## Use `sptensor` to convert an `sptenmat` to an `sptensor`. TODO"
+    "## Use `to_sptensor` to convert an `sptenmat` to an `sptensor`."
    ]
   },
   {
@@ -342,7 +358,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Y = ttb.sptensor()\n",
+    "Y = B.to_sptensor()\n",
     "Y"
    ]
   },
@@ -363,10 +379,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\n",
-    "    f\"Matrix shape: {A.shape}\\n\"\n",
-    "    f\"Original tensor shape: {A.tshape}\"\n",
-    ")"
+    "print(f\"Matrix shape: {A.shape}\\n\" f\"Original tensor shape: {A.tshape}\")"
    ]
   },
   {
@@ -407,7 +420,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A.norm() # Norm of the matrix."
+    "A.norm()  # Norm of the matrix."
    ]
   },
   {
@@ -417,7 +430,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "+A # Positive version of matrix (no change)"
+    "+A  # Positive version of matrix (no change)"
    ]
   },
   {
@@ -427,7 +440,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "-A # Negative version of matrix"
+    "-A  # Negative version of matrix"
    ]
   }
  ],

--- a/docs/source/tutorial/class_sptenmat.ipynb
+++ b/docs/source/tutorial/class_sptenmat.ipynb
@@ -1,0 +1,437 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bd6c352a",
+   "metadata": {},
+   "source": [
+    "# Converting Sparse Tensors to Matrices and vice versa\n",
+    "```\n",
+    "Copyright 2022 National Technology & Engineering Solutions of Sandia,\n",
+    "LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the\n",
+    "U.S. Government retains certain rights in this software.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c73f1a3d",
+   "metadata": {},
+   "source": [
+    "We show how to convert an `sptensor` to a matrix stored in _coordinate_ format with extra information so that is can be convertered back to an `sptensor`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77bd3fcc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyttb as ttb\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bcdd7a1",
+   "metadata": {},
+   "source": [
+    "## Creating an `sptenmat` (sparse tensor as sparse matrix) object\n",
+    "A sparse tensor can be converted to a sparse matrix, with row and column indices stored explicitly.\n",
+    "\n",
+    "First, we crease a sparse tensor to be converted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "708ea1cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(0) # Random seed for reproducibility\n",
+    "X = ttb.sptenrand((10, 10, 10, 10), nonzeros=10)\n",
+    "X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "980a4581",
+   "metadata": {},
+   "source": [
+    "Similar options as `tenmat` are available for `sptenmat`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7f260aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = ttb.sptenmat.from_tensor_type(X, np.array([0])) # Mode-0 matricization\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55e67cf1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = ttb.sptenmat.from_tensor_type(X, np.array([1, 2])) # Multiple modes mapped to rows.\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84a1ce5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = ttb.sptenmat.from_tensor_type(X, cdims=np.array([1, 2])) # Specify column dimensions.\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42a84f89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = ttb.sptenmat.from_tensor_type(X, np.arange(4)) # All modes mapped to rows, i.e., vectorize.\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11b543d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = ttb.sptenmat.from_tensor_type(X, np.array([1])) # By default, columns are ordered as [0, 2, 3]\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd329fc3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = ttb.sptenmat.from_tensor_type(X, np.array([1]), np.array([3, 0, 2])) # Specify explicit ordering\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "006533b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = ttb.sptenmat.from_tensor_type(X, np.array([1]), cdims_cyclic=\"fc\") # Forward cyclic column ordering\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26a3eae4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = ttb.sptenmat.from_tensor_type(X, np.array([1]), cdims_cyclic=\"bc\") # Backward cyclic column ordering\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9340605f",
+   "metadata": {},
+   "source": [
+    "## Constituent parts of an `sptenmat`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ba3ef1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A.subs # Subscripts of the nonzeros."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff21b5dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A.vals # Corresponding nonzero values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75193c11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A.tshape # Shape of the original tensor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3210d52c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A.rdims # Dimensions that were mapped to the rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "848e916c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A.cdims # Dimensions that were mapped to the columns."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "640de7d7",
+   "metadata": {},
+   "source": [
+    "## Creating an `sptenmat` from its constituent parts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c178790",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "B = ttb.sptenmat.from_data(A.subs, A.vals, A.rdims, A.cdims, A.tshape) # Effectively copies A\n",
+    "B"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "655152ac",
+   "metadata": {},
+   "source": [
+    "## Creating an `sptenmat` with no nonzeros"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a137cad4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = ttb.sptenmat.from_data(rdims=A.rdims, cdims=A.cdims, tshape=A.tshape) # An empty sptenmat\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0ff0cee",
+   "metadata": {},
+   "source": [
+    "# Creating an empty sptenmat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b951ba95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = ttb.sptenmat() # A really empty sptenmat\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0eae957",
+   "metadata": {},
+   "source": [
+    "## Use `double` to convert an `sptenmat` to a SciPy COO Matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18e3878d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = ttb.sptenrand((10, 10, 10, 10), nonzeros=10) # Create sptensor\n",
+    "A = ttb.sptenmat.from_tensor_type(X, np.array([0])) # Convert to an sptenmat\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0659ae7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "B = A.double() # Convert to scipy\n",
+    "B"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ac68973",
+   "metadata": {},
+   "source": [
+    "## Use `full` to convert an `sptenmat` to a `tenmat`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba2bf34b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "B = ttb.sptenmat.from_tensor_type(ttb.sptenrand((3, 3, 3), nonzeros=3), np.array([0]))\n",
+    "B"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fed6882",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "C = B.full()\n",
+    "C"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4c3139d",
+   "metadata": {},
+   "source": [
+    "## Use `sptensor` to convert an `sptenmat` to an `sptensor`. TODO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4253e876",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Y = ttb.sptensor()\n",
+    "Y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86ae431e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Access `shape` and `tshape` for dimensions of an `sptenmat`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b71f868",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    f\"Matrix shape: {A.shape}\\n\"\n",
+    "    f\"Original tensor shape: {A.tshape}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37b27807",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Subscripted assignment for an `sptenmat`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a173aff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A[0:2, 0:2] = 1\n",
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d020a1fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Basic operations for `sptenmat`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26a17ebd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A.norm() # Norm of the matrix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16306c5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "+A # Positive version of matrix (no change)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8182869d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "-A # Negative version of matrix"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyttb/sptenmat.py
+++ b/pyttb/sptenmat.py
@@ -346,7 +346,7 @@ class sptenmat(object):
         if self.vals.size == 0:
             s += str(self.shape)
         else:
-            s += (" x ").join([str(int(d)) for d in self.tshape])
+            s += f"{self.tshape!r}"
         s += " with " + str(self.vals.size) + " nonzeros"
         s += "\n"
 

--- a/pyttb/sptenmat.py
+++ b/pyttb/sptenmat.py
@@ -1,14 +1,240 @@
-"""Sparse Matricized Tensor Representation"""
 # Copyright 2022 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
 
+"""Classes and functions for working with Kruskal tensors."""
 
-class sptenmat:
+import logging
+import warnings
+
+import numpy as np
+from numpy_groupies import aggregate as accumarray
+
+import pyttb as ttb
+from pyttb.pyttb_utils import *
+
+
+class sptenmat(object):
     """
     SPTENMAT Store sparse tensor as a sparse matrix.
 
     """
 
-    def __init__(self):
-        assert False, "SPTENMAT class not yet implemented"
+    def __init__(self, *args):  # pragma:no cover
+        """
+        Construct an empty :class:`pyttb.sptenmat`
+
+        The constructor takes no arguments and returns an empty
+        :class:`pyttb.sptenmat`.
+        """
+        self.tshape = ()
+        self.rdims = np.array([])
+        self.cdims = np.array([])
+        self.subs = np.array([])
+        self.vals = np.array([])
+
+    @classmethod
+    def from_data(cls, subs, vals, rdims, cdims, tshape):
+        """
+        Construct a :class:`pyttb.sptenmat` from a set of 2D subscripts (subs)
+        and values (vals) along with the mappings of the row (rdims) and column
+        indices (cdims) and the shape of the original tensor (tshape).
+
+        Parameters
+        ----------
+        subs: :class:`numpy.ndarray`, required
+            Location of non-zero entries
+        vals: :class:`numpy.ndarray`, required
+            Values for non-zero entries
+        rdims: :class:`numpy.ndarray`, required
+            Mapping of row indices
+        cdims: :class:`numpy.ndarray`, required
+            Mapping of column indices
+        tshape: :class:`tuple`, required
+            Shape of the original tensor
+
+        """
+        n = len(tshape)
+        alldims = np.array([range(n)])
+        # Error check
+        if rdims.size == 0:
+            dims = cdims.copy()
+        elif cdims.size == 0:
+            dims = rdims.copy()
+        else:
+            dims = np.hstack([rdims, cdims])
+        if not len(dims) == n or not (alldims == np.sort(dims)).all():
+            assert (
+                False
+            ), "Incorrect specification of dimensions, the sorted concatenation of rdims and cdims must be range(len(tshape))."
+        elif subs.size > 1 and np.prod(np.array(tshape)[rdims]) < np.max(subs[:,0]):
+            assert (
+                False
+            ), "Invalid row index."
+        elif subs.size > 1 and np.prod(np.array(tshape)[cdims]) < np.max(subs[:,1]):
+            assert (
+                False
+            ), "Invalid column index."
+
+        # Sum any duplicates
+        if subs.size == 0:
+            newsubs = np.array([])
+            newvals = np.array([])
+        else:
+            # Identify only the unique indices
+            newsubs, loc = np.unique(subs, axis=0, return_inverse=True)
+            # Sum the corresponding values
+            # Squeeze to convert from column vector to row vector
+            newvals = accumarray(
+                loc, np.squeeze(vals), size=newsubs.shape[0], func=sum
+            )
+
+        # Find the nonzero indices of the new values
+        nzidx = np.nonzero(newvals)
+        newsubs = newsubs[nzidx]
+        # None index to convert from row back to column vector
+        newvals = newvals[nzidx]
+        if newvals.size > 0:
+            newvals = newvals[:, None]
+
+        sptenmatInstance = cls()
+        sptenmatInstance.tshape = tshape
+        sptenmatInstance.rdims = rdims.copy()
+        sptenmatInstance.cdims = cdims.copy()
+        sptenmatInstance.subs = newsubs
+        sptenmatInstance.vals = newvals
+        return sptenmatInstance
+
+    @classmethod
+    def from_tensor_type(cls, source, rdims=None, cdims=None, cdims_cyclic=None):
+
+        # Copy Contructor
+        if isinstance(source, sptenmat):
+            return cls().from_data(source.subs.copy(), source.vals.copy(), source.rdims.copy(), source.cdims.copy(), source.tshape)
+
+        if isinstance(source, ttb.sptensor):
+            n = source.ndims
+            alldims = np.array([range(n)])
+            tshape = source.shape
+
+            if rdims is not None and cdims is None:
+                # Single row mapping
+                if len(rdims) == 1 and cdims_cyclic is not None:
+                    if cdims_cyclic == "fc":
+                        # cdims = [rdims+1:n, 1:rdims-1];
+                        cdims = np.array(
+                            [i for i in range(rdims[0] + 1, n)]
+                            + [i for i in range(rdims[0])]
+                        )
+                    elif cdims_cyclic == "bc":
+                        # cdims = [rdims-1:-1:1, n:-1:rdims+1];
+                        cdims = np.array(
+                            [i for i in range(rdims[0] - 1, -1, -1)]
+                            + [i for i in range(n - 1, rdims[0], -1)]
+                        )
+                    else:
+                        assert (
+                            False
+                        ), 'Unrecognized value for cdims_cyclic pattern, must be "t", "fc" or "bc".'
+                else:
+                    # Multiple row mapping
+                    cdims = np.setdiff1d(alldims, rdims)
+
+            elif rdims is None and cdims is not None:
+                rdims = np.setdiff1d(alldims, cdims)
+
+            # if rdims or cdims is empty, hstack will output an array of float not int
+            if rdims.size == 0:
+                dims = cdims.copy()
+            elif cdims.size == 0:
+                dims = rdims.copy()
+            else:
+                dims = np.hstack([rdims, cdims])
+            if not len(dims) == n or not (alldims == np.sort(dims)).all():
+                assert (
+                    False
+                ), "Incorrect specification of dimensions, the sorted concatenation of rdims and cdims must be range(source.ndims)."
+
+            rsize = np.array(source.shape)[rdims]
+            csize = np.array(source.shape)[cdims]
+
+            if rdims.size == 0:
+                ridx = np.ones((source.nnz, 1))
+            elif source.subs.size == 0:
+                ridx = np.array([])
+            else:
+                ridx = tt_sub2ind(rsize, source.subs[:,rdims])
+            ridx = ridx.reshape((ridx.size, 1))
+
+            if cdims.size == 0:
+                cidx = np.ones((source.nnz, 1))
+            elif source.subs.size == 0:
+                cidx = np.array([])
+            else:
+                cidx = tt_sub2ind(csize, source.subs[:,cdims])
+            cidx = cidx.reshape((cidx.size, 1))
+
+            return cls().from_data(np.hstack([ridx, cidx]), source.vals.copy(), rdims, cdims, source.shape)
+
+    @property
+    def shape(self):
+        """
+        Return the shape of a sptenmat
+
+        Returns
+        -------
+        tuple
+        """
+        if self.tshape == ():
+            return ()
+        else:
+            m = np.prod(np.array(self.tshape)[self.rdims])
+            n = np.prod(np.array(self.tshape)[self.cdims])
+            return (m,n)
+
+    def __repr__(self):
+        """
+        String representation of a sptenmat.
+
+        Returns
+        -------
+        str
+            Contains the shape, row indices (rindices), column indices (cindices) and data as strings on different lines.
+        """
+        s = ""
+        s += "sptenmat corresponding to a sptensor of shape "
+        if self.vals.size == 0:
+            s += str(self.shape)
+        else:
+            s += (" x ").join([str(int(d)) for d in self.tshape])
+        s += " with " + str(self.vals.size) + " nonzeros"
+        s += "\n"
+
+        s += "rdims = "
+        s += "[ " + (", ").join([str(int(d)) for d in self.rdims]) + " ] "
+        s += "(modes of sptensor corresponding to rows)\n"
+
+        s += "cdims = "
+        s += "[ " + (", ").join([str(int(d)) for d in self.cdims]) + " ] "
+        s += "(modes of sptensor corresponding to columns)\n"
+
+        # Stop insane printouts
+        if self.vals.size > 10000:
+            r = input("Are you sure you want to print all nonzeros? (Y/N)")
+            if r.upper() != "Y":
+                return s
+
+        for i in range(0, self.subs.shape[0]):
+            s += "\t"
+            s += "["
+            idx = self.subs[i, :]
+            s += str(idx.tolist())[1:]
+            s += " = "
+            s += str(self.vals[i][0])
+            if i < self.subs.shape[0] - 1:
+                s += "\n"
+
+        return s
+
+    __str__ = __repr__
+

--- a/pyttb/sptenmat.py
+++ b/pyttb/sptenmat.py
@@ -12,7 +12,7 @@ from numpy_groupies import aggregate as accumarray
 from scipy import sparse
 
 import pyttb as ttb
-from pyttb.pyttb_utils import tt_sub2ind
+from pyttb.pyttb_utils import tt_ind2sub, tt_sub2ind
 
 
 class sptenmat(object):
@@ -196,10 +196,25 @@ class sptenmat(object):
             return cls().from_data(
                 np.hstack([ridx, cidx], dtype=int),
                 source.vals.copy(),
-                rdims,
-                cdims,
+                rdims.astype(int),
+                cdims.astype(int),
                 source.shape,
             )
+
+    def to_sptensor(self) -> ttb.sptensor:
+        """
+        Contruct a :class:`pyttb.sptensor` from `:class:pyttb.sptenmat`
+        """
+        vals = None
+        subs = None
+        if self.subs.size > 0:
+            print(f"Rdims: {self.rdims}")
+            tshape = np.array(self.tshape)
+            rdims = tt_ind2sub(tshape[self.rdims], self.subs[:, 0])
+            cdims = tt_ind2sub(tshape[self.cdims], self.subs[:, 1])
+            subs = np.hstack([rdims, cdims], dtype=int)
+            vals = self.vals
+        return ttb.sptensor(subs, vals, self.tshape)
 
     @property
     def shape(self) -> Tuple[int, ...]:

--- a/pyttb/sptenmat.py
+++ b/pyttb/sptenmat.py
@@ -9,6 +9,7 @@ from typing import Literal, Optional, Tuple, Union
 
 import numpy as np
 from numpy_groupies import aggregate as accumarray
+from scipy import sparse
 
 import pyttb as ttb
 from pyttb.pyttb_utils import tt_sub2ind
@@ -29,8 +30,8 @@ class sptenmat(object):
         self.tshape = ()
         self.rdims = np.array([])
         self.cdims = np.array([])
-        self.subs = np.array([])
-        self.vals = np.array([])
+        self.subs = np.array([], ndmin=2, dtype=int)
+        self.vals = np.array([], ndmin=2)
 
     @classmethod
     def from_data(  # noqa: PLR0913
@@ -60,9 +61,9 @@ class sptenmat(object):
             Shape of the original tensor
         """
         if subs is None:
-            subs = np.array([])
+            subs = np.array([], ndmin=2, dtype=int)
         if vals is None:
-            vals = np.array([])
+            vals = np.array([], ndmin=2)
         if rdims is None:
             rdims = np.array([], dtype=int)
         if cdims is None:
@@ -216,6 +217,120 @@ class sptenmat(object):
             n = np.prod(np.array(self.tshape)[self.cdims])
             return m, n
 
+    def double(self) -> sparse.coo_matrix:
+        """
+        Convert a :class:`pyttb.sptenmat` to a COO :class:`scipy.sparse.coo_matrix`.
+        """
+        if self.subs.size == 0:
+            return sparse.coo_matrix(self.shape)
+        return sparse.coo_matrix(
+            (self.vals.transpose()[0], self.subs.transpose()), self.shape
+        )
+
+    def full(self) -> ttb.tenmat:
+        """
+        Convert a :class:`pyttb.sptenmat` to a (dense) :class:`pyttb.tenmat`.
+        """
+        # Create empty dense tenmat
+        result = ttb.tenmat.from_data(
+            np.zeros(self.shape), self.rdims, self.cdims, self.tshape
+        )
+        # Assign nonzero values
+        result[tuple(self.subs.transpose())] = np.squeeze(self.vals)
+        return result
+
+    @property
+    def nnz(self) -> int:
+        """
+        Number of nonzero values in the :class:`pyttb.sptenmat`.
+        """
+        return len(self.vals)
+
+    def norm(self) -> np.floating:
+        """
+        Compute the norm (i.e., Frobenius norm, or square root of the sum of
+        squares of entries) of the :class:`pyttb.sptenmat`.
+        """
+        return np.linalg.norm(self.vals)
+
+    def __pos__(self):
+        """
+        Unary plus operator (+).
+        """
+        return self.from_tensor_type(self)
+
+    def __neg__(self):
+        """
+        Unary minus operator (-).
+        """
+        result = self.from_tensor_type(self)
+        result.vals *= -1
+        return result
+
+    def __setitem__(self, key, value):  # noqa: PLR0912
+        """
+        Subscripted assignment for the :class:`pyttb.sptenmat`.
+        """
+        if not isinstance(key, tuple):
+            raise IndexError("Sptenmat takes two arguments as a 2D array")
+        if len(key) != 2:
+            raise IndexError(
+                f"Wrong number of indices. Expected 2 received: {len(key)}"
+            )
+        rsubs = key[0]
+        if isinstance(rsubs, slice):
+            rsubs = np.arange(0, self.shape[0])[rsubs]
+        rsubs = np.asarray(rsubs, dtype=int)
+        if rsubs.shape == ():
+            rsubs = np.array([rsubs])
+
+        csubs = key[1]
+        if isinstance(csubs, slice):
+            csubs = np.arange(0, self.shape[1])[csubs]
+        csubs = np.asarray(csubs, dtype=int)
+        if csubs.shape == ():
+            csubs = np.array([csubs])
+
+        if isinstance(value, (int, float, np.floating)):
+            value = value * np.ones((len(csubs) * len(rsubs), 1))
+        value = np.asarray(value)
+
+        newsubs = []
+        newvals = []
+
+        k = -1
+
+        # Loop over row and column indices, finding appropriate row index for (i,j)
+        for j in range(len(csubs)):
+            indxc = np.array([], dtype=int)
+            if self.subs.size > 0:
+                indxc = np.where(self.subs[:, 1] == csubs[j])[0]
+            for i in range(len(rsubs)):
+                indxr = np.array([], dtype=int)
+                if self.subs.size > 0:
+                    indxr = np.where(self.subs[indxc, 0] == rsubs[i])[0]
+                indx = indxc[indxr]
+
+                k += 1
+
+                if indx.size == 0:
+                    newsubs.append(np.hstack([rsubs[i], csubs[j]]))
+                    newvals.append(value[k])
+                else:
+                    self.vals[indx] = value[k]
+
+        # If there are new values to append, then add them on and sort
+        if len(newvals) != 0:
+            if self.subs.size > 0:
+                self.subs = np.vstack((self.subs, newsubs))
+                self.vals = np.vstack((self.vals, newvals))
+            else:
+                self.subs = np.vstack(newsubs)
+                self.vals = np.vstack(newvals)
+            sort_idx = np.lexsort(self.subs.transpose()[::-1])
+            self.subs = self.subs[sort_idx]
+            self.vals = self.vals[sort_idx]
+
     def __repr__(self):
         """
         String representation of a sptenmat.
@@ -249,15 +364,17 @@ class sptenmat(object):
             if r.upper() != "Y":
                 return s
 
-        for i in range(0, self.subs.shape[0]):
-            s += "\t"
-            s += "["
-            idx = self.subs[i, :]
-            s += str(idx.tolist())[1:]
-            s += " = "
-            s += str(self.vals[i][0])
-            if i < self.subs.shape[0] - 1:
-                s += "\n"
+        # An empty ndarray with minimum dimensions still has a shape
+        if self.subs.size > 0:
+            for i in range(0, self.subs.shape[0]):
+                s += "\t"
+                s += "["
+                idx = self.subs[i, :]
+                s += str(idx.tolist())[1:]
+                s += " = "
+                s += str(self.vals[i][0])
+                if i < self.subs.shape[0] - 1:
+                    s += "\n"
 
         return s
 

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -1154,7 +1154,7 @@ class sptensor:
         If the input includes a list of 2-D arrays (factor_matrices), this
         computes a matrix product of the mode-`n` matricization of the sparse
         tensor with the Khatri-Rao product of all arrays in the list except
-        the `n`th. The length of the list of arrays must equal the number of
+        the `n` th. The length of the list of arrays must equal the number of
         dimensions of the sparse tensor. The shapes of each array must have
         leading dimensions equal to the dimensions of the sparse tensor and
         the same second dimension.
@@ -1162,7 +1162,7 @@ class sptensor:
         If the input is a :class:`pyttb.ktensor`, this
         computes a matrix product of the mode-`n` matricization of the sparse
         tensor with the Khatri-Rao product formed by the `factor_matrices` and
-        `weights` from the ktensor, excluding the `n`th factor matrix and
+        `weights` from the ktensor, excluding the `n` th factor matrix and
         corresponding weight. The shape of the ktensor must be compatible with
         the shape of the sparse tensor.
 
@@ -1313,7 +1313,7 @@ class sptensor:
         >>> S = ttb.sptensor(subs, vals, shape)
 
         Compute two mode-0 leading eigenvectors of `S`, making sign of largest
-        element of each eigenvector positive (i.e., `flipsign`=True).
+        element of each eigenvector positive (i.e., `flipsign` =True).
 
         >>> S.nvecs(0, 2, flipsign=True) # doctest: +ELLIPSIS
         array([[-0.4718...,  0.8816...],

--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -131,7 +131,7 @@ class tenmat:
         -------
         Constructed tenmat
         """
-        # Case 0b: Copy Contructor
+        # Case 0b: Copy Constructor
         if isinstance(source, tenmat):
             # Create tenmat
             tenmatInstance = cls()

--- a/pyttb/ttensor.py
+++ b/pyttb/ttensor.py
@@ -16,7 +16,6 @@ from scipy import sparse
 
 import pyttb as ttb
 from pyttb import pyttb_utils as ttb_utils
-from pyttb.sptensor import tt_to_sparse_matrix
 
 ALT_CORE_ERROR = "TTensor doesn't support non-tensor cores yet. Only tensor/sptensor."
 
@@ -626,14 +625,18 @@ class ttensor:
         H = self.core.ttm(V)
 
         if isinstance(H, ttb.sptensor):
-            HnT = tt_to_sparse_matrix(H, n, True)
+            HnT = ttb.sptenmat.from_tensor_type(
+                H, np.array([n]), cdims_cyclic="t"
+            ).double()
         else:
             HnT = ttb.tenmat.from_tensor_type(H.full(), cdims=np.array([n])).double()
 
         G = self.core
 
         if isinstance(G, ttb.sptensor):
-            GnT = tt_to_sparse_matrix(G, n, True)
+            GnT = ttb.sptenmat.from_tensor_type(
+                G, np.array([n]), cdims_cyclic="t"
+            ).double()
         else:
             GnT = ttb.tenmat.from_tensor_type(G.full(), cdims=np.array([n])).double()
 

--- a/tests/test_sptenmat.py
+++ b/tests/test_sptenmat.py
@@ -316,6 +316,12 @@ def test_sptenmat_to_sptensor(sample_sptensor_2way):
     )
 
 
+def test_sptenmat_from_sparse(sample_sptensor_2way):
+    params3, sptensorInstance = sample_sptensor_2way
+    with pytest.raises(ValueError):
+        ttb.sptenmat.from_array("NotAnArray")
+
+
 def test_sptenmat__str__(sample_sptensor_3way):
     (params3, sptensorInstance3) = sample_sptensor_3way
     tshape = params3["tshape"]

--- a/tests/test_sptenmat.py
+++ b/tests/test_sptenmat.py
@@ -3,32 +3,45 @@
 # U.S. Government retains certain rights in this software.
 
 import numpy as np
-from numpy_groupies import aggregate as accumarray
-
 import pytest
+
 import pyttb as ttb
 
 DEBUG_tests = False
+
 
 @pytest.fixture()
 def sample_sptensor_3way():
     subs = np.array([[0, 0, 0], [0, 0, 2], [1, 1, 1], [3, 3, 3]])
     vals = np.array([[10.5], [1.5], [2.5], [3.5]])
-    rdims = np.array([0,1])
+    rdims = np.array([0, 1])
     cdims = np.array([2])
     tshape = (4, 4, 4)
-    data = {"subs": subs, "vals": vals, "rdims": rdims, "cdims": cdims, "tshape": tshape}
-    sptensorInstance = ttb.sptensor.from_data(subs, vals, tshape)
+    data = {
+        "subs": subs,
+        "vals": vals,
+        "rdims": rdims,
+        "cdims": cdims,
+        "tshape": tshape,
+    }
+    sptensorInstance = ttb.sptensor(subs, vals, tshape)
     return data, sptensorInstance
+
 
 @pytest.fixture()
 def sample_sptenmat():
     subs = np.array([[11, 1], [2, 2], [3, 2], [3, 3]])
     vals = np.array([[0.5], [1.5], [2.5], [3.5]])
-    rdims = np.array([0,1])
+    rdims = np.array([0, 1])
     cdims = np.array([2])
     tshape = (4, 4, 4)
-    data = {"subs": subs, "vals": vals, "rdims": rdims, "cdims": cdims, "tshape": tshape}
+    data = {
+        "subs": subs,
+        "vals": vals,
+        "rdims": rdims,
+        "cdims": cdims,
+        "tshape": tshape,
+    }
     sptenmatInstance = ttb.sptenmat.from_data(subs, vals, rdims, cdims, tshape)
     return data, sptenmatInstance
 
@@ -46,18 +59,16 @@ def test_sptenmat_initialization_empty():
     assert (sptenmatInstance.vals == empty).all()
 
 
-def test_sptenmat_initialization_from_data(
-    sample_sptenmat
-):
+def test_sptenmat_initialization_from_data(sample_sptenmat):
     (params, sptenmatInstance) = sample_sptenmat
 
     # subs and vals should be sorted from output of np.unique
-    subs = np.array([[2,2],[3,2],[3,3],[11,1]])
-    vals = np.array([[1.5],[2.5],[3.5],[0.5]])
-    rdims = np.array([0,1])
+    subs = np.array([[2, 2], [3, 2], [3, 3], [11, 1]])
+    vals = np.array([[1.5], [2.5], [3.5], [0.5]])
+    rdims = np.array([0, 1])
     cdims = np.array([2])
     tshape = (4, 4, 4)
-    shape = (np.prod(np.array(tshape)[rdims]),np.prod(np.array(tshape)[cdims]))
+    shape = (np.prod(np.array(tshape)[rdims]), np.prod(np.array(tshape)[cdims]))
 
     # Constructor from data: subs, vals, rdims, cdims, and tshape
     S = ttb.sptenmat.from_data(subs, vals, rdims, cdims, tshape)
@@ -68,15 +79,12 @@ def test_sptenmat_initialization_from_data(
     assert S.tshape == tshape
     assert S.shape == shape
 
-def test_sptenmat__str__(
-    sample_sptensor_3way
-):
+
+def test_sptenmat__str__(sample_sptensor_3way):
     (params3, sptensorInstance3) = sample_sptensor_3way
     tshape = params3["tshape"]
     rdims = params3["rdims"]
     cdims = params3["cdims"]
-    subs = params3["subs"]
-    vals = params3["vals"]
 
     # Empty
     sptenmatInstance = ttb.sptenmat()
@@ -87,7 +95,9 @@ def test_sptenmat__str__(
     assert s == sptenmatInstance.__str__()
 
     # Test 3D
-    sptenmatInstance3 = ttb.sptenmat.from_tensor_type(sptensorInstance3, rdims, cdims, tshape)
+    sptenmatInstance3 = ttb.sptenmat.from_tensor_type(
+        sptensorInstance3, rdims, cdims, tshape
+    )
     s = ""
     s += "sptenmat corresponding to a sptensor of shape "
     s += (" x ").join([str(int(d)) for d in sptenmatInstance3.tshape])

--- a/tests/test_sptenmat.py
+++ b/tests/test_sptenmat.py
@@ -305,6 +305,17 @@ def test_sptenmat_setitem(sample_sptensor_2way):
     np.testing.assert_array_equal(S.vals, expected_vals)
 
 
+def test_sptenmat_to_sptensor(sample_sptensor_2way):
+    params3, sptensorInstance = sample_sptensor_2way
+    S = ttb.sptenmat.from_tensor_type(
+        sptensorInstance, rdims=np.array([0]), cdims=np.array([1])
+    )
+    round_trip = S.to_sptensor()
+    assert sptensorInstance.isequal(round_trip), (
+        f"Original: {sptensorInstance}\n" f"Reconstructed: {round_trip}"
+    )
+
+
 def test_sptenmat__str__(sample_sptensor_3way):
     (params3, sptensorInstance3) = sample_sptensor_3way
     tshape = params3["tshape"]
@@ -325,7 +336,7 @@ def test_sptenmat__str__(sample_sptensor_3way):
     )
     s = ""
     s += "sptenmat corresponding to a sptensor of shape "
-    s += (" x ").join([str(int(d)) for d in sptenmatInstance3.tshape])
+    s += f"{sptenmatInstance3.tshape!r}"
     s += " with " + str(sptenmatInstance3.vals.size) + " nonzeros"
     s += "\n"
     s += "rdims = "

--- a/tests/test_sptenmat.py
+++ b/tests/test_sptenmat.py
@@ -2,12 +2,111 @@
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
 # U.S. Government retains certain rights in this software.
 
-import pytest
+import numpy as np
+from numpy_groupies import aggregate as accumarray
 
+import pytest
 import pyttb as ttb
+
+DEBUG_tests = False
+
+@pytest.fixture()
+def sample_sptensor_3way():
+    subs = np.array([[0, 0, 0], [0, 0, 2], [1, 1, 1], [3, 3, 3]])
+    vals = np.array([[10.5], [1.5], [2.5], [3.5]])
+    rdims = np.array([0,1])
+    cdims = np.array([2])
+    tshape = (4, 4, 4)
+    data = {"subs": subs, "vals": vals, "rdims": rdims, "cdims": cdims, "tshape": tshape}
+    sptensorInstance = ttb.sptensor.from_data(subs, vals, tshape)
+    return data, sptensorInstance
+
+@pytest.fixture()
+def sample_sptenmat():
+    subs = np.array([[11, 1], [2, 2], [3, 2], [3, 3]])
+    vals = np.array([[0.5], [1.5], [2.5], [3.5]])
+    rdims = np.array([0,1])
+    cdims = np.array([2])
+    tshape = (4, 4, 4)
+    data = {"subs": subs, "vals": vals, "rdims": rdims, "cdims": cdims, "tshape": tshape}
+    sptenmatInstance = ttb.sptenmat.from_data(subs, vals, rdims, cdims, tshape)
+    return data, sptenmatInstance
 
 
 def test_sptenmat_initialization_empty():
-    with pytest.raises(AssertionError) as excinfo:
-        ttb.sptenmat()
-    assert "SPTENMAT class not yet implemented" in str(excinfo)
+    empty = np.array([])
+
+    # No args
+    sptenmatInstance = ttb.sptenmat()
+    assert sptenmatInstance.shape == ()
+    assert sptenmatInstance.tshape == ()
+    assert (sptenmatInstance.rdims == empty).all()
+    assert (sptenmatInstance.cdims == empty).all()
+    assert (sptenmatInstance.subs == empty).all()
+    assert (sptenmatInstance.vals == empty).all()
+
+
+def test_sptenmat_initialization_from_data(
+    sample_sptenmat
+):
+    (params, sptenmatInstance) = sample_sptenmat
+
+    # subs and vals should be sorted from output of np.unique
+    subs = np.array([[2,2],[3,2],[3,3],[11,1]])
+    vals = np.array([[1.5],[2.5],[3.5],[0.5]])
+    rdims = np.array([0,1])
+    cdims = np.array([2])
+    tshape = (4, 4, 4)
+    shape = (np.prod(np.array(tshape)[rdims]),np.prod(np.array(tshape)[cdims]))
+
+    # Constructor from data: subs, vals, rdims, cdims, and tshape
+    S = ttb.sptenmat.from_data(subs, vals, rdims, cdims, tshape)
+    assert (S.subs == subs).all()
+    assert (S.vals == vals).all()
+    assert (S.rdims == rdims).all()
+    assert (S.cdims == cdims).all()
+    assert S.tshape == tshape
+    assert S.shape == shape
+
+def test_sptenmat__str__(
+    sample_sptensor_3way
+):
+    (params3, sptensorInstance3) = sample_sptensor_3way
+    tshape = params3["tshape"]
+    rdims = params3["rdims"]
+    cdims = params3["cdims"]
+    subs = params3["subs"]
+    vals = params3["vals"]
+
+    # Empty
+    sptenmatInstance = ttb.sptenmat()
+    s = ""
+    s += "sptenmat corresponding to a sptensor of shape () with 0 nonzeros\n"
+    s += "rdims = [  ] (modes of sptensor corresponding to rows)\n"
+    s += "cdims = [  ] (modes of sptensor corresponding to columns)\n"
+    assert s == sptenmatInstance.__str__()
+
+    # Test 3D
+    sptenmatInstance3 = ttb.sptenmat.from_tensor_type(sptensorInstance3, rdims, cdims, tshape)
+    s = ""
+    s += "sptenmat corresponding to a sptensor of shape "
+    s += (" x ").join([str(int(d)) for d in sptenmatInstance3.tshape])
+    s += " with " + str(sptenmatInstance3.vals.size) + " nonzeros"
+    s += "\n"
+    s += "rdims = "
+    s += "[ " + (", ").join([str(int(d)) for d in sptenmatInstance3.rdims]) + " ] "
+    s += "(modes of sptensor corresponding to rows)\n"
+    s += "cdims = "
+    s += "[ " + (", ").join([str(int(d)) for d in sptenmatInstance3.cdims]) + " ] "
+    s += "(modes of sptensor corresponding to columns)\n"
+
+    for i in range(0, sptenmatInstance3.subs.shape[0]):
+        s += "\t"
+        s += "["
+        idx = sptenmatInstance3.subs[i, :]
+        s += str(idx.tolist())[1:]
+        s += " = "
+        s += str(sptenmatInstance3.vals[i][0])
+        if i < sptenmatInstance3.subs.shape[0] - 1:
+            s += "\n"
+    assert s == sptenmatInstance3.__str__()

--- a/tests/test_sptensor.py
+++ b/tests/test_sptensor.py
@@ -10,7 +10,6 @@ import pytest
 import scipy.sparse as sparse
 
 import pyttb as ttb
-from pyttb.sptensor import tt_from_sparse_matrix, tt_to_sparse_matrix
 
 
 @pytest.fixture()
@@ -1710,40 +1709,6 @@ def test_sptensor_ttm(sample_sptensor):
         4,
         1,
     )
-
-
-def test_sptensor_to_sparse_matrix():
-    subs = np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])
-    vals = np.array([[0.5], [1.5], [2.5], [3.5]])
-    shape = (4, 4, 4)
-    mode0 = sparse.coo_matrix(([0.5, 1.5, 2.5, 3.5], ([5, 13, 10, 15], [1, 1, 2, 3])))
-    mode1 = sparse.coo_matrix(([0.5, 1.5, 2.5, 3.5], ([5, 13, 10, 15], [1, 1, 2, 3])))
-    mode2 = sparse.coo_matrix(([0.5, 1.5, 2.5, 3.5], ([5, 5, 10, 15], [1, 3, 2, 3])))
-    Ynt = [mode0, mode1, mode2]
-    sptensorInstance = ttb.sptensor(subs, vals, shape)
-
-    for mode in range(sptensorInstance.ndims):
-        Xnt = tt_to_sparse_matrix(sptensorInstance, mode, True)
-        assert (Xnt != Ynt[mode]).nnz == 0
-        assert Xnt.shape == Ynt[mode].shape
-
-
-def test_sptensor_from_sparse_matrix():
-    subs = np.array([[1, 1, 1], [1, 1, 3], [2, 2, 2], [3, 3, 3]])
-    vals = np.array([[0.5], [1.5], [2.5], [3.5]])
-    shape = (4, 4, 4)
-    sptensorInstance = ttb.sptensor(subs, vals, shape)
-    for mode in range(sptensorInstance.ndims):
-        sptensorCopy = sptensorInstance.copy()
-        Xnt = tt_to_sparse_matrix(sptensorCopy, mode, True)
-        Ynt = tt_from_sparse_matrix(Xnt, sptensorCopy.shape, mode, 0)
-        assert sptensorCopy.isequal(Ynt)
-
-    for mode in range(sptensorInstance.ndims):
-        sptensorCopy = sptensorInstance.copy()
-        Xnt = tt_to_sparse_matrix(sptensorCopy, mode, False)
-        Ynt = tt_from_sparse_matrix(Xnt, sptensorCopy.shape, mode, 1)
-        assert sptensorCopy.isequal(Ynt)
 
 
 def test_sptensor_squash():


### PR DESCRIPTION
This resolves #102 however the docstrings need updating and the constructors are still the old style. I think punting that to #214 to update sptenmat and tensmat to be consistent makes sense. I think I covered everything except for aatx since that doesn't seem to currently be used in the matlab version.

This continued to add tech debt around our tests being somewhat redundant (all the checks of the different components of sptenmat), but that's not priority before 2.0. At some point might be nice to revisit cleaning up our tests.

<!-- readthedocs-preview pyttb start -->
----
:books: Documentation preview :books:: https://pyttb--290.org.readthedocs.build/en/290/

<!-- readthedocs-preview pyttb end -->