### PR TITLE
Fixing missing functions in documentation

### DIFF
--- a/docs/source/sptensor.rst
+++ b/docs/source/sptensor.rst
@@ -1,7 +1,7 @@
 pyttb.sptensor
 ----------------------
 
-.. autoclass:: pyttb.sptensor
+.. automodule:: pyttb.sptensor
     :members:
     :special-members:
     :exclude-members: __dict__, __weakref__, __slots__, __init__

--- a/docs/source/tensor.rst
+++ b/docs/source/tensor.rst
@@ -1,8 +1,8 @@
 pyttb.tensor
 --------------------
 
-.. autoclass:: pyttb.tensor
+.. automodule:: pyttb.tensor
     :members:
     :special-members:
-    :exclude-members: __dict__, __weakref__, __slots__, __init__
+    :exclude-members: __dict__, __weakref__, __slots__, __init__, mttv_left, mttv_mid, mttv_right, min_split
     :show-inheritance:


### PR DESCRIPTION
Documentation was missing related functions that are defined in the same file as the tensor and sptensor classes. These don't appear anywhere in the Python API documentation. Fixes #398.

<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--399.org.readthedocs.build/en/399/

<!-- readthedocs-preview pyttb end -->