### PR TITLE
Fixing inefficiency in `pyttb.tenrand`.

### DIFF
--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -2857,8 +2857,7 @@ def tenrand(shape: Shape, order: MemoryLayout = "F") -> tensor:
     # Typing doesn't play nice with partial
     # mypy issue: 1484
     def unit_uniform(pass_through_shape: Tuple[int, ...]) -> np.ndarray:
-        data = np.random.uniform(low=0, high=1, size=pass_through_shape)
-        to_memory_order(data, order)
+        data = np.random.uniform(low=0, high=1, size=np.prod(pass_through_shape))
         return data
 
     return tensor.from_function(unit_uniform, shape)


### PR DESCRIPTION
The old version was creating random data as a multiway array, reordering it to Fortran order (expensive and unnecessary), and then called the tensor constructor. Instead, we exploit the fact that we can just pass a 1D random array and then reshape that into the desired shape. While the reordering makes little difference for small tensors, it can get quite expensive at scale.