### PR TITLE
Updates to tensor class documentation (only at module and class level)

### DIFF
--- a/docs/source/tensor.rst
+++ b/docs/source/tensor.rst
@@ -1,6 +1,11 @@
 Dense Tensor (:class:`tensor`)
 ------------------------------
 
+For *all* examples in this document, the following module imports are assumed::
+
+    >>> import pyttb as ttb
+    >>> import numpy as np
+
 .. automodule:: pyttb.tensor
     :members:
     :special-members:

--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1,4 +1,4 @@
-"""Classes and functions for working with dense tensors."""
+"""Classes and functions for dense tensors (hidden module)."""
 
 # Copyright 2025 National Technology & Engineering Solutions of Sandia,
 # LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the
@@ -52,25 +52,31 @@ from pyttb.pyttb_utils import (
 
 
 class tensor:
-    """
-    TENSOR Class for dense tensors.
+    """Class for dense tensors.
 
-    Contains the following data members:
+    Attributes
+    ----------
+        data : numpy.ndarray
+            Data of the tensor
+        shape : tuple of integers
+            Size of the tensor
 
-    ``data``: :class:`numpy.ndarray` dense array containing the data elements
-    of the tensor.
+    Instances of :class:`pyttb.tensor` can be created using :meth:`__init__`
+    or the following methods:
 
-    Instances of :class:`pyttb.tensor` can be created using `__init__()` or
-    the following method:
+        * :meth:`from_function` - Create a tensor from a function
+        * :meth:`copy` - Make a deep copy of a tensor
+        * :func:`tenones` - Create an all ones tensor of a specified size
+        * :func:`tenzeros` - Create an all zeros tensor of a specified size
+        * :func:`tenrand` - Create a random tensor of a specified size
+        * :func:`tendiag` - Create a tensor with a specified diagonal
+        * :func:`teneye` - Create an identity tensor
+        * :meth:`pyttb.sptensor.to_tensor` - Convert a sparse tensor to a dense tensor
+        * :meth:`pyttb.ktensor.to_tensor` - Convert a Kruskal tensor to a dense tensor
+        * :meth:`pyttb.ttensor.to_tensor` - Convert a Tucker tensor to a dense tensor
+        * :meth:`pyttb.tenmat.to_tensor` - Convert a tenmat to a dense tensor
 
-      * :meth:`from_function`
-
-    Examples
-    --------
-    For all examples listed below, the following module imports are assumed:
-
-    >>> import pyttb as ttb
-    >>> import numpy as np
+    See :doc:`/tutorial/class_tensor` for getting started with the tensor class.
     """
 
     __slots__ = ("data", "shape")


### PR DESCRIPTION
- Move assumed module imports into `tensor.rst` so that it appears at the top of the document.
- Remove "TENSOR" in the class description, which is a remnant from MATLAB.
- Document the attributes of the class, which before were only partly documented.
- Document all the ways that a tensor can be created.

_Note:_ This does not depend on the other PRs. There may be some minor issue with `tensor.rst` depending on the order of the merges. If there is, let me know and I can fix.  There may be possible issues with crosslinks until #421 is merged, but this is sort of a pre-existing problem.

<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--423.org.readthedocs.build/en/423/

<!-- readthedocs-preview pyttb end -->