### PR TITLE
Fixing depth of HTML documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,7 +112,10 @@ html_theme = "sphinx_rtd_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'navigation_depth': 6  # Adjust the number to control the depth
+}
+
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -196,3 +199,4 @@ texinfo_documents = [
 # Autodoc settings
 autoclass_content = "both"
 autodoc_member_order = "bysource"
+

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1192,7 +1192,7 @@ class tensor:
         if prod(self.shape) != prod(shape):
             assert False, "Reshaping a tensor cannot change number of elements"
 
-        return ttb.tensor(np.reshape(self.data, shape, order=self.order), shape)
+        return ttb.tensor(self.data.reshape(shape, order=self.order), shape, copy=False)
 
     def scale(
         self,


### PR DESCRIPTION
This change makes it so that you can see the functions inside each class from the navigation bar in the HTML documentation:

![image](https://github.com/user-attachments/assets/d4f9cd22-24eb-4087-90f3-c4aec110dbb5)


Fixes #400

<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--401.org.readthedocs.build/en/401/

<!-- readthedocs-preview pyttb end -->