### PR TITLE
Using matmul instead of @ to enforce order on tenmat product

### DIFF
--- a/pyttb/tenmat.py
+++ b/pyttb/tenmat.py
@@ -512,7 +512,7 @@ class tenmat:
             if not tshape:
                 return (self.data @ other.data)[0, 0]
             tenmatInstance = tenmat(
-                self.data @ other.data,
+                np.matmul(self.data, other.data, order=self.order),
                 np.arange(len(self.rindices)),
                 np.arange(len(other.cindices)) + len(self.rindices),
                 tshape,


### PR DESCRIPTION


<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--385.org.readthedocs.build/en/385/

<!-- readthedocs-preview pyttb end -->