### PR TITLE
Unpin numpy

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = { text="BSD 2-Clause License" }
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 dependencies = [
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 
 dependencies = [
-    "numpy < 2",
+    "numpy",
     "numpy_groupies",
     "scipy",
     "matplotlib",

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -2283,6 +2283,8 @@ class ktensor:
 
         Returns
         -------
+        fig:
+            :class:`matplotlib.figure.Figure' handle for the generated figure
         axs:
             :class:`matplotlib.axes.Axes' for the generated figure
 

--- a/pyttb/ktensor.py
+++ b/pyttb/ktensor.py
@@ -23,6 +23,8 @@ from typing import (
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.sparse.linalg
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 import pyttb as ttb
 from pyttb.pyttb_utils import (
@@ -2241,7 +2243,7 @@ class ktensor:
         bot_space: Optional[float] = None,
         mode_titles: Optional[Union[tuple, list]] = None,
         title=None,
-    ):
+    ) -> Tuple[Figure, Axes]:
         """
         Visualize factors for :class:`pyttb.ktensor`.
 
@@ -2293,8 +2295,8 @@ class ktensor:
 
         Use plot K using default behavior K.vis()
 
-        >>> K.vis() # doctest: +ELLIPSIS
-        array([[<Axes: ...
+        >>> fig, axs = K.vis() # doctest: +ELLIPSIS
+        >>> plt.close(fig)
 
         Define a more realistic plot fuctions with x labels,
         control relative widths of each plot,
@@ -2310,11 +2312,11 @@ class ktensor:
         ...    ax.semilogx(np.logspace(-2,2,v.shape[0]),v)
         ...    ax.set_xlabel('$E$, [kJ]')
         >>> plots = [mode_1_plot, mode_2_plot, mode_3_plot]
-        >>> K.vis(plots=plots,
+        >>> fig, axs = K.vis(plots=plots,
         ...    rel_widths=[1,2,3],horz_space=0.4,
         ...    left_space=0.2,bot_space=0.2,
         ...    mode_titles=['Particle','Velocity','Energy']) # doctest: +ELLIPSIS
-        array([[<Axes: ...
+        >>> plt.close(fig)
         """
 
         def line_plot(v, ax):
@@ -2389,7 +2391,7 @@ class ktensor:
             fig.suptitle(title)
 
         # tune layout
-        plt.subplots_adjust(
+        fig.subplots_adjust(
             wspace=horz_space,
             hspace=vert_space,
             left=left_space,
@@ -2399,8 +2401,8 @@ class ktensor:
         )
 
         if show_figure:
-            plt.show()
-        return axs
+            fig.show()
+        return fig, axs
 
     def __add__(self, other):
         """

--- a/pyttb/sptenmat.py
+++ b/pyttb/sptenmat.py
@@ -13,7 +13,7 @@ from numpy_groupies import aggregate as accumarray
 from scipy import sparse
 
 import pyttb as ttb
-from pyttb.pyttb_utils import gather_wrap_dims, tt_ind2sub
+from pyttb.pyttb_utils import gather_wrap_dims, np_to_python, tt_ind2sub
 
 
 class sptenmat:
@@ -307,7 +307,7 @@ class sptenmat:
         else:
             m = np.prod(np.array(self.tshape)[self.rdims])
             n = np.prod(np.array(self.tshape)[self.cdims])
-            return m, n
+            return int(m), int(n)
 
     def double(self) -> sparse.coo_matrix:
         """
@@ -371,7 +371,7 @@ class sptenmat:
         """
         return len(self.vals)
 
-    def norm(self) -> np.floating:
+    def norm(self) -> float:
         """
         Compute the norm (i.e., Frobenius norm, or square root of the sum of
         squares of entries) of the :class:`pyttb.sptenmat`.
@@ -384,7 +384,7 @@ class sptenmat:
         >>> ST1.norm()
         1.0
         """
-        return np.linalg.norm(self.vals)
+        return np.linalg.norm(self.vals).item()
 
     def isequal(self, other: sptenmat) -> bool:
         """
@@ -569,9 +569,9 @@ class sptenmat:
         s = ""
         s += "sptenmat corresponding to a sptensor of shape "
         if self.vals.size == 0:
-            s += str(self.shape)
+            s += str(np_to_python(self.shape))
         else:
-            s += f"{self.tshape!r}"
+            s += f"{np_to_python(self.tshape)!r}"
         s += " with " + str(self.vals.size) + " nonzeros"
         s += "\n"
 

--- a/pyttb/sptensor.py
+++ b/pyttb/sptensor.py
@@ -232,7 +232,7 @@ class sptensor:
             subs = np.unique(subs, axis=0)
             cnt += 1
 
-        nonzeros = min(nonzeros, subs.shape[0])
+        nonzeros = int(min(nonzeros, subs.shape[0]))
         subs = subs[0:nonzeros, :]
         vals = function_handle((nonzeros, 1))
 

--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -11,7 +11,7 @@ from typing import Optional, Tuple, Union
 import numpy as np
 
 import pyttb as ttb
-from pyttb.pyttb_utils import gather_wrap_dims
+from pyttb.pyttb_utils import gather_wrap_dims, np_to_python
 
 
 class tenmat:
@@ -430,7 +430,7 @@ class tenmat:
         Examples
         --------
         >>> TM = ttb.tenones((2,2,2)).to_tenmat(np.array([0]))
-        >>> TM[0, 0]
+        >>> print(TM[0, 0])
         1.0
 
         Returns
@@ -761,7 +761,7 @@ class tenmat:
         """
         s = ""
         s += "matrix corresponding to a tensor of shape "
-        s += str(self.tshape)
+        s += str(np_to_python(self.tshape))
         s += "\n"
 
         s += "rindices = "


### PR DESCRIPTION
Unpin numpy fixes #325 
* Update pretty print for sptenmat and tenmat
* Minor other formatting fixes in doc tests

Also updates our ktensor vis:
* Makes the returns match subplots so users can manipulate figure and axes in down stream usage
* Use the updated interface to automatically generate the opened figures in doctests (for me locally the doctest hang until the figures are closed)

I think this also finished removing 3.8 support.

<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--329.org.readthedocs.build/en/329/

<!-- readthedocs-preview pyttb end -->