### PR TITLE
Quotes needed for paths with spaces

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -21,7 +21,7 @@ def test_linting():
     root_dir = os.path.dirname(os.path.dirname(__file__))
     toml_file = os.path.join(root_dir, "pyproject.toml")
     subprocess.run(
-        f"ruff check {root_dir} --config {toml_file}",
+        f'ruff check "{root_dir}" --config "{toml_file}"',
         check=True,
         shell=True,
     )
@@ -32,7 +32,7 @@ def test_formatting():
     root_dir = os.path.dirname(os.path.dirname(__file__))
     toml_file = os.path.join(root_dir, "pyproject.toml")
     subprocess.run(
-        f"ruff format --check {root_dir} --config {toml_file}",
+        f'ruff format --check "{root_dir}" --config "{toml_file}"',
         check=True,
         shell=True,
     )
@@ -50,7 +50,7 @@ def test_typing():
     root_dir = os.path.dirname(os.path.dirname(__file__))
     toml_file = os.path.join(root_dir, "pyproject.toml")
     subprocess.run(
-        f"mypy -p pyttb  --config-file {toml_file} {skip_untyped}",
+        f'mypy -p pyttb  --config-file "{toml_file}" {skip_untyped}',
         check=True,
         shell=True,
     )
@@ -61,7 +61,7 @@ def test_spelling():
     root_dir = os.path.dirname(os.path.dirname(__file__))
     toml_file = os.path.join(root_dir, "pyproject.toml")
     subprocess.run(
-        f"codespell --toml {toml_file}",
+        f'codespell --toml "{toml_file}"',
         check=True,
         shell=True,
     )


### PR DESCRIPTION
This should fix problems with spaces in the path names for  `{root_dir}` and `{toml_file}`.

I have spaces in my path names (on Windows) so that quotes are needed around `{root_dir}` and `{toml_file}` in the subprocess calls. I tried to make it so that these were escaped double quotes, and this worked fine. However, ruff insisted that I change the outer double quotes to single quotes and the inner escaped doubles quotes to regular double quotes. So that is what you're seeing in the pull request.

<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--388.org.readthedocs.build/en/388/

<!-- readthedocs-preview pyttb end -->