### PR TITLE
Optimize only specific modes in cp_als()

### DIFF
--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -198,7 +198,7 @@ def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
     for iteration in range(maxiters):
         fitold = fit
 
-        # Iterate over all N modes of the tensor
+        # Iterate over optimized modes in specified order
         for n in dimorder:
             # Calculate Unew = X_(n) * khatrirao(all U except n, 'r').
             Unew = input_tensor.mttkrp(U, n)

--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -108,8 +108,8 @@ def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
     [[0.1467... 0.0923...]
      [0.1862... 0.3455...]]
     >>> print(output["params"]) # doctest: +NORMALIZE_WHITESPACE
-    {'stoptol': 0.0001, 'maxiters': 1000, 'dimorder': [0, 1], 'printitn': 1,\
-     'fixsigns': True}
+    {'stoptol': 0.0001, 'maxiters': 1000, 'dimorder': [0, 1],\
+     'optdims': [0, 1], 'printitn': 1, 'fixsigns': True}
 
     Example using "nvecs" initialization:
 
@@ -181,7 +181,7 @@ def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
 
     # Reduce dimorder to only those modes we will optimize
     dimorder_in = dimorder  # save for output
-    dimorder = [d for d in dimorder if d in optdims] 
+    dimorder = [d for d in dimorder if d in optdims]
 
     # Store the last MTTKRP result to accelerate fitness computation
     U_mttkrp = np.zeros((input_tensor.shape[dimorder[-1]], rank))

--- a/pyttb/cp_als.py
+++ b/pyttb/cp_als.py
@@ -18,7 +18,7 @@ def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
     stoptol: float = 1e-4,
     maxiters: int = 1000,
     dimorder: Optional[List[int]] = None,
-    optdims: Optional[List[bool]] = None,
+    optdims: Optional[List[int]] = None,
     init: Union[Literal["random"], Literal["nvecs"], ttb.ktensor] = "random",
     printitn: int = 1,
     fixsigns: bool = True,
@@ -39,7 +39,7 @@ def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
         Order to loop through dimensions (default: [range(tensor.ndims)])
     optdims:
         Whether factor for corresponding mode should be optimized or not.
-        Defaults to optimizing all modes.
+        Defaults to optimizing all modes ([range(tensor.ndims)]).
     maxiters:
         Maximum number of iterations
     init:
@@ -140,13 +140,9 @@ def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
     elif tuple(range(N)) != tuple(sorted(dimorder)):
         assert False, "Dimorder must be a list or permutation of range(tensor.ndims)"
 
-    #Set up optdims if not specified
+    # Set up optdims if not specified
     if optdims is None:
-        optdims = [True]*N
-    elif not isinstance(optdims, list):
-        assert False, "optdims must be a list"
-    elif not any(optdims):
-        assert False, "optims must contain one True value"
+        optdims = list(range(N))
 
     # Error checking
     assert rank > 0, "Number of components requested must be positive"
@@ -185,7 +181,7 @@ def cp_als(  # noqa: PLR0912,PLR0913,PLR0915
 
     # Reduce dimorder to only those modes we will optimize
     dimorder_in = dimorder  # save for output
-    dimorder = [d for d in dimorder if optdims[d]] 
+    dimorder = [d for d in dimorder if d in optdims] 
 
     # Store the last MTTKRP result to accelerate fitness computation
     U_mttkrp = np.zeros((input_tensor.shape[dimorder[-1]], rank))


### PR DESCRIPTION
An argument called `optdims` of type `List[int]` is added to `cp_als()` to enable optimizing only the factor matrices of specific modes.
This was not previously possible even by scripting around `cp_als()` since it checks for convergence only after each full sweep.
Control flow was hardly altered (`dimorder` may now just be missing some entries), and the default is of course optimizing all modes.

<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--302.org.readthedocs.build/en/302/

<!-- readthedocs-preview pyttb end -->