### PR TITLE
430 replace divmod in checking for iteration output

### DIFF
--- a/pyttb/cp_apr.py
+++ b/pyttb/cp_apr.py
@@ -313,7 +313,7 @@ def tt_cp_apr_mu(  # noqa: PLR0912,PLR0913,PLR0915
                 M.factor_matrices[n] *= Phi[n]
 
                 # Print status
-                if (printinneritn > 0) and(divmod(i, printinneritn)[1] == 0):
+                if (printinneritn > 0) and (divmod(i, printinneritn)[1] == 0):
                     print(
                         "\t\tMode = {n}, Inner Iter = {i}, "
                         f"KKT violation = {kktModeViolations[n]}"

--- a/pyttb/cp_apr.py
+++ b/pyttb/cp_apr.py
@@ -313,7 +313,7 @@ def tt_cp_apr_mu(  # noqa: PLR0912,PLR0913,PLR0915
                 M.factor_matrices[n] *= Phi[n]
 
                 # Print status
-                if printinneritn != 0 and divmod(i, printinneritn)[1] == 0:
+                if (printinneritn > 0) and(divmod(i, printinneritn)[1] == 0):
                     print(
                         "\t\tMode = {n}, Inner Iter = {i}, "
                         f"KKT violation = {kktModeViolations[n]}"
@@ -323,7 +323,7 @@ def tt_cp_apr_mu(  # noqa: PLR0912,PLR0913,PLR0915
             M.normalize(normtype=1, mode=n)
 
         kktViolations[iteration] = np.max(kktModeViolations)
-        if divmod(iteration, printitn)[1] == 0:
+        if (printitn > 0) and (divmod(iteration, printitn)[1] == 0):
             print(
                 f"\tIter {iteration}: Inner Its = {nInnerIters[iteration]} "
                 f"KKT violation = {kktViolations[iteration]}, "
@@ -588,7 +588,7 @@ def tt_cp_apr_pdnr(  # noqa: PLR0912,PLR0913,PLR0915
                     if i == 0 and kkt_violation > kktModeViolations[n]:
                         kktModeViolations[n] = kkt_violation
 
-                    if printinneritn > 0 and np.mod(i, printinneritn) == 0:
+                    if (printinneritn > 0) and (divmod(i, printinneritn) == 0):
                         print(
                             f"\tMode = {n}, Row = {jj}, InnerIt = {i}",
                             end="",
@@ -675,7 +675,7 @@ def tt_cp_apr_pdnr(  # noqa: PLR0912,PLR0913,PLR0915
             rowsubprobStopTol = np.maximum(stoptol, kktViolations[iteration]) / 100.0
 
             # Print outer iteration status.
-            if printitn > 0 and np.mod(iteration, printitn) == 0:
+            if (printitn > 0) and (divmod(iteration, printitn)[1] == 0):
                 fnVals[iteration] = -tt_loglikelihood(input_tensor, M)
                 print(
                     f"{iteration}. Ttl Inner Its: {nInnerIters[iteration]}, "
@@ -966,7 +966,7 @@ def tt_cp_apr_pqnr(  # noqa: PLR0912,PLR0913,PLR0915
                     if i == 0 and kkt_violation > kktModeViolations[n]:
                         kktModeViolations[n] = kkt_violation
 
-                    if printinneritn > 0 and np.mod(i, printinneritn) == 0:
+                    if (printinneritn > 0) and (divmod(i, printinneritn) == 0):
                         print(
                             f"\tMode = {n}, Row = {jj}, InnerIt = {i}",
                             end="",
@@ -1073,7 +1073,7 @@ def tt_cp_apr_pqnr(  # noqa: PLR0912,PLR0913,PLR0915
         kktViolations[iteration] = np.max(kktModeViolations)
 
         # Print outer iteration status.
-        if printitn > 0 and np.mod(iteration, printitn) == 0:
+        if (printitn > 0) and (divmod(iteration, printitn)[1] == 0):
             fnVals[iteration] = -tt_loglikelihood(input_tensor, M)
             print(
                 f"{iteration}. Ttl Inner Its: {nInnerIters[iteration]}, KKT viol = "

--- a/pyttb/tucker_als.py
+++ b/pyttb/tucker_als.py
@@ -161,7 +161,7 @@ def tucker_als(  # noqa: PLR0912, PLR0913, PLR0915
         fit = 1 - (normresidual / normX)  # fraction explained by model
         fitchange = abs(fitold - fit)
 
-        if iteration % printitn == 0:
+        if (printitn > 0) and (divmod(iteration, printitn)[1] == 0):
             print(f" Iter {iteration}: fit = {fit:e} fitdelta = {fitchange:7.1e}")
 
         # Check for convergence


### PR DESCRIPTION
When checking for output, use divmod consistently across methods.


<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--431.org.readthedocs.build/en/431/

<!-- readthedocs-preview pyttb end -->