### PR TITLE
MTTKRP speedup (1.5x - 6x range) with einsum

### DIFF
--- a/pyttb/tensor.py
+++ b/pyttb/tensor.py
@@ -1136,7 +1136,7 @@ class tensor:  # noqa: PLW1641
             Y = np.reshape(self.data, (-1, szr), order=self.order)
             Y = Y @ Ul
             Y = np.reshape(Y, (szl, szn, R), order=self.order)
-            V = np.einsum('ijk, ik -> jk', Y, Ur)
+            V = np.einsum("ijk, ik -> jk", Y, Ur)
             return to_memory_order(V, self.order)
 
     def mttkrps(self, U: ttb.ktensor | Sequence[np.ndarray]) -> list[np.ndarray]:


### PR DESCRIPTION
Replace the Y, Ur loop
```
V = np.zeros((szn, R))
for r in range(R):
	V[:, [r]] = Y[:, :, r].T @ Ur[:, :, r]
```
with
```
V = np.einsum('ijk, ik -> jk', Y, Ur)
```
for numpy vectorization with einsum.

Some profiling results:

shape [20, 30, 40, 50]
%---------------------
mode-1 mttkrp
rank-10
new mttkrp correct True
old 0.00010779168870713975
new 6.477038065592448e-05
**speedup 1.6642126789366052**
%----------------------------------------------------------------------- rank-50
new mttkrp correct True
old 0.0006463527679443359
new 0.000177409913804796
**speedup 3.6432731073615052**
%----------------------------------------------------------------------- rank-100
new mttkrp correct True
old 0.0006452401479085287
new 0.00010201666090223525
**speedup 6.324850688132952**
%----------------------------------------------------------------------- rank-200
new mttkrp correct True
old 0.0016609827677408855
new 0.0002986590067545573
**speedup 5.561468866418307**
%----------------------------------------------------------------------- mode-1 mttkrp
rank-10
new mttkrp correct True
old 0.0004661348130967882
new 0.00024816724989149306
**speedup 1.8783091374893253**
%----------------------------------------------------------------------- rank-50
new mttkrp correct True
old 0.002485460705227322
new 0.001473824183146159
**speedup 1.6864024445043586**
%----------------------------------------------------------------------- rank-100
new mttkrp correct True
old 0.006084998448689778
new 0.0025424957275390625
**speedup 2.3933170792698175**
%----------------------------------------------------------------------- rank-200
new mttkrp correct True
old 0.04606061511569553
new 0.02842871348063151
**speedup 1.6202145463626638**
%-----------------------------------------------------------------------

<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--454.org.readthedocs.build/en/454/

<!-- readthedocs-preview pyttb end -->