### PR TITLE
Fix our tutorial hierarchy

### DIFF
--- a/docs/source/tutorial/class_sptenmat.ipynb
+++ b/docs/source/tutorial/class_sptenmat.ipynb
@@ -252,7 +252,7 @@
    "id": "24",
    "metadata": {},
    "source": [
-    "# Creating an empty sptenmat"
+    "## Creating an empty sptenmat"
    ]
   },
   {

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,7 +1,42 @@
-Tutorials
-=========
+Tensor Types
+============
 
 .. toctree::
-   :glob:
+    :maxdepth: 1
 
-   tutorial/*
+    Dense Tensors<tutorial/class_tensor.ipynb>
+    Sparse Tensors<tutorial/class_sptensor.ipynb>
+    Tucker Tensors<tutorial/class_ttensor.ipynb>
+    Kruskal Tensors<tutorial/class_ktensor.ipynb>
+    Sum of Structured Tensors<tutorial/class_sumtensor.ipynb>
+
+CP Decompositions
+=================
+
+.. toctree::
+   :maxdepth: 1
+
+   Alternating Least Squares (CP-ALS)<tutorial/algorithm_cp_als.ipynb>
+   Alternating Poisson Regression (CP-APR)<tutorial/algorithm_cp_apr.ipynb>
+   Generalized CP (GCP-OPT)<tutorial/algorithm_gcp_opt.ipynb>
+
+Tucker Decompositions
+=====================
+
+.. toctree::
+   :maxdepth: 1
+
+   Higher-order SVD (HOSVD)<tutorial/algorithm_hosvd.ipynb>
+   Alternating Least Squares (ALS)<tutorial/algorithm_tucker_als.ipynb>
+
+Working with Tensors
+====================
+
+Converting Between Tensors and Matrices
+---------------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   Dense Case<tutorial/class_tenmat.ipynb>
+   Sparse Case<tutorial/class_sptenmat.ipynb>


### PR DESCRIPTION
We can manage our tutorials on a single page with nice toc entries without too much additional work.
This fixes most of our existing things and provides the example for adding more pieces moving forwards.
One gotcha I had to fix here is that the `Desired TOC Entry`<notebook_path> format only works if there is a single top level header in the notebook. `#` if there are multiple the substitution fails.

I hadn't see the hierarchy in the matlab docs via `doc tensor_toolbox` prior to this issue.

Fixes #342 

I was editing while CI ran so the nice link didn't post [here](https://pyttb--343.org.readthedocs.build/en/343/) are the docs from this PR.