### PR TITLE
Binary export/import

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,9 @@
 # U.S. Government retains certain rights in this software.
 from __future__ import annotations
 
+import os
+import tempfile
+
 import numpy
 import numpy as np
 
@@ -19,6 +22,22 @@ import pyttb as ttb
 def add_packages(doctest_namespace):  # noqa: D103
     doctest_namespace["np"] = numpy
     doctest_namespace["ttb"] = pyttb
+
+
+@pytest.fixture()
+def test_temp_file():
+    """Create a temporary file that persists on test failure for debugging."""
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        temp_path = tmp.name
+
+    try:
+        yield temp_path
+        print(f"Temp file for inspection: {temp_path}")
+    finally:
+        try:
+            os.unlink(temp_path)
+        except FileNotFoundError:
+            pass
 
 
 @pytest.fixture(params=[{"order": "F"}, {"order": "C"}])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ plugins = "numpy.typing.mypy_plugin"
 [[tool.mypy.overrides]]
 module = [
     "scipy",
+    "scipy.io",
     "scipy.sparse",
     "scipy.sparse.linalg",
     "scipy.optimize",

--- a/pyttb/__init__.py
+++ b/pyttb/__init__.py
@@ -13,10 +13,10 @@ import warnings
 
 from pyttb.cp_als import cp_als
 from pyttb.cp_apr import cp_apr
-from pyttb.export_data import export_data
+from pyttb.export_data import export_data, export_data_bin, export_data_mat
 from pyttb.gcp_opt import gcp_opt
 from pyttb.hosvd import hosvd
-from pyttb.import_data import import_data
+from pyttb.import_data import import_data, import_data_bin, import_data_mat
 from pyttb.khatrirao import khatrirao
 from pyttb.ktensor import ktensor
 from pyttb.matlab import matlab_support
@@ -42,9 +42,13 @@ __all__ = [  # noqa: PLE0604
     cp_als.__name__,
     cp_apr.__name__,
     export_data.__name__,
+    export_data_bin.__name__,
+    export_data_mat.__name__,
     gcp_opt.__name__,
     hosvd.__name__,
     import_data.__name__,
+    import_data_bin.__name__,
+    import_data_mat.__name__,
     khatrirao.__name__,
     ktensor.__name__,
     matlab_support.__name__,

--- a/pyttb/export_data.py
+++ b/pyttb/export_data.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import warnings
 from enum import Enum
 from typing import Any, TextIO
 
@@ -126,7 +127,7 @@ def _prepare_sptensor_data(data: ttb.sptensor, index_base: int = 1) -> dict[str,
     return {
         "header": _create_header("sptensor"),
         "shape": np.array(data.shape),
-        "nnz": np.array([data.nnz]),
+        "nnz_array": np.array([data.nnz]),
         "subs": data.subs + index_base,
         "vals": data.vals,
     }
@@ -142,9 +143,14 @@ def _prepare_tensor_data(data: ttb.tensor) -> dict[str, Any]:
 
 def _prepare_matrix_data(data: np.ndarray) -> dict[str, Any]:
     """Prepare matrix data for export."""
+    if not np.isfortran(data):
+        warnings.warn(
+            "Exporting a non-Fortran ordered array. "
+            "For now we only support Fortran order so reshaping."
+        )
     return {
         "header": _create_header("matrix"),
-        "data": data,
+        "data": np.asfortranarray(data),
     }
 
 

--- a/pyttb/export_data.py
+++ b/pyttb/export_data.py
@@ -6,7 +6,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TextIO
+from enum import Enum
+from typing import Any, TextIO
 
 import numpy as np
 from scipy.io import savemat
@@ -14,8 +15,12 @@ from scipy.io import savemat
 import pyttb as ttb
 from pyttb.pyttb_utils import Shape, parse_shape
 
-if TYPE_CHECKING:
-    from io import BufferedWriter
+
+class ExportFormat(Enum):
+    """Export format enumeration."""
+
+    NUMPY = "numpy"
+    MATLAB = "matlab"
 
 
 def export_data(
@@ -66,18 +71,7 @@ def export_data_bin(
     index_base: int = 1,
 ):
     """Export tensor-related data to a binary file."""
-    if not isinstance(data, (ttb.tensor, ttb.sptensor, ttb.ktensor, np.ndarray)):
-        raise NotImplementedError(f"Invalid data type for export: {type(data)}")
-
-    with open(filename, "wb") as fp:
-        if isinstance(data, ttb.tensor):
-            _export_tensor_bin(fp, data)
-        elif isinstance(data, ttb.sptensor):
-            _export_sptensor_bin(fp, data, index_base)
-        elif isinstance(data, ttb.ktensor):
-            _export_ktensor_bin(fp, data)
-        elif isinstance(data, np.ndarray):
-            _export_matrix_bin(fp, data)
+    _export_data_binary(data, filename, ExportFormat.NUMPY, index_base)
 
 
 def export_data_mat(
@@ -86,116 +80,90 @@ def export_data_mat(
     index_base: int = 1,
 ):
     """Export tensor-related data to a matlab compatible binary file."""
+    _export_data_binary(data, filename, ExportFormat.MATLAB, index_base)
+
+
+def _export_data_binary(
+    data: ttb.tensor | ttb.ktensor | ttb.sptensor | np.ndarray,
+    filename: str,
+    export_format: ExportFormat,
+    index_base: int = 1,
+):
+    """Export tensor-related data to a binary file using specified format."""
     if not isinstance(data, (ttb.tensor, ttb.sptensor, ttb.ktensor, np.ndarray)):
         raise NotImplementedError(f"Invalid data type for export: {type(data)}")
 
+    # Prepare data for export based on type
     if isinstance(data, ttb.tensor):
-        _export_tensor_mat(filename, data)
+        export_data_dict = _prepare_tensor_data(data)
     elif isinstance(data, ttb.sptensor):
-        _export_sptensor_mat(filename, data, index_base)
+        export_data_dict = _prepare_sptensor_data(data, index_base)
     elif isinstance(data, ttb.ktensor):
-        _export_ktensor_mat(filename, data)
+        export_data_dict = _prepare_ktensor_data(data)
     elif isinstance(data, np.ndarray):
-        _export_matrix_mat(filename, data)
+        export_data_dict = _prepare_matrix_data(data)
+    else:
+        raise NotImplementedError(f"Unsupported data type: {type(data)}")
+
+    # Save using appropriate format
+    if export_format == ExportFormat.NUMPY:
+        with open(filename, "wb") as fp:
+            np.savez(fp, allow_pickle=False, **export_data_dict)
+    elif export_format == ExportFormat.MATLAB:
+        savemat(filename, export_data_dict)
+    else:
+        raise ValueError(f"Unsupported export format: {export_format}")
 
 
-def _export_sptensor_bin(fp: BufferedWriter, data: ttb.sptensor, index_base: int = 1):
-    """Export sparse array data in coordinate format using NumPy."""
-    # TODO add utility for consistent header creation
-    header = np.array(["sptensor", "F"])
-    shape = np.array(data.shape)
-    nnz = np.array([data.nnz])
-    subs = data.subs + index_base
-    vals = data.vals
-    np.savez(
-        fp,
-        allow_pickle=False,
-        header=header,
-        shape=shape,
-        nnz=nnz,
-        subs=subs,
-        vals=vals,
-    )
+def _create_header(data_type: str) -> np.ndarray:
+    """Create consistent header for tensor data."""
+    # TODO encode version information
+    return np.array([data_type, "F"])
 
 
-def _export_tensor_bin(fp: BufferedWriter, data: ttb.tensor):
-    """Export dense tensor using NumPy."""
-    # TODO add utility for consistent header creation
-    header = np.array(["tensor", "F"])
-    internal_data = data.data
-    np.savez(
-        fp,
-        allow_pickle=False,
-        header=header,
-        data=internal_data,
-    )
+def _prepare_sptensor_data(data: ttb.sptensor, index_base: int = 1) -> dict[str, Any]:
+    """Prepare sparse tensor data for export."""
+    return {
+        "header": _create_header("sptensor"),
+        "shape": np.array(data.shape),
+        "nnz": np.array([data.nnz]),
+        "subs": data.subs + index_base,
+        "vals": data.vals,
+    }
 
 
-def _export_matrix_bin(fp: BufferedWriter, data: np.ndarray):
-    """Export dense matrix using NumPy."""
-    # TODO add utility for consistent header creation
-    header = np.array(["matrix", "F"])
-    internal_data = data
-    np.savez(
-        fp,
-        allow_pickle=False,
-        header=header,
-        data=internal_data,
-    )
+def _prepare_tensor_data(data: ttb.tensor) -> dict[str, Any]:
+    """Prepare dense tensor data for export."""
+    return {
+        "header": _create_header("tensor"),
+        "data": data.data,
+    }
 
 
-def _export_ktensor_bin(fp: BufferedWriter, data: ttb.ktensor):
-    """Export ktensor using NumPy."""
-    # TODO add utility for consistent header creation
-    header = np.array(["ktensor", "F"])
+def _prepare_matrix_data(data: np.ndarray) -> dict[str, Any]:
+    """Prepare matrix data for export."""
+    return {
+        "header": _create_header("matrix"),
+        "data": data,
+    }
+
+
+def _prepare_ktensor_data(data: ttb.ktensor) -> dict[str, Any]:
+    """Prepare ktensor data for export."""
     factor_matrices = data.factor_matrices
     num_factor_matrices = len(factor_matrices)
-    all_factor_matrices = {
-        f"factor_matrix_{i}": factor_matrices[i] for i in range(num_factor_matrices)
+
+    export_dict = {
+        "header": _create_header("ktensor"),
+        "weights": data.weights,
+        "num_factor_matrices": num_factor_matrices,
     }
-    weights = data.weights
-    np.savez(
-        fp,
-        allow_pickle=False,
-        header=header,
-        num_factor_matrices=num_factor_matrices,
-        weights=weights,
-        **all_factor_matrices,
-    )
 
+    # Add individual factor matrices for NumPy compatibility
+    for i in range(num_factor_matrices):
+        export_dict[f"factor_matrix_{i}"] = factor_matrices[i]
 
-def _export_sptensor_mat(filename: str, data: ttb.sptensor, index_base: int = 1):
-    """Export sparse array data in coordinate format using savemat."""
-    header = np.array(["sptensor", "F"])
-    shape = np.array(data.shape)
-    nnz = np.array([data.nnz])
-    subs = data.subs + index_base
-    vals = data.vals
-    savemat(filename, dict(header=header, shape=shape, nnz=nnz, subs=subs, vals=vals))
-
-
-def _export_tensor_mat(filename: str, data: ttb.tensor):
-    """Export dense tensor data using savemat."""
-    header = np.array(["tensor", "F"])
-    internal_data = data.data
-    savemat(filename, dict(header=header, data=internal_data))
-
-
-def _export_matrix_mat(filename: str, data: np.ndarray):
-    """Export dense matrix data using savemat."""
-    header = np.array(["matrix", "F"])
-    internal_data = data
-    savemat(filename, dict(header=header, data=internal_data))
-
-
-def _export_ktensor_mat(filename: str, data: ttb.ktensor):
-    """Export ktensor data using savemat."""
-    header = np.array(["ktensor", "F"])
-    factor_matrices = data.factor_matrices
-    weights = data.weights
-    savemat(
-        filename, dict(header=header, factor_matrices=factor_matrices, weights=weights)
-    )
+    return export_dict
 
 
 def export_size(fp: TextIO, shape: Shape):

--- a/pyttb/import_data.py
+++ b/pyttb/import_data.py
@@ -111,20 +111,26 @@ def import_data_mat(
     def load_mat_data(filename: str):
         mat_data = loadmat(filename)
         header = mat_data["header"][0]
+
+        num_factor_matrices = None
+        if "num_factor_matrices" in mat_data:
+            if np.prod(mat_data["num_factor_matrices"].shape) != 1:
+                raise ValueError(
+                    "Expected 'num_factor_matrices' to be a single value."
+                    f" But found {mat_data['num_factor_matrices']}."
+                )
+            num_factor_matrices = int(mat_data["num_factor_matrices"].ravel()[0])
         return {
             "header": header.split()[0],
             "data": mat_data.get("data"),
             "shape": tuple(mat_data["shape"][0]) if "shape" in mat_data else None,
             "subs": mat_data.get("subs"),
             "vals": mat_data.get("vals"),
-            "num_factor_matrices": int(mat_data["num_factor_matrices"])
-            if "num_factor_matrices" in mat_data
-            else None,
+            "num_factor_matrices": num_factor_matrices,
             "factor_matrices": [
-                mat_data[f"factor_matrix_{i}"]
-                for i in range(int(mat_data["num_factor_matrices"]))
+                mat_data[f"factor_matrix_{i}"] for i in range(num_factor_matrices)
             ]
-            if "num_factor_matrices" in mat_data
+            if num_factor_matrices is not None
             else None,
             "weights": mat_data.get("weights").flatten()
             if "weights" in mat_data

--- a/pyttb/import_data.py
+++ b/pyttb/import_data.py
@@ -109,7 +109,7 @@ def import_data_mat(
     """Import tensor-related data from a MATLAB file."""
 
     def load_mat_data(filename: str):
-        mat_data = loadmat(filename)
+        mat_data = loadmat(filename, mat_dtype=True)
         header = mat_data["header"][0]
 
         num_factor_matrices = None
@@ -162,6 +162,7 @@ def _import_tensor_data(
 
     loaded_data = data_loader(filename)
     data_type = loaded_data["header"]
+    # TODO probably add future looking check here around format?
 
     if data_type not in ["tensor", "sptensor", "matrix", "ktensor"]:
         raise ValueError(f"Invalid data type found: '{data_type}'")
@@ -180,6 +181,8 @@ def _import_tensor_data(
     elif data_type == "ktensor":
         factor_matrices = loaded_data["factor_matrices"]
         weights = loaded_data["weights"]
+        print(factor_matrices)
+        print(weights)
         return ttb.ktensor(factor_matrices, weights)
 
     raise ValueError(f"Invalid data type found: {data_type}")

--- a/pyttb/import_data.py
+++ b/pyttb/import_data.py
@@ -87,7 +87,7 @@ def import_data_bin(
     data_type = header[0]
 
     if data_type not in ["tensor", "sptensor", "matrix", "ktensor"]:
-        raise ValueError(f"Invalid data type found: {data_type}")
+        raise ValueError(f"Invalid data type found: '{data_type}'")
     if data_type == "tensor":
         data = npzfile["data"]
         return ttb.tensor(data)
@@ -99,6 +99,13 @@ def import_data_bin(
     elif data_type == "matrix":
         data = npzfile["data"]
         return data
+    elif data_type == "ktensor":
+        num_factor_matrices = int(npzfile["num_factor_matrices"])
+        factor_matrices = [
+            npzfile[f"factor_matrix_{i}"] for i in range(num_factor_matrices)
+        ]
+        weights = npzfile["weights"]
+        return ttb.ktensor(factor_matrices, weights)
     raise ValueError(f"Invalid data type found: {data_type}")
 
 
@@ -128,6 +135,13 @@ def import_data_mat(
     elif data_type == "matrix":
         data = mat_data["data"]
         return data
+    elif data_type == "ktensor":
+        factor_matrices = [
+            mat_data["factor_matrices"][0, n]
+            for n in range(mat_data["factor_matrices"].shape[1])
+        ]
+        weights = mat_data["weights"].flatten()
+        return ttb.ktensor(factor_matrices, weights)
     raise ValueError(f"Invalid data type found: {data_type}")
 
 

--- a/pyttb/import_data.py
+++ b/pyttb/import_data.py
@@ -78,70 +78,104 @@ def import_data_bin(
     index_base: int = 1,
 ) -> ttb.sptensor | ttb.ktensor | ttb.tensor | np.ndarray:
     """Import tensor-related data from a binary file."""
-    # Check if file exists
-    if not os.path.isfile(filename):
-        raise FileNotFoundError(f"File path {filename} does not exist.")
 
-    npzfile = np.load(filename, allow_pickle=False)
-    header = npzfile["header"]
-    data_type = header[0]
+    def load_bin_data(filename: str):
+        npzfile = np.load(filename, allow_pickle=False)
+        return {
+            "header": npzfile["header"][0],
+            "data": npzfile.get("data"),
+            "shape": tuple(npzfile["shape"]) if "shape" in npzfile else None,
+            "subs": npzfile.get("subs"),
+            "vals": npzfile.get("vals"),
+            "num_factor_matrices": int(npzfile["num_factor_matrices"])
+            if "num_factor_matrices" in npzfile
+            else None,
+            "factor_matrices": [
+                npzfile[f"factor_matrix_{i}"]
+                for i in range(int(npzfile["num_factor_matrices"]))
+            ]
+            if "num_factor_matrices" in npzfile
+            else None,
+            "weights": npzfile.get("weights"),
+        }
 
-    if data_type not in ["tensor", "sptensor", "matrix", "ktensor"]:
-        raise ValueError(f"Invalid data type found: '{data_type}'")
-    if data_type == "tensor":
-        data = npzfile["data"]
-        return ttb.tensor(data)
-    elif data_type == "sptensor":
-        shape = tuple(npzfile["shape"])
-        subs = npzfile["subs"] - index_base
-        vals = npzfile["vals"]
-        return ttb.sptensor(subs, vals, shape)
-    elif data_type == "matrix":
-        data = npzfile["data"]
-        return data
-    elif data_type == "ktensor":
-        num_factor_matrices = int(npzfile["num_factor_matrices"])
-        factor_matrices = [
-            npzfile[f"factor_matrix_{i}"] for i in range(num_factor_matrices)
-        ]
-        weights = npzfile["weights"]
-        return ttb.ktensor(factor_matrices, weights)
-    raise ValueError(f"Invalid data type found: {data_type}")
+    return _import_tensor_data(filename, index_base, load_bin_data)
 
 
 def import_data_mat(
     filename: str,
     index_base: int = 1,
 ) -> ttb.sptensor | ttb.ktensor | ttb.tensor | np.ndarray:
-    """Import tensor-related data from a binary file."""
+    """Import tensor-related data from a MATLAB file."""
+
+    def load_mat_data(filename: str):
+        mat_data = loadmat(filename)
+        header = mat_data["header"][0]
+        return {
+            "header": header.split()[0],
+            "data": mat_data.get("data"),
+            "shape": tuple(mat_data["shape"][0]) if "shape" in mat_data else None,
+            "subs": mat_data.get("subs"),
+            "vals": mat_data.get("vals"),
+            "num_factor_matrices": int(mat_data["num_factor_matrices"])
+            if "num_factor_matrices" in mat_data
+            else None,
+            "factor_matrices": [
+                mat_data[f"factor_matrix_{i}"]
+                for i in range(int(mat_data["num_factor_matrices"]))
+            ]
+            if "num_factor_matrices" in mat_data
+            else None,
+            "weights": mat_data.get("weights").flatten()
+            if "weights" in mat_data
+            else None,
+        }
+
+    return _import_tensor_data(filename, index_base, load_mat_data)
+
+
+def _import_tensor_data(
+    filename: str,
+    index_base: int,
+    data_loader,
+) -> ttb.sptensor | ttb.ktensor | ttb.tensor | np.ndarray:
+    """Generalized function to import tensor data from different file formats.
+
+    Parameters
+    ----------
+    filename:
+        File to import.
+    index_base:
+        Index basing allows interoperability (Primarily between python and MATLAB).
+    data_loader:
+        Function that loads and structures the data from the file.
+    """
     # Check if file exists
     if not os.path.isfile(filename):
         raise FileNotFoundError(f"File path {filename} does not exist.")
 
-    mat_data = loadmat(filename)
-    header = mat_data["header"][0]
-    data_type = header.split()[0]
+    loaded_data = data_loader(filename)
+    data_type = loaded_data["header"]
 
     if data_type not in ["tensor", "sptensor", "matrix", "ktensor"]:
-        raise ValueError(f"Invalid data type found: {data_type}")
+        raise ValueError(f"Invalid data type found: '{data_type}'")
+
     if data_type == "tensor":
-        data = mat_data["data"]
+        data = loaded_data["data"]
         return ttb.tensor(data)
     elif data_type == "sptensor":
-        shape = tuple(mat_data["shape"][0])
-        subs = mat_data["subs"] - index_base
-        vals = mat_data["vals"]
+        shape = loaded_data["shape"]
+        subs = loaded_data["subs"] - index_base
+        vals = loaded_data["vals"]
         return ttb.sptensor(subs, vals, shape)
     elif data_type == "matrix":
-        data = mat_data["data"]
+        data = loaded_data["data"]
         return data
     elif data_type == "ktensor":
-        factor_matrices = [
-            mat_data["factor_matrices"][0, n]
-            for n in range(mat_data["factor_matrices"].shape[1])
-        ]
-        weights = mat_data["weights"].flatten()
+        factor_matrices = loaded_data["factor_matrices"]
+        weights = loaded_data["weights"]
         return ttb.ktensor(factor_matrices, weights)
+
     raise ValueError(f"Invalid data type found: {data_type}")
 
 

--- a/pyttb/import_data.py
+++ b/pyttb/import_data.py
@@ -76,7 +76,7 @@ def import_data(
 def import_data_bin(
     filename: str,
     index_base: int = 1,
-):
+) -> ttb.sptensor | ttb.ktensor | ttb.tensor | np.ndarray:
     """Import tensor-related data from a binary file."""
     # Check if file exists
     if not os.path.isfile(filename):
@@ -88,18 +88,24 @@ def import_data_bin(
 
     if data_type not in ["tensor", "sptensor", "matrix", "ktensor"]:
         raise ValueError(f"Invalid data type found: {data_type}")
-    if data_type == "sptensor":
+    if data_type == "tensor":
+        data = npzfile["data"]
+        return ttb.tensor(data)
+    elif data_type == "sptensor":
         shape = tuple(npzfile["shape"])
         subs = npzfile["subs"] - index_base
         vals = npzfile["vals"]
-        A = ttb.sptensor(subs, vals, shape)
-        return A
+        return ttb.sptensor(subs, vals, shape)
+    elif data_type == "matrix":
+        data = npzfile["data"]
+        return data
+    raise ValueError(f"Invalid data type found: {data_type}")
 
 
 def import_data_mat(
     filename: str,
     index_base: int = 1,
-):
+) -> ttb.sptensor | ttb.ktensor | ttb.tensor | np.ndarray:
     """Import tensor-related data from a binary file."""
     # Check if file exists
     if not os.path.isfile(filename):
@@ -111,12 +117,18 @@ def import_data_mat(
 
     if data_type not in ["tensor", "sptensor", "matrix", "ktensor"]:
         raise ValueError(f"Invalid data type found: {data_type}")
-    if data_type == "sptensor":
+    if data_type == "tensor":
+        data = mat_data["data"]
+        return ttb.tensor(data)
+    elif data_type == "sptensor":
         shape = tuple(mat_data["shape"][0])
         subs = mat_data["subs"] - index_base
         vals = mat_data["vals"]
-        A = ttb.sptensor(subs, vals, shape)
-        return A
+        return ttb.sptensor(subs, vals, shape)
+    elif data_type == "matrix":
+        data = mat_data["data"]
+        return data
+    raise ValueError(f"Invalid data type found: {data_type}")
 
 
 def import_type(fp: TextIO) -> str:

--- a/tests/test_import_export_data.py
+++ b/tests/test_import_export_data.py
@@ -161,49 +161,41 @@ def test_import_invalid():
         (ttb.export_data_mat, ttb.import_data_mat),
     ],
 )
-def test_export_data_tensor(sample_tensor, save_method, import_method):
+def test_export_data_tensor(sample_tensor, save_method, import_method, test_temp_file):
     # truth data
     T = sample_tensor
 
-    data_filename = os.path.join(os.path.dirname(__file__), "data", "tensor.out")
+    data_filename = test_temp_file
     save_method(T, data_filename)
 
     X = import_method(data_filename)
     assert T.isequal(X)
-    os.unlink(data_filename)
 
 
-def test_export_data_tensor_format(sample_tensor):
+def test_export_data_tensor_format(sample_tensor, test_temp_file):
     # truth data
     T = sample_tensor
 
     # index_base unspecified
-    data_filename = os.path.join(os.path.dirname(__file__), "data", "tensor_int.out")
+    data_filename = test_temp_file
     ttb.export_data(T, data_filename, fmt_data="%d")
 
     X = ttb.import_data(data_filename)
     assert T.isequal(X)
-    os.unlink(data_filename)
 
+    os.unlink(data_filename)
     index_base = 0
-    data_filename = os.path.join(
-        os.path.dirname(__file__), "data", f"tensor_int_index_base_{index_base}.out"
-    )
     ttb.export_data(T, data_filename, fmt_data="%d", index_base=index_base)
 
     X = ttb.import_data(data_filename, index_base=index_base)
     assert T.isequal(X)
-    os.unlink(data_filename)
 
+    os.unlink(data_filename)
     index_base = 1
-    data_filename = os.path.join(
-        os.path.dirname(__file__), "data", f"tensor_int_index_base_{index_base}.out"
-    )
     ttb.export_data(T, data_filename, fmt_data="%d", index_base=index_base)
 
     X = ttb.import_data(data_filename, index_base=index_base)
     assert T.isequal(X)
-    os.unlink(data_filename)
 
 
 @pytest.mark.parametrize(
@@ -214,26 +206,26 @@ def test_export_data_tensor_format(sample_tensor):
         (ttb.export_data_mat, ttb.import_data_mat),
     ],
 )
-def test_export_data_sptensor(sample_sptensor, save_method, import_method):
+def test_export_data_sptensor(
+    sample_sptensor, save_method, import_method, test_temp_file
+):
     # truth data
     S = sample_sptensor
 
     # imported data
-    data_filename = os.path.join(os.path.dirname(__file__), "data", "sptensor.out")
+    data_filename = test_temp_file
     save_method(S, data_filename)
 
     X = import_method(data_filename)
     assert S.isequal(X)
-    os.unlink(data_filename)
 
 
-def test_export_data_sptensor_fmt(sample_sptensor):
-    data_filename = os.path.join(os.path.dirname(__file__), "data", "sptensor_int.out")
+def test_export_data_sptensor_fmt(sample_sptensor, test_temp_file):
+    data_filename = test_temp_file
     ttb.export_data(sample_sptensor, data_filename, fmt_data="%d")
 
     X = ttb.import_data(data_filename)
     assert sample_sptensor.isequal(X)
-    os.unlink(data_filename)
 
 
 @pytest.mark.parametrize(
@@ -244,26 +236,26 @@ def test_export_data_sptensor_fmt(sample_sptensor):
         (ttb.export_data_mat, ttb.import_data_mat),
     ],
 )
-def test_export_data_ktensor(sample_ktensor, save_method, import_method):
+def test_export_data_ktensor(
+    sample_ktensor, save_method, import_method, test_temp_file
+):
     # truth data
     K = sample_ktensor
 
     # imported data
-    data_filename = os.path.join(os.path.dirname(__file__), "data", "ktensor.out")
+    data_filename = test_temp_file
     save_method(K, data_filename)
 
     X = import_method(data_filename)
     assert K.isequal(X)
-    os.unlink(data_filename)
 
 
-def test_export_data_ktensor_format(sample_ktensor):
-    data_filename = os.path.join(os.path.dirname(__file__), "data", "ktensor_int.out")
+def test_export_data_ktensor_format(sample_ktensor, test_temp_file):
+    data_filename = test_temp_file
     ttb.export_data(sample_ktensor, data_filename, fmt_data="%d", fmt_weights="%d")
 
     X = ttb.import_data(data_filename)
     assert sample_ktensor.isequal(X)
-    os.unlink(data_filename)
 
 
 @pytest.mark.parametrize(
@@ -274,32 +266,30 @@ def test_export_data_ktensor_format(sample_ktensor):
         (ttb.export_data_mat, ttb.import_data_mat),
     ],
 )
-def test_export_data_array(sample_array, save_method, import_method):
+def test_export_data_array(sample_array, save_method, import_method, test_temp_file):
     # truth data
     M = sample_array
 
     # imported data
-    data_filename = os.path.join(os.path.dirname(__file__), "data", "matrix.out")
+    data_filename = test_temp_file
     save_method(M, data_filename)
 
     X = import_method(data_filename)
     assert np.array_equal(M, X)
-    os.unlink(data_filename)
 
 
-def test_export_data_array_format(sample_array):
-    data_filename = os.path.join(os.path.dirname(__file__), "data", "matrix_int.out")
+def test_export_data_array_format(sample_array, test_temp_file):
+    data_filename = test_temp_file
     ttb.export_data(sample_array, data_filename, fmt_data="%d")
 
     X = ttb.import_data(data_filename)
     assert np.array_equal(sample_array, X)
-    os.unlink(data_filename)
 
 
-def test_export_invalid():
+def test_export_invalid(test_temp_file):
     # list data is invalid
     data = [1, 2, 3]
-    data_filename = os.path.join(os.path.dirname(__file__), "data", "invalid.out")
+    data_filename = test_temp_file
 
     with pytest.raises(AssertionError) as excinfo:
         ttb.export_data(data, data_filename)

--- a/tests/test_import_export_data.py
+++ b/tests/test_import_export_data.py
@@ -193,23 +193,33 @@ def test_export_data_tensor(sample_tensor):
     os.unlink(data_filename)
 
 
-def test_export_data_sptensor(sample_sptensor):
+@pytest.mark.parametrize(
+    ["save_method", "import_method"],
+    [
+        (ttb.export_data, ttb.import_data),
+        (ttb.export_data_bin, ttb.import_data_bin),
+        (ttb.export_data_mat, ttb.import_data_mat),
+    ],
+)
+def test_export_data_sptensor(sample_sptensor, save_method, import_method):
     # truth data
     S = sample_sptensor
 
     # imported data
     data_filename = os.path.join(os.path.dirname(__file__), "data", "sptensor.out")
-    ttb.export_data(S, data_filename)
+    save_method(S, data_filename)
 
-    X = ttb.import_data(data_filename)
+    X = import_method(data_filename)
     assert S.isequal(X)
     os.unlink(data_filename)
 
+
+def test_export_data_sptensor_fmt(sample_sptensor):
     data_filename = os.path.join(os.path.dirname(__file__), "data", "sptensor_int.out")
-    ttb.export_data(S, data_filename, fmt_data="%d")
+    ttb.export_data(sample_sptensor, data_filename, fmt_data="%d")
 
     X = ttb.import_data(data_filename)
-    assert S.isequal(X)
+    assert sample_sptensor.isequal(X)
     os.unlink(data_filename)
 
 

--- a/tests/test_import_export_data.py
+++ b/tests/test_import_export_data.py
@@ -153,16 +153,29 @@ def test_import_invalid():
     assert "Imported dimensions are not of expected size" in str(excinfo)
 
 
-def test_export_data_tensor(sample_tensor):
+@pytest.mark.parametrize(
+    ["save_method", "import_method"],
+    [
+        (ttb.export_data, ttb.import_data),
+        (ttb.export_data_bin, ttb.import_data_bin),
+        (ttb.export_data_mat, ttb.import_data_mat),
+    ],
+)
+def test_export_data_tensor(sample_tensor, save_method, import_method):
     # truth data
     T = sample_tensor
 
     data_filename = os.path.join(os.path.dirname(__file__), "data", "tensor.out")
-    ttb.export_data(T, data_filename)
+    save_method(T, data_filename)
 
-    X = ttb.import_data(data_filename)
+    X = import_method(data_filename)
     assert T.isequal(X)
     os.unlink(data_filename)
+
+
+def test_export_data_tensor_format(sample_tensor):
+    # truth data
+    T = sample_tensor
 
     # index_base unspecified
     data_filename = os.path.join(os.path.dirname(__file__), "data", "tensor_int.out")
@@ -243,23 +256,33 @@ def test_export_data_ktensor(sample_ktensor):
     os.unlink(data_filename)
 
 
-def test_export_data_array(sample_array):
+@pytest.mark.parametrize(
+    ["save_method", "import_method"],
+    [
+        (ttb.export_data, ttb.import_data),
+        (ttb.export_data_bin, ttb.import_data_bin),
+        (ttb.export_data_mat, ttb.import_data_mat),
+    ],
+)
+def test_export_data_array(sample_array, save_method, import_method):
     # truth data
     M = sample_array
 
     # imported data
     data_filename = os.path.join(os.path.dirname(__file__), "data", "matrix.out")
-    ttb.export_data(M, data_filename)
+    save_method(M, data_filename)
 
-    X = ttb.import_data(data_filename)
+    X = import_method(data_filename)
     assert np.array_equal(M, X)
     os.unlink(data_filename)
 
+
+def test_export_data_array_format(sample_array):
     data_filename = os.path.join(os.path.dirname(__file__), "data", "matrix_int.out")
-    ttb.export_data(M, data_filename, fmt_data="%d")
+    ttb.export_data(sample_array, data_filename, fmt_data="%d")
 
     X = ttb.import_data(data_filename)
-    assert np.array_equal(M, X)
+    assert np.array_equal(sample_array, X)
     os.unlink(data_filename)
 
 

--- a/tests/test_import_export_data.py
+++ b/tests/test_import_export_data.py
@@ -236,23 +236,33 @@ def test_export_data_sptensor_fmt(sample_sptensor):
     os.unlink(data_filename)
 
 
-def test_export_data_ktensor(sample_ktensor):
+@pytest.mark.parametrize(
+    ["save_method", "import_method"],
+    [
+        (ttb.export_data, ttb.import_data),
+        (ttb.export_data_bin, ttb.import_data_bin),
+        (ttb.export_data_mat, ttb.import_data_mat),
+    ],
+)
+def test_export_data_ktensor(sample_ktensor, save_method, import_method):
     # truth data
     K = sample_ktensor
 
     # imported data
     data_filename = os.path.join(os.path.dirname(__file__), "data", "ktensor.out")
-    ttb.export_data(K, data_filename)
+    save_method(K, data_filename)
 
-    X = ttb.import_data(data_filename)
+    X = import_method(data_filename)
     assert K.isequal(X)
     os.unlink(data_filename)
 
+
+def test_export_data_ktensor_format(sample_ktensor):
     data_filename = os.path.join(os.path.dirname(__file__), "data", "ktensor_int.out")
-    ttb.export_data(K, data_filename, fmt_data="%d", fmt_weights="%d")
+    ttb.export_data(sample_ktensor, data_filename, fmt_data="%d", fmt_weights="%d")
 
     X = ttb.import_data(data_filename)
-    assert K.isequal(X)
+    assert sample_ktensor.isequal(X)
     os.unlink(data_filename)
 
 


### PR DESCRIPTION
This isn't fully ready to merge since we need cross repo collaboration but I think it is close enough where concrete feedback is useful. There are also a few minor TODOS (adding a version to our headers etc). There are a few open questions around how to test this, and if people like the overall api.

Here is my branch for the matching half in MATLAB: https://gitlab.com/ntjohnson1/tensor_toolbox/-/commits/nick/import_export_compatibility (I figure we should make sure we like it here before opening discussion there)

General usage looks like:
MATLAB export
```matlab
ktensor_instance = <value>;
export_data('ktensor.mat', 'output_type', 'binary');
```
Python import
```python
import pyttb as ttb
ktensor_instance = ttb.import_data_mat('ktensor.mat')
```
OR
Python export
```python
import pyttb as ttb
ktensor_instance = <value>
ttb.export_data_mat(ktensor, 'ktensor.mat')
```
MATLAB import
```matlab
ktensor_instance = import_data('ktensor.mat', 'input_type', 'binary');
```

NOTE: I left `import_data_bin` and `export_data_bin` on our side since its not much overhead and if you aren't using matlab it seems a little strange to write to `.mat`.

Closes #466 

Testing options:
* Check-in an export file from the respective other library in each repo and make a note to re-export and upload if changing format
   * On the pyttb side we can add a lint in CI to enforce this
* Setup matlab in CI (on either repo) to actually run the compatibility test
   * If MATALB tensortoolbox already had this running python is so much easier, but seems like a lot of effort to setup just for this 
* Other ideas?

Remaining steps:
* [ ] Get initial review on the Python side
* [ ] Get initial review on the MATLAB side
* [ ] Merge one then the other

<!-- readthedocs-preview pyttb start -->
----
📚 Documentation preview 📚: https://pyttb--467.org.readthedocs.build/en/467/

<!-- readthedocs-preview pyttb end -->