### PR TITLE
Fixing #418 - Resolving namespace issues in documentation.

### DIFF
--- a/docs/source/cpals.rst
+++ b/docs/source/cpals.rst
@@ -1,7 +1,8 @@
 CP Alternating Least Squares (:obj:`cp_als`)
 ============================================
+.. note::
+    
+     The ``cp_als`` function defined in ``cp_als.py`` has been promoted to the ``pyttb`` namespace.
 
-.. automodule:: pyttb.cp_als
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. autofunction:: pyttb.cp_als
+    

--- a/docs/source/cpapr.rst
+++ b/docs/source/cpapr.rst
@@ -1,7 +1,8 @@
 CP Alternating Poisson Regression (:obj:`cp_apr`)
 =================================================
+.. note::
+    
+     The ``cp_apr`` function defined in ``cp_apr.py`` has been promoted to the ``pyttb`` namespace.
 
-.. automodule:: pyttb.cp_apr
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. autofunction:: pyttb.cp_apr
+    

--- a/docs/source/gcpopt.rst
+++ b/docs/source/gcpopt.rst
@@ -1,11 +1,11 @@
 Generalized CP Optimization (:obj:`gcp_opt`)
 ============================================
+.. note::
+    
+     The ``gcp_opt`` function defined in ``gcp_opt.py`` has been promoted to the ``pyttb`` namespace.
 
-.. automodule:: pyttb.gcp_opt
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+.. autofunction:: pyttb.gcp_opt
+    
 .. toctree::
     :glob:
 

--- a/docs/source/hosvd.rst
+++ b/docs/source/hosvd.rst
@@ -1,7 +1,8 @@
 Tucker Higher-Order SVD (:obj:`hosvd`)
 ======================================
+.. note::
+    
+     The ``hosvd`` function defined in ``hosvd.py`` has been promoted to the ``pyttb`` namespace.
 
-.. automodule:: pyttb.hosvd
-    :members:
-    :undoc-members:
-    :show-inheritance:
+
+.. autofunction:: pyttb.hosvd

--- a/docs/source/ktensor.rst
+++ b/docs/source/ktensor.rst
@@ -1,7 +1,10 @@
 Kruskal Tensor (:class:`ktensor`)
 ---------------------------------
+.. note::
+    
+     The ``ktensor`` class defined in ``ktensor.py`` has been promoted to the ``pyttb`` namespace.
 
-.. automodule:: pyttb.ktensor
+.. autoclass:: pyttb.ktensor
     :members:
     :special-members:
     :exclude-members: __dict__, __weakref__, __slots__, __init__

--- a/docs/source/sptenmat.rst
+++ b/docs/source/sptenmat.rst
@@ -1,5 +1,8 @@
 Sparse Tensor as Matrix (:class:`sptenmat`)
 -------------------------------------------
+.. note::
+    
+     The ``sptenmat`` class defined in ``sptenmat.py`` has been promoted to the ``pyttb`` namespace.
 
 .. autoclass:: pyttb.sptenmat
     :members:

--- a/docs/source/sptensor.rst
+++ b/docs/source/sptensor.rst
@@ -1,8 +1,14 @@
 Sparse Tensor (:class:`sptensor`)
 ---------------------------------
+.. note::
+    
+     Classes and functions defined in ``sptensor.py`` have been promoted to the ``pyttb`` namespace.
 
-.. automodule:: pyttb.sptensor
+.. autoclass:: pyttb.sptensor
     :members:
     :special-members:
     :exclude-members: __dict__, __weakref__, __slots__, __init__
     :show-inheritance:
+
+.. autofunction:: pyttb.sptenrand
+.. autofunction:: pyttb.sptendiag

--- a/docs/source/sumtensor.rst
+++ b/docs/source/sumtensor.rst
@@ -1,5 +1,9 @@
 Sum Tensor (:class:`sumtensor`)
 -------------------------------
+.. note::
+    
+     The ``sumtensor`` class defined in ``sumtensor.py`` has been promoted to the ``pyttb`` namespace.
+
 
 .. autoclass:: pyttb.sumtensor
     :members:

--- a/docs/source/tenmat.rst
+++ b/docs/source/tenmat.rst
@@ -1,5 +1,8 @@
 Tensor as Matrix (:class:`tenmat`)
 ----------------------------------
+.. note::
+    
+     The ``tenmat`` class defined in ``tenmat.py`` has been promoted to the ``pyttb`` namespace.
 
 .. autoclass:: pyttb.tenmat
     :members:

--- a/docs/source/tensor.rst
+++ b/docs/source/tensor.rst
@@ -1,8 +1,18 @@
 Dense Tensor (:class:`tensor`)
 ------------------------------
+.. note::
+    
+     Classes and functions defined in ``tensor.py`` have been promoted to the ``pyttb`` namespace.
 
-.. automodule:: pyttb.tensor
+.. autoclass:: pyttb.tensor
     :members:
     :special-members:
-    :exclude-members: __dict__, __weakref__, __slots__, __init__, mttv_left, mttv_mid, mttv_right, min_split
+    :exclude-members: __dict__, __weakref__, __slots__
     :show-inheritance:
+
+.. autofunction:: pyttb.tenones
+.. autofunction:: pyttb.tenzeros
+.. autofunction:: pyttb.tenrand
+.. autofunction:: pyttb.tendiag
+.. autofunction:: pyttb.teneye
+

--- a/docs/source/ttensor.rst
+++ b/docs/source/ttensor.rst
@@ -1,5 +1,8 @@
 Tucker tensor (:class:`ttensor`)
 --------------------------------
+.. note::
+    
+     The ``ttensor`` class defined in ``ttensor.py`` has been promoted to the ``pyttb`` namespace.
 
 .. autoclass:: pyttb.ttensor
     :members:

--- a/docs/source/tuckerals.rst
+++ b/docs/source/tuckerals.rst
@@ -1,7 +1,7 @@
 Tucker Alternating Least Squares (:obj:`tucker_als`)
 ====================================================
+.. note::
+    
+     The ``tucker_als`` function defined in ``tucker_als.py`` has been promoted to the ``pyttb`` namespace.
 
-.. automodule:: pyttb.tucker_als
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. autofunction:: pyttb.tucker_als


### PR DESCRIPTION
Fixing automodule versus autoclass or autofunction for classes and functions that are promoted to the pyttb level. Also adding notes to explain the promotion which is otherwise hidden from the user.

This mostly addresses #417 as well. I should have made #418 a subissue!

<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--421.org.readthedocs.build/en/421/

<!-- readthedocs-preview pyttb end -->